### PR TITLE
feat: support non-http(s) URI schemes (ipfs:, ipns:, did:, at:)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Status legend: ✅ Implemented · 🚧 In progress · 📋 Proposed
 | [shacl-alignment](shacl-alignment.md) | 📋 Proposed | Build on the SHACL standard: adopt `sh:`/`dash:` constraint terms inside templates (A) and export SHACL shapes for external validation (B) |
 | [custom-domains](custom-domains.md) | 📋 Proposed | Serve a user's profile from their own domain |
 | [draft-with-ai](draft-with-ai.md) | 📋 Proposed | Server-side "Draft with AI" nanopub authoring |
+| [uri-schemes](uri-schemes.md) | ✅ Implemented | Accepts and renders `ipfs:`, `ipns:`, `did:` and `at:` URIs alongside `http(s)`, with configurable outbound resolvers and scheme-aware short labels ([#655](https://github.com/knowledgepixels/nanodash/issues/655)) |
 | [claude-code-chat](claude-code-chat.md) | 🚧 In progress | Chat panel backed by the user's local Claude Code, acting on Nanodash via an MCP endpoint (Tier 2 of [#434](https://github.com/knowledgepixels/nanodash/issues/434)) |
 
 When a doc's status changes, update both its `**Status:**` line and the row here.

--- a/docs/uri-schemes.md
+++ b/docs/uri-schemes.md
@@ -1,0 +1,68 @@
+# Non-http(s) URI schemes
+
+**Status:** ✅ Implemented ([#655](https://github.com/knowledgepixels/nanodash/issues/655))
+
+Nanodash accepts and displays URIs in the schemes a nanopublication is allowed to reference, not
+just `http(s)`. This is about **linking to** such resources from a nanopub. It is not about
+publishing nanopublications over IPFS, and not about using DIDs as agent identifiers — Nanodash's
+agent model is still ORCID-shaped, and that is a separate design question.
+
+| Scheme | Example | What it identifies |
+| --- | --- | --- |
+| `ipfs:` | `ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi` | Content-addressed data |
+| `ipns:` | `ipns://example.org` | A mutable name pointing at content |
+| `did:` | `did:plc:z72i7hdynmk6r22z27h6tvur` | A decentralized identifier |
+| `at:` | `at://did:plc:z72i…/app.bsky.feed.post/3k2akmn5c7l2v` | An individual ATProto record |
+
+The list is not Nanodash's own: it comes from `org.nanopub.UriSchemes.ALLOWED_SCHEMES` in
+nanopub-java ([#138](https://github.com/Nanopublication/nanopub-java/issues/138)), so that Nanodash
+and the nanopublication verifier agree on what counts as a URI. Adding a scheme there is enough to
+make it work here.
+
+## What this affects
+
+- **Form input.** Placeholders that take a URI accept these schemes. A value in an unsupported
+  scheme is rejected with *"IRI scheme not allowed here; use one of: …"*.
+- **Rendering.** A value in one of these schemes is recognized as a URI and rendered as a link,
+  rather than falling through to plain text. `Utils.isUriValue(String)` is the single
+  discriminator for this; it replaced about thirty ad-hoc `matches("https?://.+")` tests.
+- **HTML from views.** The sanitizer keeps `href`/`src` attributes in these schemes instead of
+  stripping them.
+- **Labels.** `did:` has no slashes and a CID is 59 characters, so neither shortens usefully by
+  splitting on `/` and `#`. These get scheme-aware labels instead: `did:plc:z72i…tvur`,
+  `ipfs:bafy…bzdi`. An AT-URI is labelled by its record key.
+
+## Following a link
+
+Nanodash has no page of its own to show for an `ipfs:`, `did:` or `at:` resource, so it hands the
+URI to an external web resolver rather than to the Explore page. The map is configurable, with
+`$uri` expanding to the whole URI and `$rest` to the part after the scheme:
+
+```yaml
+# ~/.nanopub/nanodash-preferences.yml
+uriResolvers: "ipfs=http://127.0.0.1:8080/ipfs/$rest,did=https://dev.uniresolver.io/1.0/identifiers/$uri"
+```
+
+or as an environment variable:
+
+```
+NANODASH_URI_RESOLVERS=ipfs=http://127.0.0.1:8080/ipfs/$rest,ipns=http://127.0.0.1:8080/ipns/$rest
+```
+
+The value **replaces** the defaults rather than adding to them, so setting it to an empty string
+turns outbound resolution off and these URIs become non-links. The defaults are public third-party
+services (`ipfs.io`, `dev.uniresolver.io`, `pdsls.dev`); an instance that runs its own IPFS node
+should point the gateway at it.
+
+## A note on persistence
+
+`ipfs:` and `did:` are both offered here, but they sit at opposite ends of the same trade-off and
+should not be treated as interchangeable "persistent identifiers":
+
+- A **CID** is immutable — it is a hash of the content, so the reference cannot silently drift.
+  But it is only retrievable while somebody pins the data; nothing guarantees availability.
+- A **`did:plc:`** is reliably resolvable, but mutable: its keys can be rotated, and it depends on
+  a semi-central directory operated by Bluesky. What it resolves to today is not necessarily what
+  it resolved to last year.
+
+Which of the two failure modes is acceptable depends on what the reference is for.

--- a/docs/uri-schemes.md
+++ b/docs/uri-schemes.md
@@ -34,9 +34,11 @@ make it work here.
 
 ## Following a link
 
-Nanodash has no page of its own to show for an `ipfs:`, `did:` or `at:` resource, so it hands the
-URI to an external web resolver rather than to the Explore page. The map is configurable, with
-`$uri` expanding to the whole URI and `$rest` to the part after the scheme:
+Nanodash has no page of its own to show for an `ipfs:`, `did:` or `at:` resource, so wherever such
+a URI is rendered as a link — in nanopublication and form display (`IriItem`, `ReadonlyItem`) and
+in query-result tables and lists (`NanodashLink`) — it points at an external web resolver rather
+than at the Explore page, which has nothing to look up for one of these. The map is configurable,
+with `$uri` expanding to the whole URI and `$rest` to the part after the scheme:
 
 ```yaml
 # ~/.nanopub/nanodash-preferences.yml

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.nanopub</groupId>
       <artifactId>nanopub</artifactId>
-      <version>1.92.0</version>
+      <version>1.93.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.openhtmltopdf</groupId>

--- a/src/main/java/com/knowledgepixels/nanodash/NanodashPreferences.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanodashPreferences.java
@@ -10,7 +10,10 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Class to manage Nanodash preferences.
@@ -57,6 +60,7 @@ public class NanodashPreferences implements Serializable {
     private String claudeChatModel;
     private boolean mcpRemoteEnabled = false;
     private String apiCacheFile;
+    private String uriResolvers;
     public static final String DEFAULT_SETTING_PATH = "/.nanopub/nanodash-preferences.yml";
 
     /**
@@ -70,6 +74,23 @@ public class NanodashPreferences implements Serializable {
      * Value for {@link #getApiCacheFile()} that disables API cache persistence.
      */
     public static final String API_CACHE_DISABLED = "none";
+
+    /**
+     * Where non-http(s) URIs are sent when they are followed as links (issue #655). Nanodash
+     * cannot display an {@code ipfs:}, {@code did:} or {@code at:} resource itself, so it hands
+     * the URI to a web resolver. Keys are schemes, values are URL templates in which
+     * {@code $uri} expands to the whole URI and {@code $rest} to the part after the scheme
+     * (and after {@code //}, where present), both percent-encoded.
+     * <p>
+     * These defaults are public third-party services and are meant to be overridden — an IPFS
+     * gateway in particular is better pointed at a local node, e.g.
+     * {@code ipfs=http://127.0.0.1:8080/ipfs/$rest}.
+     */
+    public static final Map<String, String> DEFAULT_URI_RESOLVERS = Map.of(
+            "ipfs", "https://ipfs.io/ipfs/$rest",
+            "ipns", "https://ipfs.io/ipns/$rest",
+            "did", "https://dev.uniresolver.io/1.0/identifiers/$uri",
+            "at", "https://pdsls.dev/$uri");
 
     /** Where an instance is assumed to be reachable when nothing says otherwise: a local run. */
     public static final String DEFAULT_WEBSITE_URL = "http://localhost:37373/";
@@ -405,6 +426,41 @@ public class NanodashPreferences implements Serializable {
      */
     public void setApiCacheFile(String apiCacheFile) {
         this.apiCacheFile = apiCacheFile;
+    }
+
+    /**
+     * Get the resolvers for non-http(s) URI schemes, from the {@code NANODASH_URI_RESOLVERS}
+     * environment variable or the preferences file, falling back to
+     * {@link #DEFAULT_URI_RESOLVERS}. The configured form is a comma-separated list of
+     * {@code scheme=urlTemplate} entries; it replaces the defaults rather than adding to them,
+     * so an empty value switches outbound resolution off entirely.
+     *
+     * @return scheme to URL template, keyed by lower-case scheme
+     */
+    public Map<String, String> getUriResolvers() {
+        String s = System.getenv("NANODASH_URI_RESOLVERS");
+        if (s == null) s = uriResolvers;
+        if (s == null) return DEFAULT_URI_RESOLVERS;
+        Map<String, String> map = new HashMap<>();
+        for (String entry : s.split(",")) {
+            if (entry.isBlank()) continue;
+            int eq = entry.indexOf('=');
+            if (eq < 1) {
+                logger.warn("Ignoring malformed URI resolver entry (expected scheme=urlTemplate): {}", entry);
+                continue;
+            }
+            map.put(entry.substring(0, eq).trim().toLowerCase(Locale.ROOT), entry.substring(eq + 1).trim());
+        }
+        return map;
+    }
+
+    /**
+     * Set the resolvers for non-http(s) URI schemes.
+     *
+     * @param uriResolvers comma-separated {@code scheme=urlTemplate} entries
+     */
+    public void setUriResolvers(String uriResolvers) {
+        this.uriResolvers = uriResolvers;
     }
 
     public String getHomeResource() {

--- a/src/main/java/com/knowledgepixels/nanodash/RestrictedChoice.java
+++ b/src/main/java/com/knowledgepixels/nanodash/RestrictedChoice.java
@@ -70,7 +70,7 @@ public class RestrictedChoice implements Serializable {
             if (context.getTemplate().isLocalResource(placeholderIri)) {
                 // Full URIs are not local, except artifact-code wildcard IRIs, which mint
                 // a new resource per publication just like local short IDs do.
-                if (s.matches("https?://.+") && !s.contains("~~ARTIFACTCODE~~")) continue;
+                if (Utils.isUriValue(s) && !s.contains("~~ARTIFACTCODE~~")) continue;
             }
             possibleValuesList.add(s);
         }

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -18,6 +18,7 @@ import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.util.string.StringValue;
 import org.apache.wicket.util.string.Strings;
+import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
@@ -28,6 +29,7 @@ import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubUtils;
+import org.nanopub.UriSchemes;
 import org.nanopub.extra.security.KeyDeclaration;
 import org.nanopub.extra.security.MalformedCryptoElementException;
 import org.nanopub.extra.security.NanopubSignatureElement;
@@ -47,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import org.wicketstuff.select2.Select2Choice;
 
 import java.io.Serializable;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -100,6 +103,8 @@ public class Utils {
         if (uri.startsWith("https://doi.org/") || uri.startsWith("http://dx.doi.org/")) {
             return uri.replaceFirst("^https?://(dx\\.)?doi.org/", "doi:");
         }
+        String nonHierarchicalName = getNonHierarchicalShortName(uri);
+        if (nonHierarchicalName != null) return nonHierarchicalName;
         uri = uri.replaceFirst("\\?.*$", "");
         uri = uri.replaceFirst("[/#]$", "");
         uri = uri.replaceFirst("^.*[/#]([^/#]*)[/#]([0-9]+)$", "$1/$2");
@@ -112,6 +117,56 @@ public class Utils {
         uri = uri.replaceFirst("(^|[^A-Za-z0-9\\-_])RA[A-Za-z0-9\\-_]{43}[^A-Za-z0-9\\-_](.+)$", "$2");
         uri = URLDecoder.decode(uri, UTF_8);
         return uri;
+    }
+
+    // Length below which an identifier is shown whole rather than elided.
+    private static final int SHORT_NAME_ELISION_THRESHOLD = 14;
+
+    /**
+     * Short label for the URI schemes whose identifiers are opaque rather than hierarchical
+     * (issue #655). The general logic in {@link #getShortNameFromURI(String)} splits on "/" and
+     * "#", which a DID has neither of, and which leaves a bare CID as a 59-character "short"
+     * name. The scheme is kept — it is the part that says what kind of thing this is — and the
+     * identifier is elided in the middle, keeping its start (for a CID, the multibase and codec
+     * prefix) and its end (enough to tell two of them apart).
+     *
+     * @param uri the URI to shorten
+     * @return the short label, or null if the URI is hierarchical and handled by the caller
+     */
+    private static String getNonHierarchicalShortName(String uri) {
+        String scheme = UriSchemes.getScheme(uri);
+        if (scheme == null) return null;
+        if (scheme.equals("ipfs") || scheme.equals("ipns")) {
+            String id = uri.substring(scheme.length() + 1).replaceFirst("^//", "");
+            // A path under the CID is hierarchical after all, so the general rules apply.
+            if (id.contains("/")) return null;
+            return scheme + ":" + elideMiddle(id);
+        }
+        if (scheme.equals("did")) {
+            // did:<method>:<method-specific-id> -- the method is short and meaningful, so only
+            // the identifier after it is elided.
+            String rest = uri.substring(4);
+            int colon = rest.indexOf(':');
+            if (colon < 1) return "did:" + elideMiddle(rest);
+            return "did:" + rest.substring(0, colon + 1) + elideMiddle(rest.substring(colon + 1));
+        }
+        if (scheme.equals("at")) {
+            // at://<did>/<collection>/<rkey> -- the record key identifies the record, and is
+            // what the general rules would pick out too, but they choke on a URI without a path.
+            String rest = uri.substring(3).replaceFirst("^//", "");
+            int lastSlash = rest.lastIndexOf('/');
+            if (lastSlash >= 0) return "at:" + rest.substring(lastSlash + 1);
+            // No record key: what is left is the repository, which is a DID, so it shortens by
+            // the rule above rather than being elided as one opaque blob.
+            String repository = getNonHierarchicalShortName(rest);
+            return "at:" + (repository != null ? repository : elideMiddle(rest));
+        }
+        return null;
+    }
+
+    private static String elideMiddle(String id) {
+        if (id.length() <= SHORT_NAME_ELISION_THRESHOLD) return id;
+        return id.substring(0, 4) + "…" + id.substring(id.length() - 4);
     }
 
     /**
@@ -736,9 +791,15 @@ public class Utils {
                 .allowAttributes(SVG_ATTRIBUTES).onElements(SVG_ELEMENTS_WITH_LINK);
     }
 
+    // Links a view emits may point at any scheme a nanopublication is allowed to reference
+    // (issue #655); without them here the sanitizer silently strips the href. All of these are
+    // inert reference schemes -- nothing script-executing is added.
+    private static final String[] SANITIZER_URL_PROTOCOLS =
+            UriSchemes.ALLOWED_SCHEMES.stream().sorted().toArray(String[]::new);
+
     private static final PolicyFactory htmlSanitizePolicy = allowSvgSubset(new HtmlPolicyBuilder()
             .allowCommonBlockElements().allowCommonInlineFormattingElements()
-            .allowUrlProtocols("https", "http", "mailto")
+            .allowUrlProtocols(SANITIZER_URL_PROTOCOLS).allowUrlProtocols("mailto")
             .allowElements("a").allowAttributes("href").onElements("a")
             .allowElements("img").allowAttributes("src").onElements("img")
             .allowElements("pre")
@@ -756,7 +817,7 @@ public class Utils {
     }
 
     private static final PolicyFactory svgSanitizePolicy = allowSvgSubset(new HtmlPolicyBuilder()
-            .allowUrlProtocols("https", "http")
+            .allowUrlProtocols(SANITIZER_URL_PROTOCOLS)
             .allowElements("a")
             .allowWithoutAttributes("a")
             .allowAttributes("href").onElements("a")).toFactory();
@@ -1460,6 +1521,126 @@ public class Utils {
      */
     public static boolean isLocalURI(String uriAsString) {
         return !uriAsString.isBlank() && uriAsString.startsWith(LocalUri.PREFIX);
+    }
+
+    /**
+     * Checks whether a string should be treated as a URI reference rather than as plain text.
+     * This is the single discriminator used across the code base, replacing the ad-hoc
+     * {@code matches("https?://.+")} tests that only recognized http(s) (issue #655).
+     * <p>
+     * The set of accepted schemes comes from {@link UriSchemes} in nanopub-java, so that Nanodash
+     * and the nanopublication verifier agree on what counts as a URI.
+     * <p>
+     * {@link UriSchemes#isAllowedUriScheme(String)} on its own only inspects the scheme, so it
+     * accepts strings such as {@code "at: home"} that happen to start with an allowed scheme name
+     * and a colon. Since many call sites use this method to decide between a literal and an IRI,
+     * that would silently turn ordinary prose into a link. The extra conditions below reject such
+     * values: a URI contains no whitespace, and must have something after the scheme -- which,
+     * for the {@code scheme://} form, means something after the slashes, so that a bare
+     * {@code "http://"} is no more a URI than it was under the {@code "https?://.+"} test.
+     *
+     * @param value the string to check
+     * @return true if the string is a URI in one of the allowed schemes
+     */
+    public static boolean isUriValue(String value) {
+        if (value == null || value.isBlank()) return false;
+        if (!UriSchemes.isAllowedUriScheme(value)) return false;
+        for (int i = 0; i < value.length(); i++) {
+            if (Character.isWhitespace(value.charAt(i))) return false;
+        }
+        String rest = value.substring(value.indexOf(':') + 1);
+        if (rest.startsWith("//")) rest = rest.substring(2);
+        return !rest.isEmpty();
+    }
+
+    /**
+     * The external web URL where a URI Nanodash cannot display itself can be looked up, from the
+     * scheme-to-template map in {@link NanodashPreferences#getUriResolvers()} (issue #655).
+     * http(s) URIs are never resolved this way: they are their own web address.
+     *
+     * @param uri the URI to resolve
+     * @return the resolver URL, or null if the scheme has no configured resolver
+     */
+    public static String getExternalResolverUrl(String uri) {
+        String scheme = UriSchemes.getScheme(uri);
+        if (scheme == null || scheme.equals("http") || scheme.equals("https")) return null;
+        String template = NanodashPreferences.get().getUriResolvers().get(scheme);
+        if (template == null || template.isBlank()) return null;
+        String rest = uri.substring(scheme.length() + 1);
+        if (rest.startsWith("//")) rest = rest.substring(2);
+        return template.replace("$rest", encodeForPath(rest)).replace("$uri", encodeForPath(uri));
+    }
+
+    // The resolvers substitute into the path of a URL, where the colons of a DID and the slashes
+    // of an AT-URI or IPFS path are legal and load-bearing -- form encoding them (as urlEncode
+    // does) would produce a URL the resolver cannot read. So only what is unsafe in a path is
+    // escaped, which importantly includes "?" and "#": left as they are, a crafted URI could
+    // append a query or fragment to the resolver URL rather than being resolved by it.
+    private static final String PATH_SAFE_PUNCTUATION = "-._~!$&'()*+,;=:@/";
+
+    private static String encodeForPath(String s) {
+        StringBuilder sb = new StringBuilder();
+        int i = 0;
+        while (i < s.length()) {
+            int codePoint = s.codePointAt(i);
+            int width = Character.charCount(codePoint);
+            char c = s.charAt(i);
+            boolean alnum = width == 1
+                    && ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'));
+            // An existing percent-escape is passed through, so that an already-encoded URI does
+            // not come out double-encoded.
+            boolean keptEscape = width == 1 && c == '%' && i + 2 < s.length()
+                    && isHexDigit(s.charAt(i + 1)) && isHexDigit(s.charAt(i + 2));
+            if (alnum || keptEscape || (width == 1 && PATH_SAFE_PUNCTUATION.indexOf(c) >= 0)) {
+                sb.append(c);
+            } else {
+                for (byte b : new String(Character.toChars(codePoint)).getBytes(UTF_8)) {
+                    sb.append(String.format("%%%02X", b));
+                }
+            }
+            i += width;
+        }
+        return sb.toString();
+    }
+
+    private static boolean isHexDigit(char c) {
+        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+    }
+
+    /**
+     * The allowed URI schemes as a sorted, comma-separated list, for use in validation messages.
+     *
+     * @return the allowed schemes, e.g. "at, did, http, https, ipfs, ipns"
+     */
+    public static String getAllowedUriSchemesLabel() {
+        return UriSchemes.ALLOWED_SCHEMES.stream().sorted().collect(java.util.stream.Collectors.joining(", "));
+    }
+
+    /**
+     * Checks whether a string is a well-formed absolute URI.
+     * <p>
+     * {@link ParsedIRI} is tried first, so that http(s) input is judged exactly as it was before
+     * issue #655. It cannot parse AT-URIs: in {@code at://did:plc:abc/app.bsky.feed.post/3k} the
+     * authority is {@code did:plc:abc}, and it reads the colon as introducing a port, which then
+     * fails to be a number. {@link URI} allows a registry-based authority and accepts these, while
+     * still rejecting genuinely malformed input such as {@code at://}, {@code did:} or embedded
+     * spaces, so it serves as the fallback rather than as a blanket exemption.
+     *
+     * @param uri the string to check
+     * @return true if the string is a well-formed absolute URI
+     */
+    public static boolean isWellFormedUri(String uri) {
+        if (uri == null || uri.isBlank()) return false;
+        try {
+            if (new ParsedIRI(uri).isAbsolute()) return true;
+        } catch (URISyntaxException ex) {
+            // fall through to the more permissive parser below
+        }
+        try {
+            return new URI(uri).isAbsolute();
+        } catch (URISyntaxException ex) {
+            return false;
+        }
     }
 
     public static String unescapeMultiValue(String s) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/GuidedChoiceItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/GuidedChoiceItem.java
@@ -76,7 +76,7 @@ public class GuidedChoiceItem extends AbstractContextComponent {
     private String getChoiceLabel(String choiceId) {
         Template template = context.getTemplate();
         String label = null;
-        if (choiceId.matches("https?://.+") && template.getLabel(vf.createIRI(choiceId)) != null) {
+        if (Utils.isUriValue(choiceId) && template.getLabel(vf.createIRI(choiceId)) != null) {
             label = template.getLabel(vf.createIRI(choiceId));
         } else if (labelMap.containsKey(choiceId)) {
             label = labelMap.get(choiceId);
@@ -126,7 +126,7 @@ public class GuidedChoiceItem extends AbstractContextComponent {
             prefixLabelComp = new Label("prefix", "");
             prefixLabelComp.setVisible(false);
         } else {
-            if (!prefixLabel.isEmpty() && parentId.equals("subj") && !prefixLabel.matches("https?://.*")) {
+            if (!prefixLabel.isEmpty() && parentId.equals("subj") && !Utils.isUriValue(prefixLabel)) {
                 // Capitalize first letter of label if at subject position:
                 prefixLabel = prefixLabel.substring(0, 1).toUpperCase() + prefixLabel.substring(1);
             }
@@ -167,7 +167,7 @@ public class GuidedChoiceItem extends AbstractContextComponent {
                     response.addAll(possibleValues);
                     return;
                 }
-                if (term.startsWith("https://") || term.startsWith("http://")) {
+                if (Utils.isUriValue(term)) {
                     if (prefix == null || term.startsWith(prefix)) {
                         response.add(term);
                     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
@@ -76,7 +76,7 @@ public class IriItem extends AbstractContextComponent {
         if (!statementPartId.equals(template.getFirstOccurrence(iri))) {
             labelString = labelString.replaceFirst("^[aA]n? ", "the ");
         }
-        if (!labelString.isEmpty() && parentId.equals("subj") && !labelString.matches("https?://.*")) {
+        if (!labelString.isEmpty() && parentId.equals("subj") && !Utils.isUriValue(labelString)) {
             // Capitalize first letter of label if at subject position:
             labelString = labelString.substring(0, 1).toUpperCase() + labelString.substring(1);
         }

--- a/src/main/java/com/knowledgepixels/nanodash/component/IriTextfieldItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/IriTextfieldItem.java
@@ -22,7 +22,6 @@ import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.Validatable;
 import org.apache.wicket.validation.ValidationError;
-import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
 import org.nanopub.SimpleCreatorPattern;
@@ -33,7 +32,6 @@ import org.wicketstuff.select2.ChoiceProvider;
 import org.wicketstuff.select2.Response;
 import org.wicketstuff.select2.Select2Choice;
 
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Map;
 
@@ -101,7 +99,7 @@ public class IriTextfieldItem extends AbstractContextComponent {
             prefixLabelComp = new Label("prefix", "");
             prefixLabelComp.setVisible(false);
         } else {
-            if (!prefixLabel.isEmpty() && parentId.equals("subj") && !prefixLabel.matches("https?://.*")) {
+            if (!prefixLabel.isEmpty() && parentId.equals("subj") && !Utils.isUriValue(prefixLabel)) {
                 // Capitalize first letter of label if at subject position:
                 prefixLabel = prefixLabel.substring(0, 1).toUpperCase() + prefixLabel.substring(1);
             }
@@ -177,7 +175,7 @@ public class IriTextfieldItem extends AbstractContextComponent {
             public boolean isRequired() {
                 if (super.isRequired()) return true;
                 String raw = textfield.getInput();
-                return raw != null && !raw.isBlank() && !raw.matches("https?://.+");
+                return raw != null && !raw.isBlank() && !Utils.isUriValue(raw);
             }
 
         };
@@ -436,7 +434,7 @@ public class IriTextfieldItem extends AbstractContextComponent {
             if (template.isAutoEscapePlaceholder(iri)) {
                 sv = Utils.urlEncode(sv);
             }
-            if (sv.matches("https?://.+")) {
+            if (Utils.isUriValue(sv)) {
                 p = "";
             } else if (sv.contains(":") || sv.contains("#")) {
                 s.error(new ValidationError("Invalid character in postfix (e.g., colon, hash)"));
@@ -446,16 +444,11 @@ public class IriTextfieldItem extends AbstractContextComponent {
                 p = LocalUri.PREFIX;
                 iriString = p + sv;
             }
-            try {
-                ParsedIRI piri = new ParsedIRI(iriString);
-                if (!piri.isAbsolute()) {
-                    s.error(new ValidationError("IRI not well-formed"));
-                }
-                if (p.isEmpty() && !Utils.isLocalURI(sv) && !sv.matches("https?://.+")) {
-                    s.error(new ValidationError("Only http(s):// IRIs are allowed here"));
-                }
-            } catch (URISyntaxException ex) {
+            if (!Utils.isWellFormedUri(iriString)) {
                 s.error(new ValidationError("IRI not well-formed"));
+            }
+            if (p.isEmpty() && !Utils.isLocalURI(sv) && !Utils.isUriValue(sv)) {
+                s.error(new ValidationError("IRI scheme not allowed here; use one of: " + Utils.getAllowedUriSchemesLabel()));
             }
             String regex = template.getRegex(iri);
             if (regex != null) {
@@ -464,7 +457,7 @@ public class IriTextfieldItem extends AbstractContextComponent {
                 }
             }
             if (template.isExternalUriPlaceholder(iri)) {
-                if (!iriString.matches("https?://.+")) {
+                if (!Utils.isUriValue(iriString)) {
                     s.error(new ValidationError("Not an external IRI"));
                 }
             }

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanodashLink.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanodashLink.java
@@ -189,6 +189,14 @@ public class NanodashLink extends Panel {
     }
 
     private static Component createLinkComponent(String markupId, String uri, String label, String contextId, boolean explicitLabel) {
+        // An ipfs:/did:/at: resource goes to its external resolver, the same as in
+        // getPageUrl (issue #655). Checked first because the lookups below all assume an
+        // http(s) identifier, and because the Explore page fallback at the end has nothing
+        // to show for one of these.
+        String resolverUrl = Utils.getExternalResolverUrl(uri);
+        if (resolverUrl != null) {
+            return new ExternalLink(markupId, resolverUrl, displayLabel(label, explicitLabel));
+        }
         boolean isNp = TrustyUriUtils.isPotentialTrustyUri(uri);
         PageParameters params = new PageParameters().set("id", uri);
         if (contextId != null) params.set("context", contextId);

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanodashLink.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanodashLink.java
@@ -251,6 +251,11 @@ public class NanodashLink extends Panel {
      * falling back to the Explore page otherwise.
      */
     public static String getPageUrl(String uri) {
+        // An ipfs:/did:/at: resource has no Nanodash page to show and nothing to explore, so it
+        // goes to an external resolver instead of the Explore page (issue #655). Checked first
+        // because the lookups below all assume an http(s) identifier.
+        String resolverUrl = Utils.getExternalResolverUrl(uri);
+        if (resolverUrl != null) return resolverUrl;
         if (IndividualAgent.isUser(uri) || IndividualAgent.isOrcidIri(uri)) {
             return UserPage.MOUNT_PATH + "?id=" + URLEncoder.encode(uri, java.nio.charset.StandardCharsets.UTF_8);
         } else if (SpaceRepository.get().findById(uri) != null) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryParamField.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryParamField.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.Utils;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.TextArea;
@@ -9,10 +10,8 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.validation.INullAcceptingValidator;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.ValidationError;
-import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.nanopub.extra.services.QueryTemplate;
 
-import java.net.URISyntaxException;
 
 /**
  * A field for entering query parameters, with validation for required fields and IRIs.
@@ -153,16 +152,12 @@ public class QueryParamField extends Panel {
             }
             if (isIri()) {
                 for (String value : expandValues(i.getValue(), paramId)) {
-                    if (!value.matches("https?://.+")) {
-                        i.error(new ValidationError("Invalid IRI protocol: " + value));
+                    if (!Utils.isUriValue(value)) {
+                        i.error(new ValidationError("IRI scheme not allowed: " + value
+                                + " (use one of: " + Utils.getAllowedUriSchemesLabel() + ")"));
                         return;
                     }
-                    try {
-                        ParsedIRI piri = new ParsedIRI(value);
-                        if (!piri.isAbsolute()) {
-                            i.error(new ValidationError("IRI not well-formed: " + value));
-                        }
-                    } catch (URISyntaxException ex) {
+                    if (!Utils.isWellFormedUri(value)) {
                         i.error(new ValidationError("IRI not well-formed: " + value));
                     }
                 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
@@ -149,7 +149,7 @@ public class QueryResultItemList extends QueryResult {
                 String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest" + templateLinkContextParam();
                 String html = "<span class=\"form-icon\"></span> <a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
                 return new Label("listItem", html).setEscapeModelStrings(false);
-            } else if (value.matches("https?://.*")) {
+            } else if (Utils.isUriValue(value)) {
                 return new NanodashLink("listItem", value, null, null, entryLabel, contextId);
             } else if (entryLabel != null && !entryLabel.isBlank() && !entryLabel.equals(value)) {
                 // Separate display label for a (non-IRI) literal value; the full

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -168,7 +168,7 @@ public class QueryResultList extends QueryResult {
                                 String label = (labels != null && i < labels.length && !labels[i].isBlank()) ? Utils.unescapeMultiValue(labels[i]) : null;
                                 if (isPublishLink(part)) {
                                     multiComponents.add(new Label("component", publishButtonHtml(part, label)).setEscapeModelStrings(false));
-                                } else if (part.matches("https?://.+")) {
+                                } else if (Utils.isUriValue(part)) {
                                     if (label != null && label.equals(part)) {
                                         label = null;
                                     }
@@ -210,7 +210,7 @@ public class QueryResultList extends QueryResult {
                             // A ready-made link to the publish form: an action the view offers,
                             // shown as a button rather than as a link to content.
                             components.add(new Label("component", publishButtonHtml(entryValue, entry.get(key + "_label"))).setEscapeModelStrings(false));
-                        } else if (entryValue.matches("https?://.+")) {
+                        } else if (Utils.isUriValue(entryValue)) {
                             String entryLabel = entry.get(key + "_label");
                             if ("^".equals(entryLabel)) {
                                 // Folded into the per-row actions dropdown appended below.

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultRdf.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultRdf.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.Utils;
 import org.apache.wicket.extensions.ajax.markup.html.repeater.data.table.AjaxNavigationToolbar;
 import org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.AbstractColumn;
@@ -99,7 +100,7 @@ public class QueryResultRdf extends Panel {
         @Override
         public void populateItem(Item<ICellPopulator<String[]>> cellItem, String componentId, IModel<String[]> rowModel) {
             String value = rowModel.getObject()[index];
-            if (value.matches("https?://.+")) {
+            if (Utils.isUriValue(value)) {
                 cellItem.add(new NanodashLink(componentId, value));
             } else {
                 cellItem.add(new Label(componentId, value));

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -321,7 +321,7 @@ public class QueryResultTable extends QueryResult {
                             String rawLabel = (labels != null && i < labels.length && !labels[i].isBlank()) ? Utils.unescapeMultiValue(labels[i]) : null;
                             if (isPublishLink(part)) {
                                 components.add(new Label("component", publishButtonHtml(part, rawLabel)).setEscapeModelStrings(false));
-                            } else if (part.matches("https?://.+")) {
+                            } else if (Utils.isUriValue(part)) {
                                 if (rawLabel != null && rawLabel.equals(part)) {
                                     rawLabel = null;
                                 }
@@ -379,7 +379,7 @@ public class QueryResultTable extends QueryResult {
                         // shown as a button rather than as a link to content.
                         String label = rowModel.getObject().get(key + "_label");
                         cellItem.add(new Label(componentId, publishButtonHtml(value, label)).setEscapeModelStrings(false));
-                    } else if (value.matches("https?://.+")) {
+                    } else if (Utils.isUriValue(value)) {
                         String label = rowModel.getObject().get(key + "_label");
                         cellItem.add(new NanodashLink(componentId, value, null, null, label, contextId));
                     } else {

--- a/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ReadonlyItem.java
@@ -26,7 +26,6 @@ import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.Validatable;
 import org.apache.wicket.validation.ValidationError;
-import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
@@ -41,7 +40,6 @@ import org.nanopub.vocabulary.NTEMPLATE;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.List;
@@ -114,7 +112,7 @@ public class ReadonlyItem extends AbstractContextComponent {
                 String v = getFullValue();
                 if (prefixLabel == null || IndividualAgent.isUser(v) || foafNameMap.containsKey(v)) {
                     return "";
-                } else if (prefixLabel.matches("https?://.*")) {
+                } else if (Utils.isUriValue(prefixLabel)) {
                     // Hide prefix label that leaks through as a raw URL.
                     return "";
                 } else {
@@ -148,7 +146,7 @@ public class ReadonlyItem extends AbstractContextComponent {
                     } else {
                         return "";
                     }
-                } else if (obj.matches("https?://.+")) {
+                } else if (Utils.isUriValue(obj)) {
                     return NanodashLink.getPageUrl(obj);
                 } else {
                     return "";
@@ -172,7 +170,7 @@ public class ReadonlyItem extends AbstractContextComponent {
                 if (obj != null && obj.equals(LocalUri.of("assertion").stringValue())) {
                     return context.getType() == ContextType.ASSERTION ? "this assertion" : "the assertion above";
                 }
-                if (obj != null && obj.matches("https?://.+")) {
+                if (obj != null && Utils.isUriValue(obj)) {
                     IRI objIri = vf.createIRI(obj);
                     if (iri.equals(NTEMPLATE.CREATOR_PLACEHOLDER)) {
                         // TODO We might want to introduce a "(you)" flag here at some point
@@ -215,7 +213,7 @@ public class ReadonlyItem extends AbstractContextComponent {
                 if (rootResolvesToThisNanopub()) {
                     return "This is the identifier for this whole nanopublication.";
                 }
-                if (obj != null && obj.matches("https?://.+")) {
+                if (obj != null && Utils.isUriValue(obj)) {
                     IRI objIri = vf.createIRI(obj);
                     if (isAssertionValue(objIri)) {
                         return "This is the identifier for the assertion of this nanopublication.";
@@ -513,7 +511,7 @@ public class ReadonlyItem extends AbstractContextComponent {
             if (template.isAutoEscapePlaceholder(iri)) {
                 sv = Utils.urlEncode(sv);
             }
-            if (sv.matches("https?://.+")) {
+            if (Utils.isUriValue(sv)) {
                 p = "";
             } else if (sv.contains(":")) {
                 s.error(new ValidationError("Colon character is not allowed in postfix"));
@@ -523,16 +521,11 @@ public class ReadonlyItem extends AbstractContextComponent {
                 p = LocalUri.PREFIX;
                 iriString = p + sv;
             }
-            try {
-                ParsedIRI piri = new ParsedIRI(iriString);
-                if (!piri.isAbsolute()) {
-                    s.error(new ValidationError("IRI not well-formed"));
-                }
-                if (p.isEmpty() && !Utils.isLocalURI(sv) && !sv.matches("https?://.+")) {
-                    s.error(new ValidationError("Only http(s):// IRIs are allowed here"));
-                }
-            } catch (URISyntaxException ex) {
+            if (!Utils.isWellFormedUri(iriString)) {
                 s.error(new ValidationError("IRI not well-formed"));
+            }
+            if (p.isEmpty() && !Utils.isLocalURI(sv) && !Utils.isUriValue(sv)) {
+                s.error(new ValidationError("IRI scheme not allowed here; use one of: " + Utils.getAllowedUriSchemesLabel()));
             }
             String regex = template.getRegex(iri);
             if (regex != null) {
@@ -547,7 +540,7 @@ public class ReadonlyItem extends AbstractContextComponent {
                 }
             }
             if (template.isExternalUriPlaceholder(iri)) {
-                if (!iriString.matches("https?://.+")) {
+                if (!Utils.isUriValue(iriString)) {
                     s.error(new ValidationError("Not an external IRI"));
                 }
             }

--- a/src/main/java/com/knowledgepixels/nanodash/component/RestrictedChoiceItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/RestrictedChoiceItem.java
@@ -75,7 +75,7 @@ public class RestrictedChoiceItem extends AbstractContextComponent {
             prefixLabelComp = new Label("prefix", "");
             prefixLabelComp.setVisible(false);
         } else {
-            if (!prefixLabel.isEmpty() && parentId.equals("subj") && !prefixLabel.matches("https?://.*")) {
+            if (!prefixLabel.isEmpty() && parentId.equals("subj") && !Utils.isUriValue(prefixLabel)) {
                 // Capitalize first letter of label if at subject position:
                 prefixLabel = prefixLabel.substring(0, 1).toUpperCase() + prefixLabel.substring(1);
             }
@@ -88,7 +88,7 @@ public class RestrictedChoiceItem extends AbstractContextComponent {
             @Override
             public String getDisplayValue(String choiceId) {
                 if (choiceId == null || choiceId.isEmpty()) return "";
-                if (!choiceId.matches("https?://.+")) {
+                if (!Utils.isUriValue(choiceId)) {
                     return choiceId;
                 }
                 String label = "";

--- a/src/main/java/com/knowledgepixels/nanodash/component/ValueTextfieldItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ValueTextfieldItem.java
@@ -16,14 +16,12 @@ import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.Validatable;
 import org.apache.wicket.validation.ValidationError;
-import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URISyntaxException;
 
 /**
  * A text field component for entering values in a template.
@@ -161,16 +159,11 @@ public class ValueTextfieldItem extends AbstractContextComponent {
             }
             String p = "";
             if (s.getValue().matches("[^:# ]+")) p = LocalUri.PREFIX;
-            try {
-                ParsedIRI piri = new ParsedIRI(p + s.getValue());
-                if (!piri.isAbsolute()) {
-                    s.error(new ValidationError("IRI not well-formed"));
-                }
-                if (p.isEmpty() && !Utils.isLocalURI(s.getValue()) && !(s.getValue()).matches("https?://.+")) {
-                    s.error(new ValidationError("Only http(s):// IRIs are allowed here"));
-                }
-            } catch (URISyntaxException ex) {
+            if (!Utils.isWellFormedUri(p + s.getValue())) {
                 s.error(new ValidationError("IRI not well-formed"));
+            }
+            if (p.isEmpty() && !Utils.isLocalURI(s.getValue()) && !Utils.isUriValue(s.getValue())) {
+                s.error(new ValidationError("IRI scheme not allowed here; use one of: " + Utils.getAllowedUriSchemesLabel()));
             }
         }
 

--- a/src/main/java/com/knowledgepixels/nanodash/export/DocumentModelBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/export/DocumentModelBuilder.java
@@ -357,7 +357,7 @@ public final class DocumentModelBuilder {
             for (int i = 0; i < parts.length; i++) {
                 String part = parts[i];
                 String label = (labels != null && i < labels.length && !labels[i].isBlank()) ? Utils.unescapeMultiValue(labels[i]) : null;
-                if (part.matches("https?://.+")) {
+                if (Utils.isUriValue(part)) {
                     if (label == null || label.equals(part)) {
                         label = Utils.getShortNameFromURI(part);
                     }
@@ -377,7 +377,7 @@ public final class DocumentModelBuilder {
                 String display = hasLabel ? Utils.unescapeMultiValue(labels[i]) : Utils.unescapeMultiValue(parts[i]);
                 appendSeparated(inlines, new Inline(plainText(display), null));
             }
-        } else if (value.matches("https?://.+")) {
+        } else if (Utils.isUriValue(value)) {
             String label = entry.get(key + "_label");
             if (label == null || label.isBlank() || label.equals(value)) {
                 label = Utils.getShortNameFromURI(value);

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
@@ -481,7 +481,7 @@ public class TemplateContext implements Serializable {
                     prefix = targetNamespace;
                     unresolvedPrefix = false;
                 }
-                if (tfObject.matches("https?://.+")) {
+                if (Utils.isUriValue(tfObject)) {
                     prefix = "";
                     unresolvedPrefix = false;
                 }
@@ -491,7 +491,7 @@ public class TemplateContext implements Serializable {
                 if (!unresolvedPrefix) {
                     String v = prefix + tf.getObject();
                     if (v.matches("[^:# ]+")) v = targetNamespace + v;
-                    if (v.matches("https?://.*")) {
+                    if (Utils.isUriValue(v)) {
                         processedValue = vf.createIRI(v);
                     } else {
                         processedValue = vf.createLiteral(tfObject);
@@ -515,7 +515,7 @@ public class TemplateContext implements Serializable {
                 if (template.isAutoEscapePlaceholder(iri)) {
                     v = prefix + Utils.urlEncode(tf.getObject());
                 } else {
-                    if (tfObject.matches("https?://.+")) {
+                    if (Utils.isUriValue(tfObject)) {
                         prefix = "";
                         unresolvedPrefix = false;
                     }

--- a/src/test/java/com/knowledgepixels/nanodash/UriSchemeSupportTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/UriSchemeSupportTest.java
@@ -1,5 +1,9 @@
 package com.knowledgepixels.nanodash;
 
+import com.knowledgepixels.nanodash.component.NanodashLink;
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.util.tester.WicketTester;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -146,6 +150,26 @@ class UriSchemeSupportTest {
     void sanitizerStillDropsDangerousHrefs() {
         assertFalse(Utils.sanitizeHtml("<a href=\"javascript:alert(1)\">x</a>").contains("javascript:"));
         assertFalse(Utils.sanitizeHtml("<a href=\"ftp://example.org/\">x</a>").contains("ftp://"));
+    }
+
+    @Test
+    void queryResultLinksGoToTheResolverNotTheExplorePage() {
+        // NanodashLink is what query-result tables and lists build their links with; it does not
+        // go through getPageUrl, so it needs the resolver branch of its own.
+        WicketTester tester = new WicketTester();
+        try {
+            Component link = NanodashLink.createLink("link", "ipfs://" + CID, "a pinned file", null);
+            assertInstanceOf(ExternalLink.class, link);
+            assertEquals("https://ipfs.io/ipfs/" + CID,
+                    ((ExternalLink) link).getDefaultModelObjectAsString());
+
+            Component didLink = NanodashLink.createLink("link", DID, null, null);
+            assertInstanceOf(ExternalLink.class, didLink);
+            assertEquals("https://dev.uniresolver.io/1.0/identifiers/" + DID,
+                    ((ExternalLink) didLink).getDefaultModelObjectAsString());
+        } finally {
+            tester.destroy();
+        }
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/nanodash/UriSchemeSupportTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/UriSchemeSupportTest.java
@@ -1,0 +1,156 @@
+package com.knowledgepixels.nanodash;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the non-http(s) URI scheme support of issue #655.
+ */
+class UriSchemeSupportTest {
+
+    private static final String DID = "did:plc:z72i7hdynmk6r22z27h6tvur";
+    private static final String CID = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+    private static final String AT_URI = "at://" + DID + "/app.bsky.feed.post/3k2akmn5c7l2v";
+
+    @Test
+    void isUriValueAcceptsTheNewSchemes() {
+        assertTrue(Utils.isUriValue("https://w3id.org/np/RA123"));
+        assertTrue(Utils.isUriValue("http://example.org/x"));
+        assertTrue(Utils.isUriValue("ipfs://" + CID));
+        assertTrue(Utils.isUriValue("ipns://example.org"));
+        assertTrue(Utils.isUriValue(DID));
+        assertTrue(Utils.isUriValue(AT_URI));
+    }
+
+    @Test
+    void isUriValueRejectsNonUris() {
+        assertFalse(Utils.isUriValue(null));
+        assertFalse(Utils.isUriValue(""));
+        assertFalse(Utils.isUriValue("   "));
+        assertFalse(Utils.isUriValue("just some text"));
+        assertFalse(Utils.isUriValue("localName"));
+        // A scheme that is valid but not allowed in a nanopublication.
+        assertFalse(Utils.isUriValue("ftp://example.org/x"));
+        assertFalse(Utils.isUriValue("javascript:alert(1)"));
+        // Not mistaken for a DID: the scheme is matched exactly, not by prefix.
+        assertFalse(Utils.isUriValue("didsomething://example.org"));
+    }
+
+    @Test
+    void isUriValueRejectsProseThatBeginsWithAnAllowedScheme() {
+        // UriSchemes.isAllowedUriScheme alone accepts these, which would turn a literal into an
+        // IRI at the call sites that decide between the two.
+        assertFalse(Utils.isUriValue("at: home"));
+        assertFalse(Utils.isUriValue("did: the thing"));
+        assertFalse(Utils.isUriValue("http: //example.org"));
+        // Nothing after the scheme is not a URI either.
+        assertFalse(Utils.isUriValue("did:"));
+        assertFalse(Utils.isUriValue("at:"));
+        // A scheme and its slashes with nothing after them, which the "https?://.+" test that
+        // this replaces also rejected. ParsedIRI does call these absolute, so isWellFormedUri
+        // accepts them and isUriValue is what keeps them out.
+        assertFalse(Utils.isUriValue("http://"));
+        assertFalse(Utils.isUriValue("at://"));
+        assertFalse(Utils.isUriValue("ipfs://"));
+    }
+
+    @Test
+    void isWellFormedUriAcceptsAtUris() {
+        // ParsedIRI cannot parse these: it reads "did:plc:..." as an authority with a bad port.
+        assertTrue(Utils.isWellFormedUri(AT_URI));
+        assertTrue(Utils.isWellFormedUri(DID));
+        assertTrue(Utils.isWellFormedUri("ipfs://" + CID));
+    }
+
+    @Test
+    void isWellFormedUriKeepsRejectingMalformedInput() {
+        assertFalse(Utils.isWellFormedUri(null));
+        assertFalse(Utils.isWellFormedUri(""));
+        assertFalse(Utils.isWellFormedUri("not a uri"));
+        assertFalse(Utils.isWellFormedUri("https://example.org/a b"));
+        assertFalse(Utils.isWellFormedUri("relative/path"));
+    }
+
+    @Test
+    void isWellFormedUriUnchangedForHttpInput() {
+        assertTrue(Utils.isWellFormedUri("https://example.org/étude"));
+        assertTrue(Utils.isWellFormedUri("https://example.org/p?q=1#f"));
+        assertTrue(Utils.isWellFormedUri("http://example.org/a%20b"));
+        assertFalse(Utils.isWellFormedUri("https://example.org/a|b"));
+    }
+
+    @Test
+    void shortNameKeepsSchemeAndElidesOpaqueIdentifiers() {
+        assertEquals("did:plc:z72i…tvur", Utils.getShortNameFromURI(DID));
+        assertEquals("ipfs:bafy…bzdi", Utils.getShortNameFromURI("ipfs://" + CID));
+        assertEquals("ipns:example.org", Utils.getShortNameFromURI("ipns://example.org"));
+        // Short enough to show whole.
+        assertEquals("did:web:short.io", Utils.getShortNameFromURI("did:web:short.io"));
+    }
+
+    @Test
+    void shortNameOfAtUriIsTheRecordKey() {
+        assertEquals("at:3k2akmn5c7l2v", Utils.getShortNameFromURI(AT_URI));
+        assertEquals("at:did:plc:z72i…tvur", Utils.getShortNameFromURI("at://" + DID));
+    }
+
+    @Test
+    void shortNameUnchangedForHttpUris() {
+        assertEquals("any12345", Utils.getShortNameFromURI("http://knowledgepixels.com/resource#any12345"));
+        assertEquals("doi:10.1234/x", Utils.getShortNameFromURI("https://doi.org/10.1234/x"));
+    }
+
+    @Test
+    void ipfsUriWithPathStaysHierarchical() {
+        assertEquals("readme.txt", Utils.getShortNameFromURI("ipfs://" + CID + "/docs/readme.txt"));
+    }
+
+    @Test
+    void externalResolverUrlIsBuiltFromTheSchemeTemplate() {
+        assertEquals("https://ipfs.io/ipfs/" + CID, Utils.getExternalResolverUrl("ipfs://" + CID));
+        assertEquals("https://ipfs.io/ipns/example.org", Utils.getExternalResolverUrl("ipns://example.org"));
+        // Colons and slashes are structural here and must survive encoding.
+        assertEquals("https://dev.uniresolver.io/1.0/identifiers/" + DID, Utils.getExternalResolverUrl(DID));
+        assertEquals("https://pdsls.dev/" + AT_URI, Utils.getExternalResolverUrl(AT_URI));
+    }
+
+    @Test
+    void externalResolverUrlNotUsedForHttpOrUnknownSchemes() {
+        assertNull(Utils.getExternalResolverUrl("https://example.org/x"));
+        assertNull(Utils.getExternalResolverUrl("http://example.org/x"));
+        assertNull(Utils.getExternalResolverUrl("ftp://example.org/x"));
+        assertNull(Utils.getExternalResolverUrl("no-scheme"));
+    }
+
+    @Test
+    void externalResolverUrlEscapesCharactersThatWouldRedirectTheResolver() {
+        // A "?" or "#" left as-is would attach a query or fragment to the resolver URL rather
+        // than being part of the identifier handed to it.
+        assertEquals("https://ipfs.io/ipfs/abc%3Fx=1", Utils.getExternalResolverUrl("ipfs://abc?x=1"));
+        assertEquals("https://ipfs.io/ipfs/abc%23frag", Utils.getExternalResolverUrl("ipfs://abc#frag"));
+        // Existing percent-escapes are not doubled.
+        assertEquals("https://ipfs.io/ipfs/a%20b", Utils.getExternalResolverUrl("ipfs://a%20b"));
+    }
+
+    @Test
+    void sanitizerKeepsHrefsForTheNewSchemes() {
+        assertTrue(Utils.sanitizeHtml("<a href=\"ipfs://" + CID + "\">x</a>").contains("ipfs://"));
+        assertTrue(Utils.sanitizeHtml("<a href=\"" + DID + "\">x</a>").contains("did:plc:"));
+        assertTrue(Utils.sanitizeHtml("<a href=\"" + AT_URI + "\">x</a>").contains("at://"));
+        assertTrue(Utils.sanitizeHtml("<a href=\"https://example.org/\">x</a>").contains("https://example.org/"));
+        assertTrue(Utils.sanitizeHtml("<a href=\"mailto:a@b.org\">x</a>").contains("mailto:"));
+    }
+
+    @Test
+    void sanitizerStillDropsDangerousHrefs() {
+        assertFalse(Utils.sanitizeHtml("<a href=\"javascript:alert(1)\">x</a>").contains("javascript:"));
+        assertFalse(Utils.sanitizeHtml("<a href=\"ftp://example.org/\">x</a>").contains("ftp://"));
+    }
+
+    @Test
+    void allowedSchemesLabelIsSortedAndComplete() {
+        assertEquals("at, did, http, https, ipfs, ipns", Utils.getAllowedUriSchemesLabel());
+    }
+
+}


### PR DESCRIPTION
Closes #655. Requires nanopub-java 1.93.0 (Nanopublication/nanopub-java#139), which the pom bump picks up.

Nanodash rejected or silently degraded any URI outside `http(s)`. This adds `ipfs:`, `ipns:`, `did:` and `at:` for **linking to** such resources from nanopublications. Publishing nanopubs over IPFS and DIDs-as-agent-identifiers both stay out of scope.

The allowed set comes from `org.nanopub.UriSchemes.ALLOWED_SCHEMES` rather than being restated here, so Nanodash and `NanopubVerifier` agree on what counts as a URI. Adding a scheme upstream is enough to make it work here.

## What changed

**`Utils.isUriValue`** replaces ~32 ad-hoc `matches("https?://.+")` discriminators across 14 files. It wraps the nanopub-java helper rather than delegating to it: `isAllowedUriScheme` only inspects the scheme, so `"at: home"` passes it — and at the call sites that choose between a literal and an IRI (`TemplateContext:494`) that would silently turn prose into a link. It also requires something after `scheme://`, which the old `.+` did; delegating bare regressed `"http://"` to *valid*.

**`Utils.isWellFormedUri`** fixes AT-URIs. This was not in the issue: `ParsedIRI` cannot parse them at all, so they failed the validators' well-formedness check before any allowlist was consulted.

```
did:plc:z72i7hdyn…                      -> absolute=true  scheme=did
ipfs://bafybeigd                        -> absolute=true  scheme=ipfs
at://did:plc:abc/app.bsky.feed.post/3k  -> URISyntaxException:
                                           absolute or empty path expected U+70 at index 9
```

After `at://`, RDF4J reads `did:plc:abc` as an authority and `plc` as a port. The helper tries `ParsedIRI` first — so http(s) input is judged exactly as before — and falls back to `java.net.URI`, which permits a registry-based authority while still rejecting `at://`, `did:`, embedded spaces and `<>`. Confirmed the two agree on every http(s) case including non-ASCII paths. (`SimpleValueFactory.createIRI` is not usable here: it accepts all of those.)

**Sanitizer.** Both policies take the scheme list. Note the issue pointed at `Utils.java:759`, which is `svgSanitizePolicy`; the `<a href="ipfs://…">` case it described actually goes through `htmlSanitizePolicy` at `:741`.

**Resolver.** Nanodash has no page to show for these, so `NanodashLink.getPageUrl` sends them to an external resolver instead of the Explore page. Configurable via `NANODASH_URI_RESOLVERS` or a `uriResolvers` preference, `scheme=urlTemplate` with `$uri` / `$rest`; the value replaces the defaults rather than extending them, so an empty value disables outbound resolution. Substitution uses a path-safe encoder rather than `Utils.urlEncode` — form encoding would turn `did:plc:x` into `did%3Aplc%3Ax` and break the resolvers, which want the URI verbatim in the path. `?` and `#` are escaped so a crafted URI cannot append a query or fragment to the resolver URL.

**Short labels.** A DID has no slashes and a CID is 59 characters, so neither shortens by splitting on `/` and `#`: `did:plc:z72i…tvur`, `ipfs:bafy…bzdi`, AT-URIs by record key.

## Deliberately untouched

- `AgentChoiceItem:119` — DIDs as agent identifiers are out of scope per the issue.
- `LookupApis:282` — CURIE→identifiers.org expansion, where `at:foo` must stay a CURIE.
- `GuidedChoiceItem:170` *was* in scope but is a `startsWith`, not a `matches`, so the sweep would have missed it; handled explicitly.

## Testing

`UriSchemeSupportTest`, 16 cases. Full suite: **1212 tests, 0 failures**.

End-to-end on a local instance, via the Preview button (nothing published):

| Input | Result |
| --- | --- |
| `did:plc:z72i7hdynmk6r22z27h6tvur` | accepted, signed, labelled `did:plc:z72i…tvur` |
| `ipfs://bafybeigdyrzt5s…55fbzdi` | accepted, signed, labelled `ipfs:bafy…bzdi` |
| `at://did:plc:z72i…/app.bsky.feed.post/3k2akmn5c7l2v` | accepted, signed, labelled `at:3k2akmn5c7l2v` |
| `ftp://example.org/file.txt` | rejected — *IRI scheme not allowed here; use one of: at, did, http, https, ipfs, ipns* |
| `at://` | rejected |
| `some plain name` | rejected — *IRI not well-formed* |

Resolver hrefs came out as `https://ipfs.io/ipfs/bafybei…` and `https://pdsls.dev/at://did:plc:…/app.bsky.feed.post/3k…`, with colons and slashes intact.

A `did:` value no longer trips *"Invalid character in postfix (e.g., colon, hash)"* — the ordering trap the issue describes. That cascade still fires for schemes that are being rejected anyway (`ftp://` shows three stacked errors); narrowing it would change when the postfix error fires for genuine typos, so it is left as is.

## Docs

`docs/uri-schemes.md`, indexed in `docs/README.md`, including the persistence trade-off the issue asked to record user-facing: a CID is immutable but only retrievable while pinned, whereas `did:plc:` is resolvable but mutable. Neither is "a persistent identifier" in the same sense as the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
