### PR TITLE
Fix the list/grid view mode switch

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/NanodashSession.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanodashSession.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash;
 
+import com.knowledgepixels.nanodash.component.NanopubResults;
 import com.knowledgepixels.nanodash.component.PublishForm;
 import com.knowledgepixels.nanodash.page.OrcidLoginPage;
 import com.knowledgepixels.nanodash.page.ProfilePage;
@@ -66,6 +67,7 @@ public class NanodashSession extends WebSession {
 //	private IntroExtractor introExtractor;
 
     private String userDir = System.getProperty("user.home") + "/.nanopub/";
+    private NanopubResults.ViewMode nanopubResultsViewMode = NanopubResults.ViewMode.GRID;
 
     private KeyPair keyPair;
     private IRI userIri;
@@ -445,6 +447,24 @@ public class NanodashSession extends WebSession {
     public long getTimeSinceLastIntroPublished() {
         if (lastTimeIntroPublished == null) return Long.MAX_VALUE;
         return new Date().getTime() - lastTimeIntroPublished.getTime();
+    }
+
+    /**
+     * Sets the view mode for displaying nanopublication results.
+     *
+     * @param viewMode The desired view mode (e.g., GRID or LIST).
+     */
+    public void setNanopubResultsViewMode(NanopubResults.ViewMode viewMode) {
+        this.nanopubResultsViewMode = viewMode;
+    }
+
+    /**
+     * Retrieves the current view mode for displaying nanopublication results.
+     *
+     * @return The current view mode.
+     */
+    public NanopubResults.ViewMode getNanopubResultsViewMode() {
+        return this.nanopubResultsViewMode;
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanopubResults.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanopubResults.java
@@ -1,7 +1,7 @@
 package com.knowledgepixels.nanodash.component;
 
-import java.util.List;
-
+import com.knowledgepixels.nanodash.NanopubElement;
+import com.knowledgepixels.nanodash.Utils;
 import org.apache.wicket.ajax.markup.html.navigation.paging.AjaxPagingNavigator;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.NavigatorLabel;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -12,8 +12,7 @@ import org.apache.wicket.markup.repeater.data.ListDataProvider;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
 
-import com.knowledgepixels.nanodash.NanopubElement;
-import com.knowledgepixels.nanodash.Utils;
+import java.util.List;
 
 /**
  * A panel that displays a list of nanopubs.
@@ -107,6 +106,29 @@ public class NanopubResults extends Panel {
     private NanopubResults(String id) {
         super(id);
         setOutputMarkupId(true);
+    }
+
+    /**
+     * Enumeration that defines the possible view modes of the nanopub results.
+     */
+    public enum ViewMode {
+        LIST("list-view"),
+        GRID("grid-view");
+
+        private final String value;
+
+        ViewMode(String value) {
+            this.value = value;
+        }
+
+        /**
+         * Retrieves the string value associated with the view mode.
+         *
+         * @return the string value of the view mode
+         */
+        public String getValue() {
+            return value;
+        }
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/page/ListPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ListPage.html
@@ -21,7 +21,10 @@
 
       <h2>Nanopublications</h2>
       <p>Filtering by type: <a href="#" wicket:id="typeUri" id="ref"></a></p>
-      <div class="view-selector"><span wicket:id="listEnabler" class="list"></span><span wicket:id="gridEnabler" class="grid"></span></div>
+      <div class="view-selector">
+        <span wicket:id="listEnabler" class="list"></span>
+        <span wicket:id="gridEnabler" class="grid"></span>
+      </div>
       <div class="flex-container" wicket:id="nanopubs"></div>
 
     </div>

--- a/src/main/java/com/knowledgepixels/nanodash/page/ListPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ListPage.html
@@ -21,8 +21,8 @@
 
       <h2>Nanopublications</h2>
       <p>Filtering by type: <a href="#" wicket:id="typeUri" id="ref"></a></p>
-      <div class="view-selector"><span class="list"></span><span class="grid"></span></div>
-      <div class="flex-container grid-view" wicket:id="nanopubs"></div>
+      <div class="view-selector"><span wicket:id="listEnabler" class="list"></span><span wicket:id="gridEnabler" class="grid"></span></div>
+      <div class="flex-container" wicket:id="nanopubs"></div>
 
     </div>
   </div>

--- a/src/main/java/com/knowledgepixels/nanodash/page/ListPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ListPage.java
@@ -21,6 +21,9 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * A page that shows a list of nanopublications filtered by type, public key, and time range.
+ */
 public class ListPage extends NanodashPage {
 
     private static final long serialVersionUID = 1L;
@@ -44,6 +47,7 @@ public class ListPage extends NanodashPage {
     private final List<String> pubKeys = new ArrayList<>();
     private String startTime = "";
     private String endTime = "";
+    private static ViewMode currentViewMode = null;
 
     private enum ViewMode {
         LIST("list-view"),
@@ -60,8 +64,11 @@ public class ListPage extends NanodashPage {
         }
     }
 
-    private static ViewMode currentViewMode = null;
-
+    /**
+     * Constructor for ListPage.
+     *
+     * @param parameters Page parameters containing filters like types, pubKeys, startTime, and endTime.
+     */
     public ListPage(final PageParameters parameters) {
         super(parameters);
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/ListPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ListPage.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash.page;
 
 import com.knowledgepixels.nanodash.ApiCache;
+import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.QueryRef;
 import com.knowledgepixels.nanodash.component.NanopubResults;
 import com.knowledgepixels.nanodash.component.TitleBar;
@@ -47,22 +48,7 @@ public class ListPage extends NanodashPage {
     private final List<String> pubKeys = new ArrayList<>();
     private String startTime = "";
     private String endTime = "";
-    private static ViewMode currentViewMode = null;
-
-    private enum ViewMode {
-        LIST("list-view"),
-        GRID("grid-view");
-
-        private final String value;
-
-        ViewMode(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return value;
-        }
-    }
+    private static final NanodashSession session = NanodashSession.get();
 
     /**
      * Constructor for ListPage.
@@ -71,19 +57,15 @@ public class ListPage extends NanodashPage {
      */
     public ListPage(final PageParameters parameters) {
         super(parameters);
-
-        if (currentViewMode == null) {
-            currentViewMode = ViewMode.GRID;
-        }
-        logger.info("Rendering ListPage with '{}' mode.", currentViewMode.getValue());
+        logger.info("Rendering ListPage with '{}' mode.", session.getNanopubResultsViewMode().getValue());
 
         add(new AjaxLink<>("listEnabler") {
             private static final long serialVersionUID = 1L;
 
             @Override
             public void onClick(AjaxRequestTarget target) {
-                currentViewMode = ViewMode.LIST;
-                logger.info("Switched to '{}' mode", currentViewMode.getValue());
+                session.setNanopubResultsViewMode(NanopubResults.ViewMode.LIST);
+                logger.info("ListEnabler -- Switched to '{}' mode", session.getNanopubResultsViewMode().getValue());
             }
         });
 
@@ -92,8 +74,8 @@ public class ListPage extends NanodashPage {
 
             @Override
             public void onClick(AjaxRequestTarget target) {
-                currentViewMode = ViewMode.GRID;
-                logger.info("Switched to '{}' mode", currentViewMode.getValue());
+                session.setNanopubResultsViewMode(NanopubResults.ViewMode.GRID);
+                logger.info("GridEnabler -- Switched to '{}' mode", session.getNanopubResultsViewMode().getValue());
             }
         });
 
@@ -157,7 +139,7 @@ public class ListPage extends NanodashPage {
         ApiResponse cachedResponse = ApiCache.retrieveResponse(queryRef);
         if (cachedResponse != null) {
             NanopubResults cachedResults = NanopubResults.fromApiResponse("nanopubs", cachedResponse);
-            cachedResults.add(AttributeAppender.append("class", currentViewMode.getValue()));
+            cachedResults.add(AttributeAppender.append("class", session.getNanopubResultsViewMode().getValue()));
             add(cachedResults);
         } else {
             AjaxLazyLoadPanel<NanopubResults> results = new AjaxLazyLoadPanel<NanopubResults>("nanopubs") {
@@ -190,7 +172,7 @@ public class ListPage extends NanodashPage {
                 }
 
             };
-            results.add(AttributeAppender.append("class", currentViewMode.getValue()));
+            results.add(AttributeAppender.append("class", session.getNanopubResultsViewMode().getValue()));
             add(results);
         }
     }

--- a/src/main/java/com/knowledgepixels/nanodash/page/ListPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ListPage.java
@@ -48,7 +48,6 @@ public class ListPage extends NanodashPage {
     private final List<String> pubKeys = new ArrayList<>();
     private String startTime = "";
     private String endTime = "";
-    private static final NanodashSession session = NanodashSession.get();
 
     /**
      * Constructor for ListPage.
@@ -57,15 +56,15 @@ public class ListPage extends NanodashPage {
      */
     public ListPage(final PageParameters parameters) {
         super(parameters);
-        logger.info("Rendering ListPage with '{}' mode.", session.getNanopubResultsViewMode().getValue());
+        logger.info("Rendering ListPage with '{}' mode.", NanodashSession.get().getNanopubResultsViewMode().getValue());
 
         add(new AjaxLink<>("listEnabler") {
             private static final long serialVersionUID = 1L;
 
             @Override
             public void onClick(AjaxRequestTarget target) {
-                session.setNanopubResultsViewMode(NanopubResults.ViewMode.LIST);
-                logger.info("ListEnabler -- Switched to '{}' mode", session.getNanopubResultsViewMode().getValue());
+                NanodashSession.get().setNanopubResultsViewMode(NanopubResults.ViewMode.LIST);
+                logger.info("ListEnabler -- Switched to '{}' mode", NanodashSession.get().getNanopubResultsViewMode().getValue());
             }
         });
 
@@ -74,8 +73,8 @@ public class ListPage extends NanodashPage {
 
             @Override
             public void onClick(AjaxRequestTarget target) {
-                session.setNanopubResultsViewMode(NanopubResults.ViewMode.GRID);
-                logger.info("GridEnabler -- Switched to '{}' mode", session.getNanopubResultsViewMode().getValue());
+                NanodashSession.get().setNanopubResultsViewMode(NanopubResults.ViewMode.GRID);
+                logger.info("GridEnabler -- Switched to '{}' mode", NanodashSession.get().getNanopubResultsViewMode().getValue());
             }
         });
 
@@ -139,7 +138,7 @@ public class ListPage extends NanodashPage {
         ApiResponse cachedResponse = ApiCache.retrieveResponse(queryRef);
         if (cachedResponse != null) {
             NanopubResults cachedResults = NanopubResults.fromApiResponse("nanopubs", cachedResponse);
-            cachedResults.add(AttributeAppender.append("class", session.getNanopubResultsViewMode().getValue()));
+            cachedResults.add(AttributeAppender.append("class", NanodashSession.get().getNanopubResultsViewMode().getValue()));
             add(cachedResults);
         } else {
             AjaxLazyLoadPanel<NanopubResults> results = new AjaxLazyLoadPanel<NanopubResults>("nanopubs") {
@@ -172,7 +171,7 @@ public class ListPage extends NanodashPage {
                 }
 
             };
-            results.add(AttributeAppender.append("class", session.getNanopubResultsViewMode().getValue()));
+            results.add(AttributeAppender.append("class", NanodashSession.get().getNanopubResultsViewMode().getValue()));
             add(results);
         }
     }

--- a/src/main/java/com/knowledgepixels/nanodash/page/ListPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ListPage.java
@@ -68,26 +68,27 @@ public class ListPage extends NanodashPage {
         if (currentViewMode == null) {
             currentViewMode = ViewMode.GRID;
         }
+        logger.info("Rendering ListPage with '{}' mode.", currentViewMode.getValue());
 
-        AjaxLink<Void> listEnabler = new AjaxLink<Void>("listEnabler") {
+        add(new AjaxLink<>("listEnabler") {
             private static final long serialVersionUID = 1L;
 
             @Override
             public void onClick(AjaxRequestTarget target) {
                 currentViewMode = ViewMode.LIST;
+                logger.info("Switched to '{}' mode", currentViewMode.getValue());
             }
-        };
-        AjaxLink<Void> gridEnabler = new AjaxLink<Void>("gridEnabler") {
+        });
+
+        add(new AjaxLink<>("gridEnabler") {
             private static final long serialVersionUID = 1L;
 
             @Override
             public void onClick(AjaxRequestTarget target) {
                 currentViewMode = ViewMode.GRID;
+                logger.info("Switched to '{}' mode", currentViewMode.getValue());
             }
-        };
-
-        add(listEnabler);
-        add(gridEnabler);
+        });
 
         // TODO the query works with multiple types, but the UI does not yet support that so we just assume one type is mandatory and we show the first one only for now
         if (parameters.get("types").isNull() || parameters.get("types").isEmpty()) {


### PR DESCRIPTION
This PR includes changes to store the view mode of the `ListPage` to improve the UI/UX. The view mode is kept for both in-page navigation and page change/refresh. This way, when the `ListPage` is accessed, the latest view mode chosen by the user is always used.