### PR TITLE
fix: refresh the list of view displays before the views themselves

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/PageTitleMenu.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PageTitleMenu.java
@@ -104,11 +104,22 @@ public class PageTitleMenu extends Panel {
     }
 
     /**
-     * Brings the whole page up to date: the resource's own structure (which views it shows)
-     * and every view query rendered on it, then a re-render so each of them comes back
-     * through the refreshing panels — the page keeps what it has on screen and swaps in the
-     * parts that turn out to have changed. The page-level counterpart of a view display's
-     * "refresh now", which does the same for its one query.
+     * Brings the whole page up to date, in that order: first the resource's own structure —
+     * which views it shows — and then the views that refreshed structure turns out to
+     * contain. The two steps are deliberately sequential: refreshing the views that happen
+     * to be on screen at the moment of the click would refresh the <em>old</em> list, so a
+     * view display that has just been added would arrive with whatever the cache held for
+     * it, and one that has just been removed would be re-queried for nothing. The request
+     * is therefore left standing on the resource and honoured by the view list that is
+     * built once the refreshed structure has landed (see
+     * {@link AbstractResourceWithProfile#requestViewRefresh()} and
+     * {@link RefreshingStructurePanel}).
+     * <p>
+     * Views that are not part of that structure-driven list — the About and Explore tabs
+     * build their own — have no refreshed list to wait for and are marked right away.
+     * <p>
+     * The page-level counterpart of a view display's "refresh now", which does the same for
+     * its one query.
      *
      * @param resource the page's resource, or null if the page has none
      * @return the menu entry
@@ -120,10 +131,21 @@ public class PageTitleMenu extends Panel {
             @Override
             public void onClick(Optional<AjaxRequestTarget> target) {
                 AbstractResourceWithProfile r = resourceId == null ? null : AbstractResourceWithProfile.get(resourceId);
-                if (r != null) r.forceRefresh(0);
+                // Only a page that shows a view list has views to refresh once the
+                // refreshed structure lands. Asking for it on a page that has none (a
+                // tab that builds its own views) would leave the request standing on the
+                // process-wide resource for some later page to pick up.
+                boolean hasViewList = Boolean.TRUE.equals(getPage().visitChildren(ViewList.class,
+                        (IVisitor<ViewList, Boolean>) (list, visit) -> visit.stop(Boolean.TRUE)));
+                if (r != null) {
+                    r.forceRefresh(0);
+                    if (hasViewList) r.requestViewRefresh();
+                }
                 getPage().visitChildren(QueryResult.class, (IVisitor<QueryResult, Void>) (view, visit) -> {
                     QueryRef queryRef = view.getQueryRef();
-                    if (queryRef != null) ApiCache.clearCache(queryRef, 0);
+                    if (queryRef != null && view.findParent(ViewList.class) == null) {
+                        ApiCache.clearCache(queryRef, 0);
+                    }
                 });
                 setResponsePage(getPage().getClass(), getPage().getPageParameters());
             }

--- a/src/main/java/com/knowledgepixels/nanodash/component/RefreshingStructurePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/RefreshingStructurePanel.java
@@ -77,10 +77,12 @@ public class RefreshingStructurePanel extends Panel {
             return;
         }
         timer.stop(target);
-        if (Objects.equals(shownSignature, resource.getStructureSignature())) {
+        if (!resource.isViewRefreshRequested() && Objects.equals(shownSignature, resource.getStructureSignature())) {
             // The refresh left the page structure as it is, so there is nothing worth
             // rebuilding — and rebuilding anyway would throw away whatever the user is
             // doing in the views (a typed filter, an open menu, the current table page).
+            // A page-level "refresh now" is the exception: there the views themselves are
+            // to be brought up to date, which is what the rebuild below carries them.
             return;
         }
         addOrReplace(factory.create(CONTENT_ID));

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewList.java
@@ -2,6 +2,7 @@ package com.knowledgepixels.nanodash.component;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import com.knowledgepixels.nanodash.ApiCache;
 import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewAnchors;
 import com.knowledgepixels.nanodash.ViewDisplay;
@@ -24,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -36,6 +38,17 @@ public class ViewList extends Panel {
     // representative ref. Null = representative ref. Read at render time by the inner
     // ListView, so it may be set after the delegating constructor. See docs/space-ref-identity.md.
     private String refRoot;
+
+    // Set when this list is built to honour a page-level "refresh now" (see
+    // AbstractResourceWithProfile.isViewRefreshDue): each view's query is marked as
+    // outdated just before the view is built, so the view comes back through
+    // RefreshingResultPanel — what is on screen now, plus a spinner — and swaps in the new
+    // results once the query has run.
+    private final boolean refreshViews;
+
+    // The queries already marked, so that a re-render of this same list does not keep
+    // marking them: the inner ListView repopulates on every render.
+    private final Set<String> refreshMarked = new HashSet<>();
 
     public ViewList(String markupId, AbstractResourceWithProfile resourceWithProfile) {
         this(markupId, resourceWithProfile, null, null, null, null, null, true, null);
@@ -73,6 +86,9 @@ public class ViewList extends Panel {
 
     private ViewList(String markupId, AbstractResourceWithProfile resourceWithProfile, String partId, String nanopubId, Set<IRI> partClasses, AbstractResourceWithProfile footerResource, List<AbstractLink> footerAdminButtons, boolean showEmptyNotice, List<ViewDisplay> explicitViewDisplays) {
         super(markupId);
+
+        this.refreshViews = resourceWithProfile != null
+                && resourceWithProfile.isViewRefreshDue(explicitViewDisplays == null);
 
         final String id = (partId == null ? resourceWithProfile.getId() : partId);
         final String npId = (nanopubId == null ? resourceWithProfile.getNanopubId() : nanopubId);
@@ -193,6 +209,9 @@ public class ViewList extends Panel {
                                 return;
                             }
                             QueryRef queryRef = new QueryRef(view.getQuery().getQueryId(), queryRefParams);
+                            if (refreshViews && refreshMarked.add(queryRef.getAsUrlString())) {
+                                ApiCache.clearCache(queryRef, 0);
+                            }
                             Component resultComponent = QueryResultComponentFactory.build("view", queryRef, item.getModelObject(),
                                     resourceWithProfile, id, resourceWithProfile.getId(), refRoot);
                             if (resultComponent != null) {

--- a/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
@@ -8,6 +8,8 @@ import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.repository.SpaceRepository;
 import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
+import org.apache.wicket.MetaDataKey;
+import org.apache.wicket.request.cycle.RequestCycle;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.util.Values;
 import org.nanopub.Nanopub;
@@ -48,6 +50,19 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
     // requested after a publication, with the previously loaded structure kept on screen
     // meanwhile. Cleared once the refreshed data has landed. See forceRefresh.
     private volatile boolean structureRefreshPending = false;
+    // The page-level "refresh now" asks not only for a refreshed structure but for the
+    // views of that structure to be brought up to date with it. Kept apart from
+    // forceRefresh, which a publication triggers too — there only the view that was acted
+    // on is refreshed (issue #622). Taken away by the first view list built once the
+    // refreshed structure has landed. See isViewRefreshDue.
+    private volatile boolean viewRefreshRequested = false;
+
+    // Whether the view lists built during the current request are to refresh their views,
+    // answered once per resource and remembered for the rest of the render so that several
+    // view lists on one page all refresh together rather than the first one taking the
+    // request away from the others.
+    private static final MetaDataKey<HashMap<String, Boolean>> VIEW_REFRESH_DUE = new MetaDataKey<>() {
+    };
 
     /**
      * Inner class to hold the data associated with a resource, including its view displays.
@@ -230,6 +245,12 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
     public void forceRefresh(long waitMillis) {
         logger.info("Forcing refresh of resource {} after {} ms", id, waitMillis);
         dataNeedsUpdate = true;
+        // Mark the view-display query itself as outdated, the way every other refresh does
+        // (see ApiCache.clearCache). Without it, a forced fetch that finds a refresh of the
+        // same query already in flight settles for whatever that one leaves behind — a
+        // response fetched before this refresh was asked for, so the structure would come
+        // back unchanged even though it was re-fetched.
+        ApiCache.clearCache(viewDisplaysQueryRef(), waitMillis);
         if (dataInitialized && !data.viewDisplays.isEmpty()) {
             structureRefreshPending = true;
         } else {
@@ -249,6 +270,64 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
         if (!structureRefreshPending) return false;
         triggerDataUpdate();
         return structureRefreshPending;
+    }
+
+    /**
+     * Asks for the views of this resource's structure to be brought up to date along with
+     * the structure itself — the page-level "refresh now", which refreshes the list of view
+     * displays first and then the views that list turns out to contain. The request is
+     * honoured by the first view list built once the refreshed structure has landed (see
+     * {@link #isViewRefreshDue(boolean)}), so it is the refreshed list that gets refreshed, not
+     * the one that happened to be on screen when the user clicked.
+     */
+    public void requestViewRefresh() {
+        viewRefreshRequested = true;
+    }
+
+    /**
+     * Whether a {@link #requestViewRefresh()} is still waiting to be honoured. Read by
+     * {@link com.knowledgepixels.nanodash.component.RefreshingStructurePanel}, which has to
+     * rebuild its content for the request to reach the views even when the refreshed
+     * structure turned out to be the same one.
+     *
+     * @return true while the views have not been refreshed yet
+     */
+    public boolean isViewRefreshRequested() {
+        return viewRefreshRequested;
+    }
+
+    /**
+     * Whether the view lists built for this resource in the current request are to refresh
+     * their views, i.e. a {@link #requestViewRefresh()} is pending and the list being built
+     * is the refreshed one. Takes the request away, but answers the same for every view
+     * list of the same render, so that several lists on one page refresh together.
+     *
+     * @param waitsForStructure whether the list being built takes its view displays from
+     *                          this resource's asynchronously refreshed structure, as
+     *                          opposed to carrying its own (a {@code ?root=}-pinned space
+     *                          page fetches them itself, and so has nothing to wait for)
+     * @return true if this render's views are to be brought up to date
+     */
+    public boolean isViewRefreshDue(boolean waitsForStructure) {
+        // Off a request thread there is nothing to remember the answer in; the request is
+        // then simply taken by the caller.
+        HashMap<String, Boolean> answered = null;
+        RequestCycle requestCycle = RequestCycle.get();
+        if (requestCycle != null) {
+            answered = requestCycle.getMetaData(VIEW_REFRESH_DUE);
+            if (answered == null) {
+                answered = new HashMap<>();
+                requestCycle.setMetaData(VIEW_REFRESH_DUE, answered);
+            }
+            Boolean known = answered.get(id);
+            if (known != null) return known;
+        }
+        // Still waiting for the refreshed structure: the views to refresh are the ones that
+        // list will contain, so the request is left standing for the render that follows it.
+        boolean due = viewRefreshRequested && !(waitsForStructure && structureRefreshPending);
+        if (due) viewRefreshRequested = false;
+        if (answered != null) answered.put(id, due);
+        return due;
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/nanodash/domain/StructureRefreshTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/domain/StructureRefreshTest.java
@@ -1,6 +1,10 @@
 package com.knowledgepixels.nanodash.domain;
 
 import com.knowledgepixels.nanodash.ViewDisplay;
+import org.apache.wicket.ThreadContext;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.nanopub.Nanopub;
@@ -16,6 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * The post-publish refresh of a resource's page structure (issue #622): a structure that
  * is already on screen is kept and swapped in place, and only an empty one is invalidated
  * outright so the pages' lazy path can make a first view display appear.
+ * <p>
+ * Also the page-level "refresh now", which goes one step further: the views are refreshed
+ * after the list of view displays, so that it is the refreshed list whose views are
+ * brought up to date rather than the one that was on screen when the user clicked.
  */
 class StructureRefreshTest {
 
@@ -45,6 +53,22 @@ class StructureRefreshTest {
             return getId();
         }
 
+    }
+
+    // isViewRefreshDue remembers its answer for the rest of the request cycle, so each
+    // call below has to stand on its own: whatever cycle another test left bound to this
+    // thread is taken away for the duration and put back afterwards.
+    private RequestCycle boundRequestCycle;
+
+    @BeforeEach
+    void detachRequestCycle() {
+        boundRequestCycle = RequestCycle.get();
+        ThreadContext.setRequestCycle(null);
+    }
+
+    @AfterEach
+    void reattachRequestCycle() {
+        ThreadContext.setRequestCycle(boundRequestCycle);
     }
 
     // The flags forceRefresh acts on are read directly: going through isDataInitialized()
@@ -120,6 +144,52 @@ class StructureRefreshTest {
         TestResource r = new TestResource("https://example.org/test/idle");
         setStructure(r, viewDisplay());
         assertFalse(r.isStructureRefreshPending());
+    }
+
+    @Test
+    @DisplayName("the views wait for the refreshed structure before they are refreshed")
+    void viewRefreshWaitsForTheStructure() throws Exception {
+        TestResource r = new TestResource("https://example.org/test/views-wait");
+        setStructure(r, viewDisplay());
+
+        r.forceRefresh(5000);
+        r.requestViewRefresh();
+
+        assertTrue(r.isViewRefreshRequested());
+        assertFalse(r.isViewRefreshDue(true), "the list on screen is the old one, so it must not refresh yet");
+        assertTrue(r.isViewRefreshRequested(), "the request must survive for the refreshed list");
+
+        // The refreshed structure lands.
+        setField(r, "structureRefreshPending", false);
+
+        assertTrue(r.isViewRefreshDue(true), "the refreshed list refreshes its views");
+        assertFalse(r.isViewRefreshRequested(), "and takes the request away");
+        assertFalse(r.isViewRefreshDue(true), "so a later list does not refresh again");
+    }
+
+    @Test
+    @DisplayName("a list carrying its own view displays has no structure to wait for")
+    void viewRefreshOnAnExplicitList() throws Exception {
+        TestResource r = new TestResource("https://example.org/test/views-explicit");
+        setStructure(r, viewDisplay());
+
+        r.forceRefresh(5000);
+        r.requestViewRefresh();
+
+        // A ?root=-pinned page fetches its view displays itself, so what it shows is
+        // already the refreshed list even while the singleton structure is still in flight.
+        assertTrue(r.isViewRefreshDue(false));
+        assertFalse(r.isViewRefreshRequested());
+    }
+
+    @Test
+    @DisplayName("no view refresh without a request")
+    void noViewRefreshByDefault() throws Exception {
+        TestResource r = new TestResource("https://example.org/test/views-idle");
+        setStructure(r, viewDisplay());
+        assertFalse(r.isViewRefreshRequested());
+        assertFalse(r.isViewRefreshDue(true));
+        assertFalse(r.isViewRefreshDue(false));
     }
 
 }


