### PR TITLE
fix: don't number introduced resources in repeatable groups

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/IriItem.java
@@ -84,9 +84,12 @@ public class IriItem extends AbstractContextComponent {
         labelString = labelString.replaceAll("%I%", "" + rg.getRepeatIndex());
         // Auto-number repeated local resources so each expansion of a repeatable group is
         // distinguishable (e.g. "the context-specific alias 1", "… 2"). Skip when the label
-        // already injects the index via %I%. The index/count are read lazily at render time
-        // (see the link model below) because they change as repetitions are added/removed.
-        final boolean autoNumber = template.isLocalResource(iri) && !hadIndexPlaceholder;
+        // already injects the index via %I%. The index/count and the narrow-scope check are
+        // read lazily at render time (see the link model below): the count changes as
+        // repetitions are added/removed, and the narrow-scope map is only complete once all
+        // statement items have been initialized.
+        final boolean numberable = template.isLocalResource(iri) && !hadIndexPlaceholder;
+        final IRI templateIri = template.getTemplateIri(iri);
 
         String iriString = iri.stringValue();
         String description = "";
@@ -130,11 +133,16 @@ public class IriItem extends AbstractContextComponent {
         // the entity's own page (shown as its title).
         final String linkLabelBase = Utils.truncateLinkLabel(labelString.replaceFirst(" - .*$", ""));
         IModel<String> linkLabelModel;
-        if (autoNumber) {
+        if (numberable) {
             // Append the 1-based repetition index, but only once there is more than one
             // repetition. Read lazily so the number stays correct as groups are added/removed.
+            // Only a resource that is narrowly scoped to this statement gets a fresh instance
+            // per repetition (see StatementItem.RepetitionGroup#transform); one that also
+            // occurs in other statements — like an introduced resource that a repeatable
+            // statement merely refers to — is the same resource in every repetition and
+            // must not be numbered.
             linkLabelModel = (IModel<String>) () -> {
-                if (rg.getRepetitionCount() > 1) {
+                if (rg.getRepetitionCount() > 1 && rg.getContext().hasNarrowScope(templateIri)) {
                     return linkLabelBase + " " + (rg.getRepeatIndex() + 1);
                 }
                 return linkLabelBase;

--- a/src/main/java/com/knowledgepixels/nanodash/template/Template.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/Template.java
@@ -1430,6 +1430,17 @@ public class Template implements Serializable {
         l.add(type);
     }
 
+    /**
+     * Maps a rendered IRI back to its template form, undoing the artifact-code expansion and the
+     * {@code __N} repetition suffix that are added while rendering a repeatable statement group.
+     *
+     * @param iri the rendered IRI.
+     * @return the corresponding template IRI, or the given IRI if no transformation is needed.
+     */
+    public IRI getTemplateIri(IRI iri) {
+        return transform(iri);
+    }
+
     private IRI transform(IRI iri) {
         // A template can leave a statement part undefined (see getStatementErrors()), in which
         // case the null propagates here through getSubject()/getPredicate(). Let the type and

--- a/src/test/java/com/knowledgepixels/nanodash/template/RepeatedLocalResourceLabelTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/RepeatedLocalResourceLabelTest.java
@@ -1,0 +1,175 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.component.StatementItem;
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.util.tester.WicketTester;
+import org.apache.wicket.util.visit.IVisit;
+import org.apache.wicket.util.visit.IVisitor;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the auto-numbering of local resources in repeatable statement groups (issue #651).
+ *
+ * <p>A local resource that is scoped to a single repeatable statement gets a fresh instance per
+ * repetition, so its label is numbered to keep the repetitions distinguishable. A local resource
+ * that also occurs in other statements — typically the introduced resource that the whole
+ * template is about — denotes the same thing in every repetition and must stay unnumbered.</p>
+ */
+public class RepeatedLocalResourceLabelTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String SHARED_NP = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Shar1";
+    private static final String SCOPED_NP = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Scop1";
+
+    private WicketTester tester;
+    private MockedStatic<TemplateData> templateDataMockedStatic;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester(new WicketApplication());
+        templateDataMockedStatic = mockStatic(TemplateData.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        templateDataMockedStatic.close();
+    }
+
+    /**
+     * A template whose introduced resource ("this nanosuggestion") is the subject of a plain
+     * statement and of a repeatable one, as in issue #651.
+     */
+    private TemplateContext sharedResourceContext() throws Exception {
+        IRI st1 = vf.createIRI(SHARED_NP + "/st1");
+        IRI st2 = vf.createIRI(SHARED_NP + "/st2");
+        IRI suggestion = vf.createIRI(SHARED_NP + "/suggestion");
+        IRI space = vf.createIRI(SHARED_NP + "/space");
+        NanopubCreator creator = newTemplate(SHARED_NP, "Shared resource template", st1, st2);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, suggestion);
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(st1, RDF.OBJECT, vf.createIRI(SHARED_NP + "/title"));
+        creator.addAssertionStatement(vf.createIRI(SHARED_NP + "/title"), RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(vf.createIRI(SHARED_NP + "/title"), RDFS.LABEL, vf.createLiteral("the title"));
+        creator.addAssertionStatement(st2, RDF.TYPE, NTEMPLATE.REPEATABLE_STATEMENT);
+        creator.addAssertionStatement(st2, RDF.SUBJECT, suggestion);
+        creator.addAssertionStatement(st2, RDF.PREDICATE, RDFS.SEEALSO);
+        creator.addAssertionStatement(st2, RDF.OBJECT, space);
+        creator.addAssertionStatement(suggestion, RDF.TYPE, NTEMPLATE.LOCAL_RESOURCE);
+        creator.addAssertionStatement(suggestion, RDF.TYPE, NTEMPLATE.INTRODUCED_RESOURCE);
+        creator.addAssertionStatement(suggestion, RDFS.LABEL, vf.createLiteral("this nanosuggestion"));
+        creator.addAssertionStatement(space, RDF.TYPE, NTEMPLATE.URI_PLACEHOLDER);
+        creator.addAssertionStatement(space, RDFS.LABEL, vf.createLiteral("a space"));
+        return contextFor(SHARED_NP, creator);
+    }
+
+    /**
+     * A template whose local resource occurs only within the repeatable statement, so each
+     * repetition mints its own instance.
+     */
+    private TemplateContext scopedResourceContext() throws Exception {
+        IRI st1 = vf.createIRI(SCOPED_NP + "/st1");
+        IRI alias = vf.createIRI(SCOPED_NP + "/alias");
+        IRI name = vf.createIRI(SCOPED_NP + "/name");
+        NanopubCreator creator = newTemplate(SCOPED_NP, "Scoped resource template", st1);
+        creator.addAssertionStatement(st1, RDF.TYPE, NTEMPLATE.REPEATABLE_STATEMENT);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, alias);
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(st1, RDF.OBJECT, name);
+        creator.addAssertionStatement(alias, RDF.TYPE, NTEMPLATE.LOCAL_RESOURCE);
+        creator.addAssertionStatement(alias, RDFS.LABEL, vf.createLiteral("a context-specific alias"));
+        creator.addAssertionStatement(name, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(name, RDFS.LABEL, vf.createLiteral("the name"));
+        return contextFor(SCOPED_NP, creator);
+    }
+
+    private static NanopubCreator newTemplate(String npUri, String label, IRI... statements) throws Exception {
+        NanopubCreator creator = new NanopubCreator(npUri);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral(label));
+        for (IRI st : statements) {
+            creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st);
+        }
+        return creator;
+    }
+
+    private TemplateContext contextFor(String npUri, NanopubCreator creator) throws Exception {
+        Template template = new Template(creator.finalizeNanopub());
+        TemplateData templateDataMock = mock(TemplateData.class);
+        templateDataMockedStatic.when(TemplateData::get).thenReturn(templateDataMock);
+        when(templateDataMock.getTemplate(npUri)).thenReturn(template);
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, npUri, "statement", (String) null);
+        context.initStatements();
+        return context;
+    }
+
+    /**
+     * Renders the given statement item and returns the labels of its resource links, in order.
+     */
+    private List<String> linkLabels(StatementItem si) {
+        tester.startComponentInPage(si);
+        List<String> labels = new ArrayList<>();
+        si.visitChildren(ExternalLink.class, (IVisitor<Component, Void>) (c, visit) -> {
+            Object body = ((ExternalLink) c).getBody().getObject();
+            if (body != null) labels.add(body.toString());
+        });
+        return labels;
+    }
+
+    @Test
+    void sharedIntroducedResourceIsNotNumbered() throws Exception {
+        TemplateContext context = sharedResourceContext();
+        StatementItem repeatable = context.getStatementItems().get(1);
+        repeatable.addRepetitionGroup();
+        assertEquals(2, repeatable.getRepetitionCount());
+
+        List<String> labels = linkLabels(repeatable);
+        assertEquals(List.of("This nanosuggestion", "This nanosuggestion"), subjectLabels(labels, "This nanosuggestion"),
+                "the introduced resource is the same in every repetition and must not be numbered");
+    }
+
+    @Test
+    void resourceScopedToRepeatableStatementIsNumbered() throws Exception {
+        TemplateContext context = scopedResourceContext();
+        StatementItem repeatable = context.getStatementItems().get(0);
+        repeatable.addRepetitionGroup();
+        assertEquals(2, repeatable.getRepetitionCount());
+
+        List<String> labels = linkLabels(repeatable);
+        assertEquals(List.of("A context-specific alias 1", "A context-specific alias 2"),
+                subjectLabels(labels, "A context-specific alias"),
+                "a per-repetition local resource stays distinguishable by its index");
+    }
+
+    private static List<String> subjectLabels(List<String> labels, String prefix) {
+        List<String> matching = new ArrayList<>();
+        for (String l : labels) {
+            if (l.startsWith(prefix)) matching.add(l);
+        }
+        return matching;
+    }
+
+}


### PR DESCRIPTION
Fixes #651.

## Cause

`IriItem` auto-numbers repeated local resources (added in 04c8c7cf so that e.g. "a context-specific alias 1 / 2" stay distinguishable inside a repeatable group). The condition was just `template.isLocalResource(iri)`, which is too broad.

Only resources that are **narrowly scoped** to a single statement actually get a fresh instance per repetition — that is exactly the condition in `StatementItem.RepetitionGroup#transform` (`getRepeatIndex() > 0 && context.hasNarrowScope(iri)`) that appends the `__N` suffix. `this nanosuggestion` is the introduced resource used as subject in many statements, so it is *not* narrow-scoped and denotes the same thing in every repetition. Hence the published nanopubs were fine and only the label was wrong.

## Fix

- `IriItem`: numbering now also requires `hasNarrowScope(templateIri)`, evaluated **inside** the lazy label model rather than in the constructor. That matters: `narrowScopeMap` is filled statement by statement during `TemplateContext.initStatements()`, so at construction time of the first repetition group it is still incomplete and the answer would depend on statement order. At render time it is complete.
- `Template.getTemplateIri(IRI)`: new public accessor exposing the existing private `transform()`, needed to map the rendered IRI (artifact code expanded, `__N` suffixed) back to the template form the narrow-scope map is keyed on.

## Test

New `RepeatedLocalResourceLabelTest` renders a repeatable statement item and reads the actual link labels:

- introduced resource shared across statements → `["This nanosuggestion", "This nanosuggestion"]`
- local resource confined to the repeatable statement → `["A context-specific alias 1", "A context-specific alias 2"]` (regression guard for 04c8c7cf)

The first test fails on the pre-fix code with exactly the symptom from the issue (`This nanosuggestion 1`, `This nanosuggestion 2`). Full suite: 1215 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)