### PR TITLE
fix: read the part view-displays query from its view, not a constant

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -305,18 +305,8 @@ public class QueryApiAccess {
     // ref-scoped query requires root_np; the IRI-keyed variant backs the users' view. See
     // docs/queries/list-view-displays{,-ref}.trig.
 
-    // Part view-displays listing (resource + partid + partclass): the owning resource's displays,
-    // each ?displayed_here-flagged for the specific part. RAMy6Nu supersedes RAPaHJiD (renames
-    // ?shown_here → ?displayed_here). RAFkUf3A (derived from RAMy6Nu) adds a ?position_label column
-    // (first 3 chars of the structural position) so the position cell shows e.g. "1.1" with the full
-    // literal on hover.
-    // RAs9S7c9 (supersedes RA2LG9c5) swaps the authority gate to the npa:hasGoverningSpaceRef gate
-    // keyed on materialized npa:hasRoleType (issue #510), preserving the ?position_label column.
-    // RAKHyaoB (supersedes RAs9S7c9) adds space-governed version resolution (gen:governedBy;
-    // docs/views-and-presets-as-maintained-resources.md): a referenced version declaring a
-    // governing space resolves to the newest member+-signed version of its (kind, space)
-    // pair via a run-once governed sub-select, falling back to the pinned version.
-    public static final String LIST_PART_VIEW_DISPLAYS = "RAKHyaoBCpNdbGsdPLdc8lbxLb4KuLhnmU0V2-NcxHei0/list-part-view-displays";
+    // The part view-displays listing is not referenced here either: AboutPartPanel takes it
+    // from the part view nanopub's gen:hasViewQuery and passes resource + partid + partclass.
 
     // Ref-scoped preset-assignment listing (root_np): reads the server-materialised
     // npa:PresetAssignment rows scoped by npa:forSpaceRef from the validated current space-state

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutPartPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutPartPanel.java
@@ -1,6 +1,5 @@
 package com.knowledgepixels.nanodash.component;
 
-import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.knowledgepixels.nanodash.Utils;
@@ -100,7 +99,11 @@ public class AboutPartPanel extends Panel {
         for (IRI partClass : partClasses) {
             vdParams.put("partclass", partClass.stringValue());
         }
-        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(QueryApiAccess.LIST_PART_VIEW_DISPLAYS, vdParams), new ViewDisplay(vdView)).resourceWithProfile(context).id(context.getId()).contextId(context.getId()).build());
+        // Take the query from the view itself (as the space/user/maintained-resource panels do)
+        // rather than from a constant here: a constant silently drifts from the view's
+        // gen:hasViewQuery, and the view's per-row actions map columns the view's own query
+        // version provides.
+        add(QueryResultTableBuilder.create("viewdisplays", new QueryRef(vdView.getQuery().getQueryId(), vdParams), new ViewDisplay(vdView)).resourceWithProfile(context).id(context.getId()).contextId(context.getId()).build());
     }
 
 }


### PR DESCRIPTION
Part of #664.

`AboutPartPanel` ran `QueryApiAccess.LIST_PART_VIEW_DISPLAYS` (`RAKHyaoB…`) while the part view nanopub declared `RA74rCoU…` — two separate live heads, the constant having been left behind by the 2026-08-20 federation rebase. The space, user and maintained-resource panels all take the query off the view; the part panel now does the same, and the drifted constant is removed.

### Why it matters beyond tidiness

The drift is silent, and it gets worse as views gain per-row actions. An action maps query *result columns* into a pre-filled publish form, so a panel running an older query version than its view declares renders **no button at all** — no error, no log line. That is exactly what would have happened to the new `♻️ override...` action of #664, whose mapping columns only exist in the version the view points at.

### Context: the nanopub side of #664

Already published live, no code change needed for them (the view constants are chain anchors, `View.get` follows supersedes):

| | query | view |
|---|---|---|
| space | `RAGnECNo…/list-view-displays-space` | `RA3G86T6…/view-displays-view` |
| user | `RAzaL0ej…/list-view-displays` | `RAtVGHYy…/view-displays-view` |
| maintained resource | `RAKFhW1T…/list-view-displays` | `RAM3xp8U…/view-displays-view` |
| part | `RAsdgRZ1…/list-part-view-displays` | `RA7eYpQF…/part-view-displays-view` |

Each view-displays table now offers exactly one `♻️ override...` per row, selected in SPARQL rather than in code: a standalone display reopens its own nanopub in override fill mode, while a preset-borne row (whose source nanopub is the preset assignment, not a display) instead opens the add-view-display form pre-filled with its view, publishing a standalone display that wins latest-wins over the preset-supplied one. The two mapping columns are exact complements, so the shared label can never double up.

Presets and roles were deliberately left out of #664: a preset assignment is a `(preset, resource)` pair and a role attachment is a single `gen:hasRole` triple, so deactivate/detach already covers them. (Both would also have needed more than a view change to work at all — `Preset.get` resolves latest only through the supersedes chain, and role IRIs are `npx:embeds`-ed so they are re-minted on every new version.)

### Testing

- Compiles.
- All four published queries verified against the live API: results byte-identical to the previous heads on every pre-existing column, and zero rows with both or neither override column set.
- No measurable performance change (interleaved timings, deltas within run-to-run noise): space 2.01s → 2.02s, user 2.44s → 2.36s, maintained resource 0.57s → 0.60s, part 0.66s → 0.66s.
- Not yet exercised: the override publish form round-trip itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqfrG3VXH5tzWXPvYJzXML