### PR DESCRIPTION
The page-level "refresh now" set both refreshes going at once: the resource's structure, and — over the `QueryResult`s on screen — every view query. Both then ran concurrently on the re-rendered page, and since the structure query is often the slower one it landed **last**. Home page log, click at `20:34:51.749`:

```
20:34:51.801  Refreshing cache for …/get-view-displays
20:34:52.0–52.5  (all 15 view queries refreshed)
20:34:58.243  Updating cached API response …/get-view-displays   ← 7.2 s later
```

Worse, the views it refreshed were the ones on screen **at the moment of the click**, i.e. the pre-refresh list. When the refreshed structure landed and `RefreshingStructurePanel` swapped in the rebuilt `ViewList`, its views were built straight from the cache and no query refresh was issued for them at all — so a view display that had just been added showed whatever the cache happened to hold.

## What this does

The two steps are now sequential: first the list of view displays, then the views that list turns out to contain.

- **`PageTitleMenu`** only marks the structure and leaves a view-refresh request standing on the resource, instead of clearing the on-screen views' caches.
- **`AbstractResourceWithProfile.isViewRefreshDue(waitsForStructure)`** hands that request to the first view list built *once the refreshed structure has landed*. The answer is memoised per `RequestCycle`, so several lists on one page refresh together rather than the first one taking the request away from the others.
- **`ViewList`** marks each view's query as outdated just before building it, so the view comes back through `RefreshingResultPanel` — what is on screen now, plus a spinner — and swaps in the new results once the query has run.
- **`RefreshingStructurePanel`** rebuilds its content for a standing request even when the refreshed structure turned out to be the same one; that rebuild is what carries the request to the views.
- **`forceRefresh`** now also marks the view-display query itself in `ApiCache`, the way every other refresh does. Without it, a forced fetch that finds a refresh of the same query already in flight settles for what that one leaves behind — a response fetched before this refresh was asked for.

Views built outside the structure-driven list — the About and Explore tabs build their own — have no refreshed list to wait for and are still marked right away (`findParent(ViewList.class) == null`). A `?root=`-pinned space page fetches its view displays inline, so what it shows is already the refreshed list and it does not wait either.

## Trade-off

The views no longer start refreshing immediately: they wait for the structure query. On the home page that is the ~7 s visible above, with the `StructureRefreshIndicator` spinner running beside the title menu meanwhile. This is deliberate — it is what makes the refreshed list the one whose views get refreshed.

## Verification

Full suite green (1192 tests), including three new cases in `StructureRefreshTest` covering the wait, the explicit-list path and the no-request default.

Driven end-to-end against a local instance. Home page, after the change:

```
20:34:51.801  Refreshing cache for …/get-view-displays          ← step 1
20:34:58.243  Updating cached API response …/get-view-displays  ← lands
20:34:59.379  Getting view displays …                            ← content rebuilt
20:34:59.58–59.93  (all 15 view queries updated)                 ← step 2
```

Nothing refreshes between the click and the structure landing. The space page behaves the same; the About tab still refreshes its own nine view queries immediately; pages render clean with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)