### PR TITLE
feat: add "partial" fill mode that discards non-matching source content

### DIFF
--- a/docs/fill-modes.md
+++ b/docs/fill-modes.md
@@ -16,6 +16,7 @@ and — the subject of [#527](https://github.com/knowledgepixels/nanodash/issues
 | Mode | URL param | Provenance link | Introduced IRIs | Root definition |
 | --- | --- | --- | --- | --- |
 | **Use** | `use` / `use-a` | none | re-minted | new nanopub |
+| **Partial** | `partial` / `partial-a` | none | re-minted | new nanopub |
 | **Supersede** | `supersede` / `supersede-a` | `npx:supersedes` | **kept** | **kept** (same resource, new version) |
 | **Derive** | `derive` / `derive-a` | `prov:wasDerivedFrom` | re-minted (new resource) | **new nanopub** |
 | **Override** | `override` / `override-a` | `prov:wasDerivedFrom` | **kept** | **kept** |
@@ -33,6 +34,31 @@ the root-nanopub placeholder) live in the assertion.
 A fresh nanopub seeded from a source or example. Every identifier from the
 source is rewritten into the new nanopub's namespace, and no provenance link
 back to the source is recorded.
+
+### Partial
+
+Identical to **Use**, except that source content which does not match the
+template being filled is **discarded silently** instead of being listed under
+*"Some content from the existing nanopublication could not be filled in:"*.
+
+Use it when filling deliberately **across** templates, where the source is only
+a seed for the form and a mismatch is expected rather than a warning. The
+motivating case is a view action that opens one template's form seeded from a
+nanopub made with another: e.g. the Nanosuggestions "assign" action, whose
+source may be the nanopub that *reported* the issue — its title, description,
+status and space links have no counterpart in the assign template, so every
+such form would otherwise carry a warning listing them.
+
+Every other mode keeps reporting unmatched content, which is what you want when
+source and target template are meant to line up: there, leftovers mean content
+would be silently lost. The distinction is deliberately **explicit in the
+parameter** rather than inferred (e.g. from the source's
+`nt:wasCreatedFromTemplate` differing from the target): filling across templates
+is not by itself evidence that the author wants the difference hidden.
+
+Discarding also covers the pubinfo catch-all — unmatched pubinfo is dropped
+rather than swept into the hand-coded statements template, which would publish
+it after all.
 
 ### Supersede
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -98,6 +98,20 @@ public class PublishForm extends Panel {
          */
         USE,
         /**
+         * Partial fill mode: identical to {@link #USE} (no provenance link back to
+         * the source, introduced IRIs re-minted, the new nanopub is its own root),
+         * except that content of the source which does not match the template being
+         * filled is discarded <em>silently</em> instead of being reported.
+         * <p>
+         * Intended for filling deliberately <em>across</em> templates, where the
+         * source is only a seed for the form and a mismatch is expected rather than a
+         * warning: e.g. a view action that opens an "assign" form seeded from the
+         * nanopublication that reported the issue. The other modes keep reporting
+         * unmatched content, which is what you want when the source and the target
+         * template are meant to line up.
+         */
+        PARTIAL,
+        /**
          * Supersede fill mode
          */
         SUPERSEDE,
@@ -172,6 +186,13 @@ public class PublishForm extends Panel {
         } else if (!pageParams.get("use-a").isNull()) {
             fillNp = Utils.getNanopub(pageParams.get("use-a").toString());
             fillMode = FillMode.USE;
+            fillOnlyAssertion = true;
+        } else if (!pageParams.get("partial").isNull()) {
+            fillNp = Utils.getNanopub(pageParams.get("partial").toString());
+            fillMode = FillMode.PARTIAL;
+        } else if (!pageParams.get("partial-a").isNull()) {
+            fillNp = Utils.getNanopub(pageParams.get("partial-a").toString());
+            fillMode = FillMode.PARTIAL;
             fillOnlyAssertion = true;
         } else if (!pageParams.get("supersede").isNull()) {
             fillNp = Utils.getNanopub(pageParams.get("supersede").toString());
@@ -483,7 +504,9 @@ public class PublishForm extends Panel {
                 for (IRI creator : SimpleCreatorPattern.getCreators(fillNp)) {
                     piFiller.removeUnusedStatements(creator, FOAF.NAME, null);
                 }
-                if (piFiller.hasUnusedStatements()) {
+                if (piFiller.hasUnusedStatements() && fillMode != FillMode.PARTIAL) {
+                    // A partial fill discards what does not match rather than sweeping it into
+                    // the catch-all, which would publish it after all.
                     if (handcodedContext == null) {
                         handcodedContext = createPubInfoContext(handcodedStatementsTemplateId);
                         handcodedContext.setFillSource(fillNp);
@@ -512,6 +535,14 @@ public class PublishForm extends Panel {
             ValueFiller filler = new ValueFiller(improveNp, ContextType.ASSERTION, true);
             filler.fill(assertionContext);
             unusedStatementList.addAll(filler.getUnusedStatements());
+        }
+        if (fillMode == FillMode.PARTIAL) {
+            // A partial fill takes what matches and drops the rest without telling the user:
+            // the mismatch is intended, so reporting it would only be noise. Every other
+            // mode keeps reporting it.
+            unusedStatementList.clear();
+            unusedPrStatementList.clear();
+            unusedPiStatementList.clear();
         }
         if (!unusedStatementList.isEmpty()) {
             add(new Label("warnings", "Some content from the existing nanopublication could not be filled in:"));

--- a/src/test/java/com/knowledgepixels/nanodash/component/PublishFormSourceTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/PublishFormSourceTest.java
@@ -37,9 +37,21 @@ class PublishFormSourceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"use", "use-a", "derive", "derive-a", "improve", "fill-all"})
+    @ValueSource(strings = {"use", "use-a", "partial", "partial-a", "derive", "derive-a", "improve", "fill-all"})
     void sourceIdIsNullForNonSupersedingParams(String key) {
         assertNull(PublishForm.getSupersededOrOverriddenNanopubId(params(key, OLD_NP)));
+    }
+
+    /**
+     * Partial is a Use variant: it claims neither the source's identity nor its root,
+     * so it must not be treated as superseding/overriding (no outdated-source check,
+     * and {@link PublishForm#withSourceNanopub} must leave it alone).
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"partial", "partial-a"})
+    void tryUseIsNotASupersedingSource(String key) {
+        assertFalse(PublishForm.isSourceOutdated(params(key, OLD_NP)));
+        assertEquals(OLD_NP, PublishForm.withSourceNanopub(params(key, OLD_NP), NEW_NP).get(key).toString());
     }
 
     @Test


### PR DESCRIPTION
## What

Adds a fifth fill mode, **`partial`** (URL params `partial` / `partial-a`), alongside `use` / `supersede` / `derive` / `override`.

| Mode | URL param | Provenance link | Introduced IRIs | Root definition |
| --- | --- | --- | --- | --- |
| **Use** | `use` / `use-a` | none | re-minted | new nanopub |
| **Partial** | `partial` / `partial-a` | none | re-minted | new nanopub |
| **Supersede** | `supersede` / `supersede-a` | `npx:supersedes` | kept | kept |
| **Derive** | `derive` / `derive-a` | `prov:wasDerivedFrom` | re-minted | new nanopub |
| **Override** | `override` / `override-a` | `prov:wasDerivedFrom` | kept | kept |

`partial` is identical to `use` in every respect except one: source content that does not match the template being filled is **discarded silently** instead of being listed under *"Some content from the existing nanopublication could not be filled in:"*.

## Why

That report is correct when source and target template are meant to line up — leftovers there mean content would be silently lost. It is noise when a form is deliberately seeded from a nanopublication made with a *different* template.

The motivating case is a view action. The Nanosuggestions `assign...` action opens the assign template seeded from whichever nanopublication currently assigns the issue — which may be the one that **reported** it, since the report template's `schema:agent` field is optional and repeatable. That nanopub's title, description, status and space links have no counterpart in the assign template, so every such form carried a warning listing them.

The distinction is deliberately **explicit in the parameter** rather than inferred (e.g. from the source's `nt:wasCreatedFromTemplate` differing from the target's). Filling across templates is not by itself evidence that the author wants the difference hidden, and an `override` across templates should still report it.

## Notes for review

- **Small by construction.** Every other fill branch tests explicitly for `SUPERSEDE`/`DERIVE`/`OVERRIDE` (20 `FillMode.` comparisons across `PublishForm`, `ValueFiller`, `TemplateContext`, `ValueItem`, `ReadonlyItem`), so the new enum value inherits `USE`'s behaviour everywhere without touching those sites.
- **The pubinfo catch-all is also skipped.** For the non-`-a` variant, leftover pubinfo is normally swept into the hand-coded statements template and published — which would have contradicted "discards the rest".
- **Not added to `sourceParamKeys`.** That array drives the outdated-source check and is only for modes that claim the source's identity; `partial` claims neither identity nor root. Covered by a new test.

## Testing

`mvn test` on the fill-mode suites (`PublishFormSourceTest`, `PublishFormTemplateErrorTest`, `OverrideIntroducedResourceIriTest`, `DeriveIntroducedResourceFillTest`, `TemplateContextTest`): **41 tests, 0 failures**, including 4 new assertions that `partial` is not treated as a superseding source.

Not exercised through the UI — the behaviour is reachable only from a logged-in publish form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)