### PR TITLE
feat: wire role revocation and detachment into the space About tab

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/PostPublishRefresh.java
+++ b/src/main/java/com/knowledgepixels/nanodash/PostPublishRefresh.java
@@ -44,6 +44,7 @@ public class PostPublishRefresh {
             KPXL_TERMS.DEACTIVATED_PRESET_ASSIGNMENT,
             KPXL_TERMS.VIEW_ENTITY,
             KPXL_TERMS.ROLE_INSTANTIATION,
+            KPXL_TERMS.REVOKED_ROLE_INSTANTIATION,
             KPXL_TERMS.SPACE,
             KPXL_TERMS.MAINTAINED_RESOURCE
     );
@@ -61,6 +62,7 @@ public class PostPublishRefresh {
             KPXL_TERMS.HAS_VIEW,
             KPXL_TERMS.HAS_ADMIN_PREDICATE,
             KPXL_TERMS.HAS_ROLE,
+            KPXL_TERMS.DETACHED_ROLE,
             KPXL_TERMS.IS_VISIBLE_TO,
             KPXL_TERMS.IS_MAINTAINED_BY,
             KPXL_TERMS.HAS_ROOT_DEFINITION,

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -235,13 +235,13 @@ public class QueryApiAccess {
     // scoped to the SAME role property ((npa:regularProperty|npa:inverseProperty) ?roleProp on
     // ?vriH), so a higher tier held through a different property no longer suppresses the observer
     // association, while the #498 tier-collision fix (same property validated at a higher tier)
-    // is preserved. RARcL1s1 (supersedes RAQylZL4) distinguishes pending accounts (issue #625 /
+    // is preserved. RAt8PKQ2 (supersedes RARcL1s1, adding the hidden revokeAgent action-mapping column; RARcL1s1 superseded RAQylZL4) distinguishes pending accounts (issue #625 /
     // nanopub-query#195): an association validated only through a pending account — the
     // materialized RoleInstantiation carries npa:trustStatus npa:seen, produced by the
     // PendingAccountState self-arm for observer-tier self-signups of introduced-but-unapproved
     // users — shows ⏳ in the headerless flag column (empty = approved-validated, ⏳ =
     // pending-validated, ⚠️ = not validated at all).
-    public static final String LIST_SPACE_OBSERVERS_REF = "RARcL1s1A1FitiH8LSm7qtOH0JIAmKepMA9F_pTG3sVmo/list-space-observers";
+    public static final String LIST_SPACE_OBSERVERS_REF = "RAt8PKQ21Ppsf3EZTH-Th749ZF8bjaniYc0jDqLt6ixXg/list-space-observers";
 
     // Ref-scoped non-approved role claims (root_np): agents holding a higher-tier role
     // instantiation (admin/maintainer/member) that is NOT in the validated state — a
@@ -289,10 +289,10 @@ public class QueryApiAccess {
     // (npa:hasRoleType) and its role (gen:hasRole) in the current space state, now that nanopub-query
     // persists tier on the instantiation (nanopub-query#125 + #127). Simplifies away the earlier
     // RoleAssignment-scoping workaround and the global RoleDeclaration matching that leaked observer-tier
-    // members into the Approved listing. See nanodash#498. Latest (RA7E54m5, supersedes RApyKS9D)
+    // members into the Approved listing. See nanodash#498. Latest (RAJ15No3, supersedes RA7E54m5, adding the hidden revokeAgent action-mapping column; RA7E54m5 superseded RApyKS9D)
     // drops the role-label coalesce to read schema:name only.
-    public static final String LIST_SPACE_MEMBERS_REF = "RA7E54m5Hb413Ud-0T9HEiH9wnxlJXBkcUT701NDaUGQk/list-space-members";
-    public static final String LIST_SPACE_ROLES_REF = "RAYrSRARuWV2iTWVe6tKDgkaED8ztlr1q5Z5QBIDV4a-Q/list-space-roles";
+    public static final String LIST_SPACE_MEMBERS_REF = "RAJ15No3ghODCXHgk71ix3ZHOWlrL_u6FhuIPffgkjA_Y/list-space-members";
+    public static final String LIST_SPACE_ROLES_REF = "RAYy3dC-N0ps7va0vZ8vQiD9cbU5XNOxmbfvhrImx7UMU/list-space-roles";
     public static final String LIST_SUB_SPACES_REF = "RA-j0DFqkNUHxF_WIds8wWJix6DkDFBmUBWmKXfG24XYQ/list-sub-spaces";
     public static final String LIST_MAINTAINED_RESOURCES_REF = "RAPthUMRDXiJeD2BrOsZigTsbA0LktBc-HC4alDSfVNKM/list-maintained-resources";
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutSpacePanel.java
@@ -44,14 +44,14 @@ public class AboutSpacePanel extends Panel {
      * count of how many of the space's users hold each role), built on the
      * list-space-roles query. The built-in Admin role is always the first row.
      */
-    public static final String SPACE_ROLES_VIEW = "https://w3id.org/np/RActRjB7sOPegsSWdlJPNXvEfqEuomlO9HvjmBuXMqfQw/space-roles-view";
+    public static final String SPACE_ROLES_VIEW = "https://w3id.org/np/RAbUQYCEiYIWBmJ4W1OvD2fpTXxxhrBjusUlIVT9cFlTE/space-roles-view";
 
     /**
      * View listing a space's members (admins, maintainers, members) with their
      * highest role tier, built on the list-space-members query. Observer-tier
      * members are excluded.
      */
-    public static final String MEMBERS_VIEW = "https://w3id.org/np/RAFmrcEqniX7mqrZQ8c4OCqjU-3wwKjLhE2glXAZKFNT0/space-members-view";
+    public static final String MEMBERS_VIEW = "https://w3id.org/np/RAsv1Tede_234X-bmKeq38nepPfFzwuJg2_BDKLqo_CQ0/view";
 
     /**
      * View listing a space's non-approved role claims (agents holding an
@@ -75,7 +75,7 @@ public class AboutSpacePanel extends Panel {
      * i.e. holding no admin/maintainer/member role), built on the
      * list-space-observers query.
      */
-    public static final String OBSERVERS_VIEW = "https://w3id.org/np/RA7uYe4WmsJCk3NaMTE8p0YofcMcRfjLyM8PGLaADkH18/space-observers-view";
+    public static final String OBSERVERS_VIEW = "https://w3id.org/np/RADW4rDxlnkF7cAInPjmUGnRBktsZkr46K9-6dkI0YsWE/view";
 
     /**
      * View listing a space's direct sub-spaces with their types, built on the
@@ -194,7 +194,10 @@ public class AboutSpacePanel extends Panel {
                 ? new QueryRef(QueryApiAccess.LIST_SPACE_MEMBERS_REF, "root_np", refRoot)
                 : new QueryRef(membersView.getQuery().getQueryId(), "space", space.getId());
         ViewDisplay membersDisplay = new ViewDisplay(membersView);
-        add(anchors.anchor(QueryResultTableBuilder.create("members", membersQuery, membersDisplay).build(), membersDisplay));
+        // resourceWithProfile/contextId let the view's per-row "revoke role" action gate on the
+        // viewer's tier in this space and pre-fill param_space (issue #639); postPublishTab
+        // returns the revoker to the About tab, where the shrunk listing shows.
+        add(anchors.anchor(QueryResultTableBuilder.create("members", membersQuery, membersDisplay).resourceWithProfile(space).id(space.getId()).contextId(space.getId()).postPublishTab("about").refRoot(refRoot).build(), membersDisplay));
 
         // Non-approved (pending) higher-tier role claims, between members and observers.
         // Ref-scoped (root_np), like the observers table below; there is no IRI-keyed
@@ -221,7 +224,8 @@ public class AboutSpacePanel extends Panel {
                 ? new QueryRef(QueryApiAccess.LIST_SPACE_OBSERVERS_REF, "root_np", refRoot)
                 : new QueryRef(observersView.getQuery().getQueryId(), "space", space.getId());
         ViewDisplay observersDisplay = new ViewDisplay(observersView);
-        add(anchors.anchor(QueryResultTableBuilder.create("observers", observersQuery, observersDisplay).build(), observersDisplay));
+        // Same action wiring as the members table above (issue #639).
+        add(anchors.anchor(QueryResultTableBuilder.create("observers", observersQuery, observersDisplay).resourceWithProfile(space).id(space.getId()).contextId(space.getId()).postPublishTab("about").refRoot(refRoot).build(), observersDisplay));
 
         // "Sub-units" section: sub-spaces and maintained resources, side by side
         // (both views declare 6/12 width). resourceWithProfile/id/contextId let the

--- a/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
+++ b/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
@@ -165,6 +165,14 @@ public class KPXL_TERMS {
     public static final IRI INVERSE_ROLE_PROPERTY = VocabUtils.createIRI(NAMESPACE, "InverseRoleProperty");
     public static final IRI REGULAR_ROLE_PROPERTY = VocabUtils.createIRI(NAMESPACE, "RegularRoleProperty");
 
+    // Role revocation (issue #639 / nanopub-query #129): key-level negatives resolved
+    // server-side by authorization-scoped latest-wins. A gen:RevokedRoleInstantiation
+    // nanopub revokes one (space, agent, role) assignment (admins keyed on
+    // gen:hasRole gen:AdminRole); a gen:detachedRole triple removes a role from a
+    // space altogether. See nanopub-query's doc/design-role-revocation.md.
+    public static final IRI REVOKED_ROLE_INSTANTIATION = VocabUtils.createIRI(NAMESPACE, "RevokedRoleInstantiation");
+    public static final IRI DETACHED_ROLE = VocabUtils.createIRI(NAMESPACE, "detachedRole");
+
     // Role tiers (subclasses of gen:SpaceMemberRole; materialized server-side by
     // nanopub-query as the npa:hasRoleType value). Ordered admin > maintainer >
     // member > observer; observer is the default when a role declares no tier.


### PR DESCRIPTION
Closes #639.

Code side of deactivation support for roles, building on nanopub-query's server-side revocation model (knowledgepixels/nanopub-query#129): `gen:RevokedRoleInstantiation` revokes one `(space, agent, role)` assignment (admins keyed on `gen:hasRole gen:AdminRole`), and `gen:detachedRole` removes a role from a space altogether, cascading to its holders.

### Code changes

- **KPXL_TERMS**: add `REVOKED_ROLE_INSTANTIATION` and `DETACHED_ROLE`.
- **PostPublishRefresh**: treat revocations and detachments as structural publications — a revoked role can change which role-gated views the target sees, so the page structure refreshes after publishing one.
- **AboutSpacePanel**: pass the space as entitlement/context resource to the members and observers table builders (previously built bare, which made per-row entry actions impossible there), and bump the roles/members/observers view constants to the current heads so `View.get`'s exact-version fallback can no longer surface stale titles or queries.
- **QueryApiAccess**: bump the ref-scoped roles/members/observers query constants to the versions carrying the hidden action-feed columns (`detachRole`, `revokeAgent`) — grlc serves by exact artifact code, so supersedes alone don't redirect the endpoints.

### Published counterparts (already live)

- Templates: "Revoking a space role" (`RAgP7Hztxe…`) and "Detaching a role from a space" (`RAVnwxKE…`).
- Query supersedes adding `detachRole`/`revokeAgent` action-feed columns (IRI-keyed + ref-scoped variants).
- View supersedes: "🎭 Assigned roles" gains a per-row "➖ detach role..." action (hidden on the built-in admin row, which is constitutional); the members and observers views gain per-row "🚫 revoke role..." actions (admin-gated; member-tier-gated on observers).

Verified end-to-end on an isolated jetty with headless Chrome: correct view titles, no leaked action-feed columns, detach only on non-admin role rows, and click-through confirms each action opens its intended template with `param_space` + `param_role`/`param_agent` pre-filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)