### PR TITLE
feat(template): support xsd:gYear and its relatives as placeholder types

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralGregorianItem.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralGregorianItem.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:wicket="http://wicket.apache.org">
+
+<head>
+  <link rel="stylesheet" href="../../../../../webapp/style.css?for-local-testing-only" type="text/css" media="screen"
+        title="Stylesheet"/>
+</head>
+<body>
+
+<wicket:panel>
+  <span class="nowrap">
+    <input type="text" class="nanopub-textfield gregorian-year" size="6" wicket:id="year"/>
+    <select wicket:id="month" class="gregorian-part"></select>
+    <select wicket:id="day" class="gregorian-part"></select>
+  </span>
+  <span wicket:id="datatype" class="litdatatype">datatype</span>
+</wicket:panel>
+
+</body>
+
+</html>

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralGregorianItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralGregorianItem.java
@@ -266,6 +266,7 @@ public class LiteralGregorianItem extends AbstractContextComponent {
     private final String regex;
     private final GregorianModel model;
     private final List<FormComponent<String>> fields = new ArrayList<>();
+    private final FormComponent<String> yearField, monthField, dayField;
 
     /**
      * Constructs a LiteralGregorianItem with the specified ID, IRI, optional flag, and template
@@ -299,7 +300,18 @@ public class LiteralGregorianItem extends AbstractContextComponent {
             }
         }
 
-        TextField<String> yearField = new TextField<>("year", new PartModel(model, PartModel.Part.YEAR));
+        // Each part of a two-part value requires the other, but only in a request that carries
+        // that other one: its raw input decides, not its stored value. An Ajax update of one
+        // part alone is then stored rather than rejected for the absence of a part the user has
+        // not reached yet -- being rejected is what used to leave both parts unstored, so the
+        // value could never be completed -- while a submit carries both and reports a half one.
+        // The same idiom keeps a language-tagged literal from being published untagged.
+        yearField = new TextField<>("year", new PartModel(model, PartModel.Part.YEAR)) {
+            @Override
+            public boolean isRequired() {
+                return super.isRequired() || (type.hasMonth() && hasInput(monthField));
+            }
+        };
         // A number input gives the spinner and the numeric keypad; the pattern is what actually
         // decides, since the input is a text field again in browsers that ignore the type.
         yearField.add(new AttributeModifier("type", "number"));
@@ -309,43 +321,56 @@ public class LiteralGregorianItem extends AbstractContextComponent {
                 v.error(new ValidationError("A year is four or more digits, e.g. 2026"));
             }
         });
-        DropDownChoice<String> monthField = new DropDownChoice<>("month",
-                new PartModel(model, PartModel.Part.MONTH), monthChoices(), monthRenderer());
-        DropDownChoice<String> dayField = new DropDownChoice<>("day",
-                new PartModel(model, PartModel.Part.DAY), dayChoices());
+        monthField = new DropDownChoice<>("month",
+                new PartModel(model, PartModel.Part.MONTH), monthChoices(), monthRenderer()) {
+            @Override
+            public boolean isRequired() {
+                return super.isRequired()
+                        || (type.hasYear() && hasInput(yearField))
+                        || (type.hasDay() && hasInput(dayField));
+            }
+        };
+        dayField = new DropDownChoice<>("day",
+                new PartModel(model, PartModel.Part.DAY), dayChoices(), dayRenderer()) {
+            @Override
+            public boolean isRequired() {
+                return super.isRequired() || (type.hasMonth() && hasInput(monthField));
+            }
+        };
+        String label = template.getLabel(iri);
+        String of = (label == null) ? "" : " of '" + label + "'";
+        yearField.setLabel(Model.of("year" + of));
+        monthField.setLabel(Model.of("month" + of));
+        dayField.setLabel(Model.of("day" + of));
 
         addField(yearField, type.hasYear(), optional, template);
         addField(monthField, type.hasMonth(), optional, template);
         addField(dayField, type.hasDay(), optional, template);
 
-        if (regex != null && !fields.isEmpty()) {
-            // The template's own pattern applies to the assembled value, which is what ends up
-            // in the nanopublication, so it is checked once rather than per part.
-            fields.getFirst().add((IValidator<String>) v -> {
-                String assembled = model.getObject();
-                if (!assembled.isEmpty() && !assembled.matches(regex)) {
-                    v.error(new ValidationError("Value '" + assembled + "' doesn't match the pattern '" + regex + "'"));
+        // These judge the whole value rather than one part of it, so they go on every part: a
+        // pattern that only the month breaks has to be applied when the month is what changed.
+        // They read the value as the controls hold it now -- reading the stored value would
+        // judge the previous entry, so the first value rejected would be measured against the
+        // pattern from then on and no correction could ever pass.
+        if (regex != null) {
+            addValueCheck(v -> {
+                String candidate = candidateValue();
+                if (!candidate.isEmpty() && !candidate.matches(regex)) {
+                    v.error(new ValidationError("Value '" + candidate + "' doesn't match the pattern '" + regex + "'"));
                 }
             });
         }
-
-        if (type == GregorianType.G_YEAR_MONTH) {
-            addPartialityCheck(yearField, monthField, "a month");
-            addPartialityCheck(monthField, yearField, "a year");
-        }
         if (type == GregorianType.G_MONTH_DAY) {
-            addPartialityCheck(monthField, dayField, "a day");
-            addPartialityCheck(dayField, monthField, "a month");
             // February has 29 days at most, April 31 never: a day the month cannot have is not
             // a value of this datatype, and the dropdowns alone cannot rule it out.
-            dayField.add((IValidator<String>) v -> {
-                String month = monthField.getValue();
-                if (month == null || month.isEmpty()) return;
+            addValueCheck(v -> {
+                String month = partInput(monthField), day = partInput(dayField);
+                if (month.isEmpty() || day.isEmpty()) return;
                 try {
-                    MonthDay.of(Integer.parseInt(month), Integer.parseInt(v.getValue()));
+                    MonthDay.of(Integer.parseInt(month), Integer.parseInt(day));
                 } catch (DateTimeException ex) {
                     v.error(new ValidationError(Month.of(Integer.parseInt(month))
-                            .getDisplayName(TextStyle.FULL, Locale.ENGLISH) + " has no day " + Integer.parseInt(v.getValue())));
+                            .getDisplayName(TextStyle.FULL, Locale.ENGLISH) + " has no day " + Integer.parseInt(day)));
                 }
             });
         }
@@ -396,17 +421,47 @@ public class LiteralGregorianItem extends AbstractContextComponent {
     }
 
     /**
-     * Reports a value that names one part of a two-part datatype and not the other. Wicket
-     * skips validators on empty input, so the check has to sit on the part that was filled in
-     * and look at the one that was not.
+     * What a control holds right now: the input being validated where there is one, and the
+     * stored part otherwise. A value assembled from these reflects the entry being made rather
+     * than the one last accepted.
      */
-    private static void addPartialityCheck(FormComponent<String> filled, FormComponent<String> missing, String what) {
-        filled.add((IValidator<String>) v -> {
-            String other = missing.getValue();
-            if (other == null || other.isEmpty()) {
-                v.error(new ValidationError("Please also select " + what));
-            }
-        });
+    private static String partInput(FormComponent<String> field) {
+        if (!field.isVisible()) return "";
+        String value = field.getValue();
+        return (value == null) ? "" : value.trim();
+    }
+
+    /**
+     * Adds a check of the value as a whole to every part, so that it runs whichever part the
+     * user changed. Only the first part to report keeps its message: on a submit, where every
+     * part is validated, the same complaint would otherwise be made once per part.
+     */
+    private void addValueCheck(IValidator<String> check) {
+        for (FormComponent<String> field : fields) {
+            field.add((IValidator<String>) v -> {
+                if (fields.stream().anyMatch(FormComponent::hasErrorMessage)) return;
+                check.validate(v);
+            });
+        }
+    }
+
+    /**
+     * The value the controls hold right now, assembled as the datatype prescribes, or "" while
+     * a part is missing.
+     */
+    private String candidateValue() {
+        return type.assemble(partInput(yearField), partInput(monthField), partInput(dayField), model.zone);
+    }
+
+    /**
+     * Whether a part was submitted with something in it in this request. Reading the raw input
+     * rather than the value is what tells a submit, which carries every field, apart from an
+     * Ajax update of one field alone.
+     */
+    private static boolean hasInput(FormComponent<String> field) {
+        if (field == null) return false;
+        String raw = field.getInput();
+        return raw != null && !raw.isBlank();
     }
 
     private static List<String> monthChoices() {
@@ -422,16 +477,29 @@ public class LiteralGregorianItem extends AbstractContextComponent {
     }
 
     private static IChoiceRenderer<String> monthRenderer() {
+        return partRenderer(month -> Month.of(Integer.parseInt(month)).getDisplayName(TextStyle.FULL, Locale.ENGLISH));
+    }
+
+    private static IChoiceRenderer<String> dayRenderer() {
+        return partRenderer(day -> String.valueOf(Integer.parseInt(day)));
+    }
+
+    /**
+     * A renderer that submits the part itself rather than its position in the list. Wicket's
+     * default submits the index, which every reader of the field would then have to translate
+     * back -- and a reader that forgets to would see the day before the one that was picked.
+     */
+    private static IChoiceRenderer<String> partRenderer(SerializableFunction<String, String> label) {
         return new IChoiceRenderer<>() {
 
             @Override
-            public Object getDisplayValue(String month) {
-                return Month.of(Integer.parseInt(month)).getDisplayName(TextStyle.FULL, Locale.ENGLISH);
+            public Object getDisplayValue(String part) {
+                return label.apply(part);
             }
 
             @Override
-            public String getIdValue(String month, int index) {
-                return month;
+            public String getIdValue(String part, int index) {
+                return part;
             }
 
             @Override
@@ -440,6 +508,13 @@ public class LiteralGregorianItem extends AbstractContextComponent {
             }
 
         };
+    }
+
+    /**
+     * A {@link java.util.function.Function} that survives page serialization, as everything a
+     * Wicket component holds on to has to.
+     */
+    private interface SerializableFunction<T, R> extends java.util.function.Function<T, R>, java.io.Serializable {
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralGregorianItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralGregorianItem.java
@@ -8,6 +8,9 @@ import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
+import org.apache.wicket.behavior.Behavior;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.FormComponent;
@@ -27,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.time.DateTimeException;
 import java.time.Month;
 import java.time.MonthDay;
+import java.time.Year;
 import java.time.format.TextStyle;
 import java.util.ArrayList;
 import java.util.List;
@@ -316,6 +320,8 @@ public class LiteralGregorianItem extends AbstractContextComponent {
         // decides, since the input is a text field again in browsers that ignore the type.
         yearField.add(new AttributeModifier("type", "number"));
         yearField.add(new AttributeModifier("placeholder", "YYYY"));
+        yearField.setOutputMarkupId(true);
+        yearField.add(new CurrentYearOnFirstStep());
         yearField.add((IValidator<String>) v -> {
             if (!v.getValue().matches("-?\\d{4,}")) {
                 v.error(new ValidationError("A year is four or more digits, e.g. 2026"));
@@ -429,6 +435,66 @@ public class LiteralGregorianItem extends AbstractContextComponent {
         if (!field.isVisible()) return "";
         String value = field.getValue();
         return (value == null) ? "" : value.trim();
+    }
+
+    /**
+     * Starts an empty year field at the current year when its spinner is first used. Stepping an
+     * empty number input lands on 1 or -1, which is a year nobody means and four keystrokes away
+     * from any they do; the year they are most likely to want is this one. Once the field holds
+     * something -- including the year just put there -- the browser's own stepping takes over,
+     * so the arrows go on counting up and down from wherever the value stands.
+     */
+    static class CurrentYearOnFirstStep extends Behavior {
+
+        private static final String SCRIPT = """
+                (function() {
+                  var input = document.getElementById('%s');
+                  if (!input || input.dataset.gregorianYearStep) return;
+                  input.dataset.gregorianYearStep = '1';
+                  var currentYear = '%s';
+                  var previous = input.value;
+                  function startAtCurrentYear() {
+                    input.value = currentYear;
+                    previous = currentYear;
+                    input.dispatchEvent(new Event('input', { bubbles: true }));
+                    input.dispatchEvent(new Event('change', { bubbles: true }));
+                  }
+                  input.addEventListener('keydown', function(e) {
+                    if (previous === '' && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
+                      e.preventDefault();
+                      startAtCurrentYear();
+                    }
+                  });
+                  input.addEventListener('input', function(e) {
+                    // Typing carries an inputType; using the spinner does not, which is what
+                    // tells a click on the arrows apart from a 1 the user meant to type.
+                    if (previous === '' && !e.inputType) {
+                      startAtCurrentYear();
+                    } else {
+                      previous = input.value;
+                    }
+                  });
+                  input.addEventListener('blur', function() { previous = input.value; });
+                })();
+                """;
+
+        /**
+         * The script for one field, so that what it says can be asserted on without a browser.
+         *
+         * @param markupId the field's markup id
+         * @param year     the year an empty field starts at
+         * @return the script
+         */
+        static String script(String markupId, Year year) {
+            return SCRIPT.formatted(markupId, year);
+        }
+
+        @Override
+        public void renderHead(Component component, IHeaderResponse response) {
+            super.renderHead(component, response);
+            response.render(OnDomReadyHeaderItem.forScript(script(component.getMarkupId(), Year.now())));
+        }
+
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralGregorianItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralGregorianItem.java
@@ -1,0 +1,509 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.template.Template;
+import com.knowledgepixels.nanodash.template.TemplateContext;
+import com.knowledgepixels.nanodash.template.UnificationException;
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.DropDownChoice;
+import org.apache.wicket.markup.html.form.FormComponent;
+import org.apache.wicket.markup.html.form.IChoiceRenderer;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.validation.IValidator;
+import org.apache.wicket.validation.ValidationError;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.DateTimeException;
+import java.time.Month;
+import java.time.MonthDay;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A component for literal placeholders typed with one of the XSD Gregorian datatypes:
+ * {@code xsd:gYear}, {@code xsd:gYearMonth}, {@code xsd:gMonth}, {@code xsd:gMonthDay} and
+ * {@code xsd:gDay}. They name a point on the calendar that is coarser than a date, which is
+ * why a date picker cannot express them: "2026" and "--05-17" are values a full date has no
+ * way to leave unsaid.
+ * <p>
+ * Each part is entered through a control that can only produce a value the datatype allows —
+ * a number field for the year, dropdowns for month and day — and the parts are assembled into
+ * the lexical form the datatype prescribes.
+ */
+public class LiteralGregorianItem extends AbstractContextComponent {
+
+    private static final long serialVersionUID = 1L;
+
+    private final static Logger logger = LoggerFactory.getLogger(LiteralGregorianItem.class);
+
+    /**
+     * A timezone may be appended to any of these values. Nothing here offers to add one, but a
+     * value being filled in from an existing nanopublication may carry one, and dropping it
+     * would silently change what the nanopub says.
+     */
+    private static final String ZONE = "(Z|[+-]\\d{2}:\\d{2})?";
+
+    /**
+     * The XSD Gregorian datatypes, with the lexical form each one prescribes.
+     */
+    public enum GregorianType {
+
+        G_YEAR(XSD.GYEAR, true, false, false, "(-?\\d{4,})" + ZONE),
+        G_YEAR_MONTH(XSD.GYEARMONTH, true, true, false, "(-?\\d{4,})-(\\d{2})" + ZONE),
+        G_MONTH(XSD.GMONTH, false, true, false, "--(\\d{2})" + ZONE),
+        G_MONTH_DAY(XSD.GMONTHDAY, false, true, true, "--(\\d{2})-(\\d{2})" + ZONE),
+        G_DAY(XSD.GDAY, false, false, true, "---(\\d{2})" + ZONE);
+
+        private final IRI datatype;
+        private final boolean hasYear, hasMonth, hasDay;
+        private final Pattern pattern;
+
+        GregorianType(IRI datatype, boolean hasYear, boolean hasMonth, boolean hasDay, String regex) {
+            this.datatype = datatype;
+            this.hasYear = hasYear;
+            this.hasMonth = hasMonth;
+            this.hasDay = hasDay;
+            this.pattern = Pattern.compile("^" + regex + "$");
+        }
+
+        /**
+         * The type for a datatype IRI, or null if the datatype is not a Gregorian one.
+         *
+         * @param datatype the datatype IRI, which may be null
+         * @return the matching type, or null
+         */
+        public static GregorianType of(IRI datatype) {
+            if (datatype == null) return null;
+            for (GregorianType t : values()) {
+                if (t.datatype.equals(datatype)) return t;
+            }
+            return null;
+        }
+
+        /**
+         * @return the datatype IRI this type stands for
+         */
+        public IRI getDatatype() {
+            return datatype;
+        }
+
+        /**
+         * @return whether values of this type name a year
+         */
+        public boolean hasYear() {
+            return hasYear;
+        }
+
+        /**
+         * @return whether values of this type name a month
+         */
+        public boolean hasMonth() {
+            return hasMonth;
+        }
+
+        /**
+         * @return whether values of this type name a day
+         */
+        public boolean hasDay() {
+            return hasDay;
+        }
+
+        /**
+         * Assembles a lexical value from its parts, or the empty string if a part this type
+         * needs is missing. Half-entered values are never assembled into something the
+         * datatype would reject; the form reports them instead (see the partiality check in
+         * the constructor).
+         *
+         * @param year  the year, e.g. "2026" (empty if not entered)
+         * @param month the month as two digits, e.g. "05" (empty if not entered)
+         * @param day   the day as two digits, e.g. "17" (empty if not entered)
+         * @param zone  a timezone suffix to append, e.g. "Z" (usually empty)
+         * @return the lexical value, or ""
+         */
+        public String assemble(String year, String month, String day, String zone) {
+            if (hasYear && year.isEmpty()) return "";
+            if (hasMonth && month.isEmpty()) return "";
+            if (hasDay && day.isEmpty()) return "";
+            String suffix = (zone == null) ? "" : zone;
+            return switch (this) {
+                case G_YEAR -> year + suffix;
+                case G_YEAR_MONTH -> year + "-" + month + suffix;
+                case G_MONTH -> "--" + month + suffix;
+                case G_MONTH_DAY -> "--" + month + "-" + day + suffix;
+                case G_DAY -> "---" + day + suffix;
+            };
+        }
+
+        /**
+         * Splits a lexical value into its parts.
+         *
+         * @param value the lexical value
+         * @return the parts, or null if the value is not a valid value of this type
+         */
+        public String[] split(String value) {
+            if (value == null) return null;
+            Matcher m = pattern.matcher(value.trim());
+            if (!m.matches()) return null;
+            String year = "", month = "", day = "";
+            int group = 1;
+            if (hasYear) year = m.group(group++);
+            if (hasMonth) month = m.group(group++);
+            if (hasDay) day = m.group(group++);
+            String zone = m.group(m.groupCount());
+            return new String[]{year, month, day, zone == null ? "" : zone};
+        }
+
+        /**
+         * @param value the lexical value to check
+         * @return whether the value is a valid value of this type
+         */
+        public boolean isValid(String value) {
+            return split(value) != null;
+        }
+
+    }
+
+    /**
+     * Whether this component handles the given datatype.
+     *
+     * @param datatype the datatype IRI, which may be null
+     * @return true if the datatype is one of the XSD Gregorian types
+     */
+    public static boolean supports(IRI datatype) {
+        return GregorianType.of(datatype) != null;
+    }
+
+    /**
+     * The value as its parts, presented to the rest of the form as the single lexical string
+     * the placeholder's datatype prescribes. Keeping the parts rather than the string is what
+     * lets a half-entered value stay on screen: "May" survives the moment before a day is
+     * picked, while {@link #getObject()} reports nothing until the value is complete.
+     */
+    private static class GregorianModel implements IModel<String> {
+
+        private final GregorianType type;
+        private String year = "", month = "", day = "", zone = "";
+
+        GregorianModel(GregorianType type) {
+            this.type = type;
+        }
+
+        @Override
+        public String getObject() {
+            return type.assemble(year, month, day, zone);
+        }
+
+        @Override
+        public void setObject(String value) {
+            String[] parts = (value == null) ? null : type.split(value);
+            if (parts == null) {
+                year = month = day = zone = "";
+            } else {
+                year = parts[0];
+                month = parts[1];
+                day = parts[2];
+                zone = parts[3];
+            }
+        }
+
+    }
+
+    /**
+     * A view of one part of the value, so that each control edits its own part while they all
+     * share the one model the rest of the form sees.
+     */
+    private static class PartModel implements IModel<String> {
+
+        private enum Part {YEAR, MONTH, DAY}
+
+        private final GregorianModel value;
+        private final Part part;
+
+        PartModel(GregorianModel value, Part part) {
+            this.value = value;
+            this.part = part;
+        }
+
+        @Override
+        public String getObject() {
+            return switch (part) {
+                case YEAR -> value.year;
+                case MONTH -> value.month;
+                case DAY -> value.day;
+            };
+        }
+
+        @Override
+        public void setObject(String object) {
+            String v = (object == null) ? "" : object.trim();
+            switch (part) {
+                case YEAR -> value.year = v;
+                case MONTH -> value.month = v;
+                case DAY -> value.day = v;
+            }
+        }
+
+    }
+
+    private final GregorianType type;
+    private final IRI iri;
+    private final String regex;
+    private final GregorianModel model;
+    private final List<FormComponent<String>> fields = new ArrayList<>();
+
+    /**
+     * Constructs a LiteralGregorianItem with the specified ID, IRI, optional flag, and template
+     * context.
+     *
+     * @param id       the component ID
+     * @param iri      the IRI of the placeholder
+     * @param optional whether this field is optional
+     * @param context  the template context containing models and parameters
+     */
+    public LiteralGregorianItem(String id, final IRI iri, boolean optional, TemplateContext context) {
+        super(id, context);
+        final Template template = context.getTemplate();
+        this.iri = iri;
+        this.type = GregorianType.of(template.getDatatype(iri));
+        this.regex = template.getRegex(iri);
+
+        Map<IRI, IModel<?>> componentModels = context.getComponentModels();
+        // A repeated statement group hands the same placeholder to a second item, which has to
+        // go on editing the value the first one holds.
+        if (componentModels.get(iri) instanceof GregorianModel existing && existing.type == type) {
+            model = existing;
+        } else {
+            model = new GregorianModel(type);
+            Object previous = (componentModels.get(iri) == null) ? null : componentModels.get(iri).getObject();
+            if (previous != null) model.setObject(previous.toString());
+            componentModels.put(iri, model);
+            String postfix = Utils.getUriPostfix(iri);
+            if (previous == null && context.hasParam(postfix)) {
+                model.setObject(context.getParam(postfix));
+            }
+        }
+
+        TextField<String> yearField = new TextField<>("year", new PartModel(model, PartModel.Part.YEAR));
+        // A number input gives the spinner and the numeric keypad; the pattern is what actually
+        // decides, since the input is a text field again in browsers that ignore the type.
+        yearField.add(new AttributeModifier("type", "number"));
+        yearField.add(new AttributeModifier("placeholder", "YYYY"));
+        yearField.add((IValidator<String>) v -> {
+            if (!v.getValue().matches("-?\\d{4,}")) {
+                v.error(new ValidationError("A year is four or more digits, e.g. 2026"));
+            }
+        });
+        DropDownChoice<String> monthField = new DropDownChoice<>("month",
+                new PartModel(model, PartModel.Part.MONTH), monthChoices(), monthRenderer());
+        DropDownChoice<String> dayField = new DropDownChoice<>("day",
+                new PartModel(model, PartModel.Part.DAY), dayChoices());
+
+        addField(yearField, type.hasYear(), optional, template);
+        addField(monthField, type.hasMonth(), optional, template);
+        addField(dayField, type.hasDay(), optional, template);
+
+        if (regex != null && !fields.isEmpty()) {
+            // The template's own pattern applies to the assembled value, which is what ends up
+            // in the nanopublication, so it is checked once rather than per part.
+            fields.getFirst().add((IValidator<String>) v -> {
+                String assembled = model.getObject();
+                if (!assembled.isEmpty() && !assembled.matches(regex)) {
+                    v.error(new ValidationError("Value '" + assembled + "' doesn't match the pattern '" + regex + "'"));
+                }
+            });
+        }
+
+        if (type == GregorianType.G_YEAR_MONTH) {
+            addPartialityCheck(yearField, monthField, "a month");
+            addPartialityCheck(monthField, yearField, "a year");
+        }
+        if (type == GregorianType.G_MONTH_DAY) {
+            addPartialityCheck(monthField, dayField, "a day");
+            addPartialityCheck(dayField, monthField, "a month");
+            // February has 29 days at most, April 31 never: a day the month cannot have is not
+            // a value of this datatype, and the dropdowns alone cannot rule it out.
+            dayField.add((IValidator<String>) v -> {
+                String month = monthField.getValue();
+                if (month == null || month.isEmpty()) return;
+                try {
+                    MonthDay.of(Integer.parseInt(month), Integer.parseInt(v.getValue()));
+                } catch (DateTimeException ex) {
+                    v.error(new ValidationError(Month.of(Integer.parseInt(month))
+                            .getDisplayName(TextStyle.FULL, Locale.ENGLISH) + " has no day " + Integer.parseInt(v.getValue())));
+                }
+            });
+        }
+
+        Label datatypeComp = new Label("datatype",
+                Model.of("(" + type.getDatatype().stringValue().replace(XSD.NAMESPACE, "xsd:") + ")"));
+        add(datatypeComp);
+    }
+
+    /**
+     * Adds one part control to the form, or a hidden placeholder for the parts this datatype
+     * does not name.
+     */
+    private void addField(FormComponent<String> field, boolean used, boolean optional, Template template) {
+        add(field);
+        if (!used) {
+            field.setVisible(false);
+            return;
+        }
+        if (!optional) field.setRequired(true);
+        if (template.getLabel(iri) != null) {
+            field.add(new AttributeModifier("title", template.getLabel(iri)));
+        }
+        field.add(new OnChangeAjaxBehavior() {
+            @Override
+            protected void onUpdate(AjaxRequestTarget target) {
+                for (Component c : context.getComponents()) {
+                    if (c == field) continue;
+                    if (c.getDefaultModel() == field.getModel()) {
+                        c.modelChanged();
+                        target.add(c);
+                    }
+                }
+            }
+        });
+        field.add(new ValueItem.KeepValueAfterRefreshBehavior());
+        field.add(new InvalidityHighlighting());
+        context.getComponents().add(field);
+        fields.add(field);
+    }
+
+    /**
+     * Reports a value that names one part of a two-part datatype and not the other. Wicket
+     * skips validators on empty input, so the check has to sit on the part that was filled in
+     * and look at the one that was not.
+     */
+    private static void addPartialityCheck(FormComponent<String> filled, FormComponent<String> missing, String what) {
+        filled.add((IValidator<String>) v -> {
+            String other = missing.getValue();
+            if (other == null || other.isEmpty()) {
+                v.error(new ValidationError("Please also select " + what));
+            }
+        });
+    }
+
+    private static List<String> monthChoices() {
+        List<String> months = new ArrayList<>();
+        for (int m = 1; m <= 12; m++) months.add(String.format("%02d", m));
+        return months;
+    }
+
+    private static List<String> dayChoices() {
+        List<String> days = new ArrayList<>();
+        for (int d = 1; d <= 31; d++) days.add(String.format("%02d", d));
+        return days;
+    }
+
+    private static IChoiceRenderer<String> monthRenderer() {
+        return new IChoiceRenderer<>() {
+
+            @Override
+            public Object getDisplayValue(String month) {
+                return Month.of(Integer.parseInt(month)).getDisplayName(TextStyle.FULL, Locale.ENGLISH);
+            }
+
+            @Override
+            public String getIdValue(String month, int index) {
+                return month;
+            }
+
+            @Override
+            public String getObject(String id, IModel<? extends List<? extends String>> choices) {
+                return id;
+            }
+
+        };
+    }
+
+    /**
+     * The value as the rest of the form sees it: the assembled lexical form, or "" while the
+     * value is incomplete.
+     *
+     * @return the value model
+     */
+    IModel<String> getValueModel() {
+        return model;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeFromContext() {
+        context.getComponents().removeAll(fields);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isUnifiableWith(Value v) {
+        if (v == null) return true;
+        if (!(v instanceof Literal vL)) return false;
+        if (!type.getDatatype().equals(vL.getDatatype())) return false;
+        if (!type.isValid(vL.stringValue())) return false;
+        if (regex != null && !vL.stringValue().matches(regex)) return false;
+        String current = model.getObject();
+        return current.isEmpty() || current.equals(vL.stringValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void unifyWith(Value v) throws UnificationException {
+        if (v == null) return;
+        if (!isUnifiableWith(v)) throw new UnificationException(v.stringValue());
+        model.setObject(v.stringValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void fillFinished() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void finalizeValues() {
+        Value defaultValue = context.getTemplate().getDefault(iri);
+        if (isUnifiableWith(defaultValue)) {
+            try {
+                unifyWith(defaultValue);
+            } catch (UnificationException ex) {
+                logger.error("Could not unify with default value.", ex);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "[Literal " + type.getDatatype().stringValue().replace(XSD.NAMESPACE, "xsd:") + " item]";
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralGregorianItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralGregorianItem.java
@@ -369,19 +369,27 @@ public class LiteralGregorianItem extends AbstractContextComponent {
         if (template.getLabel(iri) != null) {
             field.add(new AttributeModifier("title", template.getLabel(iri)));
         }
+        // Exactly one updating behavior per field. A second one -- KeepValueAfterRefreshBehavior,
+        // which every other item adds on top of its own -- runs updateModel() again in the same
+        // request, by which point the input it reads is empty, and writes that emptiness over
+        // the value this one just stored. A field whose entry had been rejected then ignored
+        // every correction (issue #670). The Ajax round-trip this behavior already makes is
+        // what keeps the value across a refresh, which is all the other one was there for.
         field.add(new OnChangeAjaxBehavior() {
             @Override
             protected void onUpdate(AjaxRequestTarget target) {
                 for (Component c : context.getComponents()) {
                     if (c == field) continue;
-                    if (c.getDefaultModel() == field.getModel()) {
+                    // The parts of one value have models of their own, so components sharing
+                    // this placeholder are found by the value behind them, not by the model in
+                    // front of it.
+                    if (c.getDefaultModel() instanceof PartModel other && other.value == model) {
                         c.modelChanged();
                         target.add(c);
                     }
                 }
             }
         });
-        field.add(new ValueItem.KeepValueAfterRefreshBehavior());
         field.add(new InvalidityHighlighting());
         context.getComponents().add(field);
         fields.add(field);

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralGregorianItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralGregorianItem.java
@@ -335,12 +335,24 @@ public class LiteralGregorianItem extends AbstractContextComponent {
                         || (type.hasYear() && hasInput(yearField))
                         || (type.hasDay() && hasInput(dayField));
             }
+
+            // The option standing in for no selection yet, in place of Wicket's "Choose One":
+            // two of these can sit side by side, and each should say which part it is waiting for.
+            @Override
+            protected String getNullKeyDisplayValue() {
+                return "choose month";
+            }
         };
         dayField = new DropDownChoice<>("day",
                 new PartModel(model, PartModel.Part.DAY), dayChoices(), dayRenderer()) {
             @Override
             public boolean isRequired() {
                 return super.isRequired() || (type.hasMonth() && hasInput(monthField));
+            }
+
+            @Override
+            protected String getNullKeyDisplayValue() {
+                return "choose day";
             }
         };
         String label = template.getLabel(iri);

--- a/src/main/java/com/knowledgepixels/nanodash/component/ValueItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ValueItem.java
@@ -68,11 +68,14 @@ public class ValueItem extends AbstractContextComponent {
             } else if (template.isLongLiteralPlaceholder(iri)) {
                 component = new LiteralTextareaItem("value", iri, rg.isOptionalPart(statementPartId), this.context);
             } else if (template.isLiteralPlaceholder(iri)) {
-                // TODO add all date time types
                 if (XSD.DATE.equals(template.getDatatype(iri))) {
                     component = new LiteralDateItem("value", iri, rg.isOptionalPart(statementPartId), this.context);
                 } else if (XSD.DATETIME.equals(template.getDatatype(iri))) {
                     component = new LiteralDateTimeItem("value", iri, rg.isOptionalPart(statementPartId), this.context);
+                } else if (LiteralGregorianItem.supports(template.getDatatype(iri))) {
+                    // xsd:gYear and its relatives name a point on the calendar that is coarser
+                    // than a date, so they get parts to pick rather than a date picker.
+                    component = new LiteralGregorianItem("value", iri, rg.isOptionalPart(statementPartId), this.context);
                 } else {
                     component = new LiteralTextfieldItem("value", iri, rg.isOptionalPart(statementPartId), this.context);
                 }

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -1725,6 +1725,17 @@ span.nanopub-assertion, span.nanopub-provenance, span.nanopub-pubinfo {
 }
 */
 
+/* The parts of an xsd:gYear/gMonth/... value: a year is four characters, not a full-width
+   text field, and a month or day dropdown needs only enough room for its longest name. */
+.gregorian-year {
+  width: 7em;
+}
+
+.gregorian-part {
+  min-width: 8em;
+  margin-left: 2px;
+}
+
 .pubinfosection .nanopub-pubinfo {
   display: none;
 }

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -1726,13 +1726,17 @@ span.nanopub-assertion, span.nanopub-provenance, span.nanopub-pubinfo {
 */
 
 /* The parts of an xsd:gYear/gMonth/... value: a year is four characters, not a full-width
-   text field, and a month or day dropdown needs only enough room for its longest name. */
+   text field, and a month or day dropdown needs only enough room for its longest name -- so it
+   sizes to its widest option rather than to the 350px every other select gets. The height is
+   the one input[type=text] is given, which a select does not pick up on its own. */
 .gregorian-year {
   width: 7em;
 }
 
 .gregorian-part {
+  width: auto;
   min-width: 8em;
+  height: 28px;
   margin-left: 2px;
 }
 

--- a/src/test/java/com/knowledgepixels/nanodash/component/LiteralGregorianItemTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/LiteralGregorianItemTest.java
@@ -3,6 +3,7 @@ package com.knowledgepixels.nanodash.component;
 import com.knowledgepixels.nanodash.WicketApplication;
 import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.template.TemplateData;
+import org.apache.wicket.Component;
 import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.util.tester.FormTester;
@@ -20,10 +21,12 @@ import org.nanopub.Nanopub;
 import org.nanopub.NanopubCreator;
 import org.nanopub.vocabulary.NTEMPLATE;
 
+import java.time.Year;
 import java.util.List;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -381,6 +384,26 @@ class LiteralGregorianItemTest {
 
         assertEquals("2026-05", value(), "the year entered a request earlier has to still be there");
         assertEquals("2026", tester.getComponentFromLastRenderedPage(yearPath).getDefaultModelObject());
+    }
+
+    @Test
+    void anEmptyYearFieldStartsItsSpinnerAtTheCurrentYear() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg18", XSD.GYEAR);
+        Component yearField = tester.getComponentFromLastRenderedPage("panel:form:" + YEAR_FIELD);
+
+        assertFalse(yearField.getBehaviors(LiteralGregorianItem.CurrentYearOnFirstStep.class).isEmpty(),
+                "the year field should carry the stepping script");
+
+        String script = LiteralGregorianItem.CurrentYearOnFirstStep.script(yearField.getMarkupId(), Year.of(2026));
+        assertTrue(script.contains("document.getElementById('" + yearField.getMarkupId() + "')"),
+                "the script has to name this field: " + script);
+        assertTrue(script.contains("var currentYear = '2026'"),
+                "an empty field steps to the current year, not to 1");
+        assertTrue(script.contains("previous === ''"), "and only while it is empty");
+        assertTrue(script.contains("ArrowUp") && script.contains("ArrowDown"),
+                "either arrow starts it off");
+        assertTrue(script.contains("new Event('change'"),
+                "and the value has to reach the form, not just the field");
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/nanodash/component/LiteralGregorianItemTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/LiteralGregorianItemTest.java
@@ -232,6 +232,80 @@ class LiteralGregorianItemTest {
     }
 
     @Test
+    void aCorrectedYearIsPickedUpAfterTheError() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg11", XSD.GYEAR);
+        FormTester form = filledForm();
+        form.setValue(YEAR_FIELD, "26");
+        form.submit();
+        assertEquals("", value(), "the rejected year is not kept as a value");
+
+        FormTester corrected = filledForm();
+        corrected.setValue(YEAR_FIELD, "2026");
+        corrected.submit();
+
+        assertEquals("2026", value(), "the corrected year has to reach the value");
+    }
+
+    @Test
+    void aCorrectedYearIsPickedUpOverAjax() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg12", XSD.GYEAR);
+        String yearPath = "panel:form:" + YEAR_FIELD;
+
+        FormTester form = tester.newFormTester("panel:form");
+        form.setValue(YEAR_FIELD, "26");
+        tester.executeAjaxEvent(yearPath, "change");
+        assertEquals("", value(), "the rejected year is not kept as a value");
+
+        FormTester corrected = tester.newFormTester("panel:form");
+        corrected.setValue(YEAR_FIELD, "2026");
+        tester.executeAjaxEvent(yearPath, "change");
+
+        assertEquals("2026", value(), "the corrected year has to reach the value");
+        // The Ajax response re-renders only what the update asked for, so what the field will
+        // render next is asserted on its model rather than on this response.
+        assertEquals("2026", tester.getComponentFromLastRenderedPage(yearPath).getDefaultModelObject(),
+                "and has to be what the field holds afterwards");
+    }
+
+    @Test
+    void theTwoPartsSurvivePickingThemOneAtATime() throws Exception {
+        // Each Ajax update carries only the field that changed, so the part picked first has to
+        // survive the request that picks the second.
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg13", XSD.GMONTHDAY);
+        String monthPath = "panel:form:" + MONTH_FIELD;
+        String dayPath = "panel:form:" + DAY_FIELD;
+
+        tester.newFormTester("panel:form").select(MONTH_FIELD, MAY);
+        tester.executeAjaxEvent(monthPath, "change");
+        assertEquals("", value(), "a month alone is not yet a gMonthDay");
+
+        tester.newFormTester("panel:form").select(DAY_FIELD, DAY_17);
+        tester.executeAjaxEvent(dayPath, "change");
+
+        assertEquals("--05-17", value());
+    }
+
+    @Test
+    void aValueSurvivesAChangeToAnotherField() throws Exception {
+        // What KeepValueAfterRefreshBehavior was there for, and what this item's own updating
+        // behavior has to go on providing now that it no longer carries both.
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg14", XSD.GYEAR);
+        String yearPath = "panel:form:" + YEAR_FIELD;
+        String namePath = "panel:form:statements:0:statement:statement-group:0:statement:obj:value:textfield";
+
+        tester.newFormTester("panel:form").setValue(YEAR_FIELD, "2026");
+        tester.executeAjaxEvent(yearPath, "change");
+        assertEquals("2026", value());
+
+        FormTester other = tester.newFormTester("panel:form");
+        other.setValue("statements:0:statement:statement-group:0:statement:obj:value:textfield", "some name");
+        tester.executeAjaxEvent(namePath, "change");
+
+        assertEquals("2026", value(), "a change elsewhere on the form must not clear the year");
+        assertEquals("2026", tester.getComponentFromLastRenderedPage(yearPath).getDefaultModelObject());
+    }
+
+    @Test
     void anEmptyOptionalValueStaysEmpty() throws Exception {
         startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg10", XSD.GYEAR);
         filledForm().submit();

--- a/src/test/java/com/knowledgepixels/nanodash/component/LiteralGregorianItemTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/LiteralGregorianItemTest.java
@@ -1,0 +1,242 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.page.PublishPage;
+import com.knowledgepixels.nanodash.template.TemplateData;
+import org.apache.wicket.feedback.FeedbackMessage;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.tester.FormTester;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Filling in a literal placeholder typed with one of the XSD Gregorian datatypes, from the form
+ * the user actually gets: what the parts assemble into is what a published nanopublication would
+ * carry.
+ */
+class LiteralGregorianItemTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String ITEM =
+            "panel:form:statements:1:statement:statement-group:0:statement:obj:value";
+    private static final String YEAR_FIELD =
+            "statements:1:statement:statement-group:0:statement:obj:value:year";
+    private static final String MONTH_FIELD =
+            "statements:1:statement:statement-group:0:statement:obj:value:month";
+    private static final String DAY_FIELD =
+            "statements:1:statement:statement-group:0:statement:obj:value:day";
+
+    /** Index of a month or day in its dropdown: the choices run from 01. */
+    private static final int MAY = 4, FEBRUARY = 1, DAY_17 = 16, DAY_30 = 29;
+
+    private WicketTester tester;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester(new WicketApplication());
+        tester.getSession().setLocale(Locale.ENGLISH);
+    }
+
+    @AfterEach
+    void tearDown() {
+        tester.destroy();
+    }
+
+    /**
+     * Registers a template with a plain literal ("the name") and a literal of the given
+     * datatype ("the moment"). Each test needs its own nanopub URI, because templates are
+     * cached by URI.
+     */
+    private static String registerTemplate(String npUri, IRI datatype, boolean momentIsOptional) throws Exception {
+        IRI st1 = vf.createIRI(npUri + "/st1");
+        IRI st2 = vf.createIRI(npUri + "/st2");
+        IRI thing = vf.createIRI(npUri + "/thing");
+        IRI name = vf.createIRI(npUri + "/name");
+        IRI moment = vf.createIRI(npUri + "/moment");
+        NanopubCreator creator = new NanopubCreator(npUri);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Gregorian test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st1);
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st2);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, thing);
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(st1, RDF.OBJECT, name);
+        if (momentIsOptional) creator.addAssertionStatement(st2, RDF.TYPE, NTEMPLATE.OPTIONAL_STATEMENT);
+        creator.addAssertionStatement(st2, RDF.SUBJECT, thing);
+        creator.addAssertionStatement(st2, RDF.PREDICATE, RDFS.COMMENT);
+        creator.addAssertionStatement(st2, RDF.OBJECT, moment);
+        creator.addAssertionStatement(thing, RDF.TYPE, NTEMPLATE.URI_PLACEHOLDER);
+        creator.addAssertionStatement(thing, RDFS.LABEL, vf.createLiteral("the thing"));
+        creator.addAssertionStatement(name, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(name, RDFS.LABEL, vf.createLiteral("the name"));
+        creator.addAssertionStatement(moment, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(moment, NTEMPLATE.HAS_DATATYPE, datatype);
+        creator.addAssertionStatement(moment, RDFS.LABEL, vf.createLiteral("the moment"));
+        Nanopub np = creator.finalizeNanopub();
+        TemplateData.get().registerTemplate(np);
+        return npUri;
+    }
+
+    private void startForm(String npUri, IRI datatype) throws Exception {
+        startForm(npUri, datatype, true, new PageParameters());
+    }
+
+    private void startForm(String npUri, IRI datatype, boolean optional, PageParameters extraParams) throws Exception {
+        PageParameters params = new PageParameters(extraParams)
+                .add("template", registerTemplate(npUri, datatype, optional));
+        tester.startComponentInPage(new PublishForm("panel", params, PublishPage.class, null));
+    }
+
+    /**
+     * Fills in everything but the moment, so that submitting exercises validation while the
+     * rest of the form is complete.
+     */
+    private FormTester filledForm() {
+        FormTester form = tester.newFormTester("panel:form");
+        form.setValue("statements:0:statement:statement-group:0:statement:subj:value:textfield", "http://example.org/thing");
+        form.setValue("statements:0:statement:statement-group:0:statement:obj:value:textfield", "some name");
+        form.setValue("statements:1:statement:statement-group:0:statement:subj:value:textfield", "http://example.org/thing");
+        return form;
+    }
+
+    private LiteralGregorianItem item() {
+        return (LiteralGregorianItem) tester.getComponentFromLastRenderedPage(ITEM);
+    }
+
+    private String value() {
+        return item().getValueModel().getObject();
+    }
+
+    private void assertErrorMessage(String expectedFragment) {
+        List<FeedbackMessage> messages = tester.getFeedbackMessages(m -> m.getLevel() == FeedbackMessage.ERROR);
+        assertTrue(messages.stream().anyMatch(m -> m.getMessage().toString().contains(expectedFragment)),
+                "Expected an error mentioning '" + expectedFragment + "', got " + messages);
+    }
+
+    @Test
+    void aYearIsEnteredAsAYear() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg01", XSD.GYEAR);
+        FormTester form = filledForm();
+        form.setValue(YEAR_FIELD, "2026");
+        form.submit();
+
+        assertEquals("2026", value());
+        assertTrue(tester.getLastResponseAsString().contains("type=\"number\""),
+                "a year is entered in a number field, not a free-text one");
+    }
+
+    @Test
+    void aYearAndMonthAssembleIntoOneValue() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg02", XSD.GYEARMONTH);
+        FormTester form = filledForm();
+        form.setValue(YEAR_FIELD, "2026");
+        form.select(MONTH_FIELD, MAY);
+        form.submit();
+
+        assertEquals("2026-05", value());
+    }
+
+    @Test
+    void aMonthIsPickedFromItsName() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg03", XSD.GMONTH);
+        FormTester form = filledForm();
+        form.select(MONTH_FIELD, MAY);
+        form.submit();
+
+        assertEquals("--05", value());
+        assertTrue(tester.getLastResponseAsString().contains("May"), "months are named, not numbered");
+    }
+
+    @Test
+    void aMonthAndDayAssembleIntoOneValue() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg04", XSD.GMONTHDAY);
+        FormTester form = filledForm();
+        form.select(MONTH_FIELD, MAY);
+        form.select(DAY_FIELD, DAY_17);
+        form.submit();
+
+        assertEquals("--05-17", value());
+    }
+
+    @Test
+    void aDayIsPickedOnItsOwn() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg05", XSD.GDAY);
+        FormTester form = filledForm();
+        form.select(DAY_FIELD, DAY_17);
+        form.submit();
+
+        assertEquals("---17", value());
+    }
+
+    @Test
+    void halfOfATwoPartValueIsReportedRatherThanPublished() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg06", XSD.GYEARMONTH);
+        FormTester form = filledForm();
+        form.setValue(YEAR_FIELD, "2026");
+        form.submit();
+
+        assertEquals("", value(), "a year alone is not a gYearMonth");
+        assertErrorMessage("Please also select a month");
+    }
+
+    @Test
+    void aDayItsMonthCannotHaveIsReported() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg07", XSD.GMONTHDAY);
+        FormTester form = filledForm();
+        form.select(MONTH_FIELD, FEBRUARY);
+        form.select(DAY_FIELD, DAY_30);
+        form.submit();
+
+        assertErrorMessage("February has no day 30");
+    }
+
+    @Test
+    void aYearOfTheWrongShapeIsReported() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg08", XSD.GYEAR);
+        FormTester form = filledForm();
+        form.setValue(YEAR_FIELD, "26");
+        form.submit();
+
+        assertEquals("", value());
+        assertErrorMessage("A year is four or more digits");
+    }
+
+    @Test
+    void aValueGivenInTheUrlFillsTheFieldsIn() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg09", XSD.GYEARMONTH,
+                true, new PageParameters().add("param_moment", "2026-05"));
+
+        assertEquals("2026-05", value(), "the value from the URL should reach the fields");
+        assertTrue(tester.getLastResponseAsString().contains("value=\"2026\""), "the year field shows it");
+    }
+
+    @Test
+    void anEmptyOptionalValueStaysEmpty() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg10", XSD.GYEAR);
+        filledForm().submit();
+
+        assertEquals("", value());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/component/LiteralGregorianItemTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/LiteralGregorianItemTest.java
@@ -45,7 +45,7 @@ class LiteralGregorianItemTest {
             "statements:1:statement:statement-group:0:statement:obj:value:day";
 
     /** Index of a month or day in its dropdown: the choices run from 01. */
-    private static final int MAY = 4, FEBRUARY = 1, DAY_17 = 16, DAY_30 = 29;
+    private static final int MAY = 4, FEBRUARY = 1, DECEMBER = 11, DAY_17 = 16, DAY_30 = 29;
 
     private WicketTester tester;
 
@@ -66,6 +66,10 @@ class LiteralGregorianItemTest {
      * cached by URI.
      */
     private static String registerTemplate(String npUri, IRI datatype, boolean momentIsOptional) throws Exception {
+        return registerTemplate(npUri, datatype, momentIsOptional, null);
+    }
+
+    private static String registerTemplate(String npUri, IRI datatype, boolean momentIsOptional, String regex) throws Exception {
         IRI st1 = vf.createIRI(npUri + "/st1");
         IRI st2 = vf.createIRI(npUri + "/st2");
         IRI thing = vf.createIRI(npUri + "/thing");
@@ -93,6 +97,7 @@ class LiteralGregorianItemTest {
         creator.addAssertionStatement(moment, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
         creator.addAssertionStatement(moment, NTEMPLATE.HAS_DATATYPE, datatype);
         creator.addAssertionStatement(moment, RDFS.LABEL, vf.createLiteral("the moment"));
+        if (regex != null) creator.addAssertionStatement(moment, NTEMPLATE.HAS_REGEX, vf.createLiteral(regex));
         Nanopub np = creator.finalizeNanopub();
         TemplateData.get().registerTemplate(np);
         return npUri;
@@ -103,8 +108,12 @@ class LiteralGregorianItemTest {
     }
 
     private void startForm(String npUri, IRI datatype, boolean optional, PageParameters extraParams) throws Exception {
+        startForm(npUri, datatype, optional, extraParams, null);
+    }
+
+    private void startForm(String npUri, IRI datatype, boolean optional, PageParameters extraParams, String regex) throws Exception {
         PageParameters params = new PageParameters(extraParams)
-                .add("template", registerTemplate(npUri, datatype, optional));
+                .add("template", registerTemplate(npUri, datatype, optional, regex));
         tester.startComponentInPage(new PublishForm("panel", params, PublishPage.class, null));
     }
 
@@ -197,7 +206,7 @@ class LiteralGregorianItemTest {
         form.submit();
 
         assertEquals("", value(), "a year alone is not a gYearMonth");
-        assertErrorMessage("Please also select a month");
+        assertErrorMessage("'month of 'the moment'' is required");
     }
 
     @Test
@@ -302,6 +311,75 @@ class LiteralGregorianItemTest {
         tester.executeAjaxEvent(namePath, "change");
 
         assertEquals("2026", value(), "a change elsewhere on the form must not clear the year");
+        assertEquals("2026", tester.getComponentFromLastRenderedPage(yearPath).getDefaultModelObject());
+    }
+
+    @Test
+    void aValueRejectedByTheTemplatePatternDoesNotOutliveItsCorrection() throws Exception {
+        // A template may narrow a gYear further, e.g. to four digits exactly. The value the
+        // pattern judges has to be the one being entered, not the one entered before it.
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg15", XSD.GYEAR,
+                true, new PageParameters(), "[0-9]{4}");
+        String yearPath = "panel:form:" + YEAR_FIELD;
+
+        tester.newFormTester("panel:form").setValue(YEAR_FIELD, "46464");
+        tester.executeAjaxEvent(yearPath, "change");
+        assertEquals("", value(), "a value the pattern rejects is not stored");
+        assertErrorMessage("Value '46464' doesn't match the pattern");
+
+        tester.clearFeedbackMessages();
+        tester.newFormTester("panel:form").setValue(YEAR_FIELD, "2026");
+        tester.executeAjaxEvent(yearPath, "change");
+
+        assertEquals("2026", value(), "the corrected year has to be accepted");
+        List<FeedbackMessage> errors = tester.getFeedbackMessages(m -> m.getLevel() == FeedbackMessage.ERROR);
+        assertTrue(errors.stream().noneMatch(m -> m.getMessage().toString().contains("46464")),
+                "the rejected value must not still be the one judged, got " + errors);
+    }
+
+    @Test
+    void aPatternOverATwoPartValueJudgesBothPartsAsTheyStand() throws Exception {
+        // Only the first half of the year, so the month decides -- and the month is the part
+        // that is not being changed when the year is, and the other way round.
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg16", XSD.GYEARMONTH,
+                true, new PageParameters(), "[0-9]{4}-0[1-6]");
+        String yearPath = "panel:form:" + YEAR_FIELD;
+        String monthPath = "panel:form:" + MONTH_FIELD;
+
+        tester.newFormTester("panel:form").setValue(YEAR_FIELD, "2026");
+        tester.executeAjaxEvent(yearPath, "change");
+
+        tester.newFormTester("panel:form").select(MONTH_FIELD, DECEMBER);
+        tester.executeAjaxEvent(monthPath, "change");
+        assertEquals("", value(), "December is outside the pattern, so nothing is stored");
+        assertErrorMessage("Value '2026-12' doesn't match the pattern");
+
+        tester.clearFeedbackMessages();
+        tester.newFormTester("panel:form").select(MONTH_FIELD, MAY);
+        tester.executeAjaxEvent(monthPath, "change");
+
+        assertEquals("2026-05", value(), "the corrected month has to be accepted");
+    }
+
+    @Test
+    void eachPartIsStoredAsItIsEnteredRatherThanWaitingForTheOther() throws Exception {
+        // The way a browser sends it: one field per request. A part rejected for the absence of
+        // one the user has not reached yet would never be stored, and the value could then never
+        // be completed at all.
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg17", XSD.GYEARMONTH);
+        String yearPath = "panel:form:" + YEAR_FIELD;
+        String monthPath = "panel:form:" + MONTH_FIELD;
+
+        tester.newFormTester("panel:form").setValue(YEAR_FIELD, "2026");
+        tester.executeAjaxEvent(yearPath, "change");
+        assertEquals("", value(), "a year alone is not yet a gYearMonth");
+        assertTrue(tester.getFeedbackMessages(m -> m.getLevel() == FeedbackMessage.ERROR).isEmpty(),
+                "and is not an error while the month is still being reached for");
+
+        tester.newFormTester("panel:form").select(MONTH_FIELD, MAY);
+        tester.executeAjaxEvent(monthPath, "change");
+
+        assertEquals("2026-05", value(), "the year entered a request earlier has to still be there");
         assertEquals("2026", tester.getComponentFromLastRenderedPage(yearPath).getDefaultModelObject());
     }
 

--- a/src/test/java/com/knowledgepixels/nanodash/component/LiteralGregorianItemTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/LiteralGregorianItemTest.java
@@ -202,6 +202,16 @@ class LiteralGregorianItemTest {
     }
 
     @Test
+    void anUnpickedDropdownSaysWhichPartItIsWaitingFor() throws Exception {
+        startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg19", XSD.GMONTHDAY);
+        String response = tester.getLastResponseAsString();
+
+        assertTrue(response.contains("choose month"), "the month dropdown names the month");
+        assertTrue(response.contains("choose day"), "the day dropdown names the day");
+        assertFalse(response.contains("Choose One"), "not Wicket's default, which says neither");
+    }
+
+    @Test
     void halfOfATwoPartValueIsReportedRatherThanPublished() throws Exception {
         startForm("https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Greg06", XSD.GYEARMONTH);
         FormTester form = filledForm();

--- a/src/test/java/com/knowledgepixels/nanodash/component/LiteralGregorianValueTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/LiteralGregorianValueTest.java
@@ -1,0 +1,89 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.component.LiteralGregorianItem.GregorianType;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The lexical forms of the XSD Gregorian datatypes, which is what this component has to get
+ * right: what it assembles ends up verbatim in a published nanopublication.
+ */
+class LiteralGregorianValueTest {
+
+    @Test
+    void everyGregorianDatatypeIsRecognized() {
+        assertEquals(GregorianType.G_YEAR, GregorianType.of(XSD.GYEAR));
+        assertEquals(GregorianType.G_YEAR_MONTH, GregorianType.of(XSD.GYEARMONTH));
+        assertEquals(GregorianType.G_MONTH, GregorianType.of(XSD.GMONTH));
+        assertEquals(GregorianType.G_MONTH_DAY, GregorianType.of(XSD.GMONTHDAY));
+        assertEquals(GregorianType.G_DAY, GregorianType.of(XSD.GDAY));
+    }
+
+    @Test
+    void otherDatatypesAreLeftToTheirOwnComponents() {
+        assertFalse(LiteralGregorianItem.supports(XSD.DATE), "xsd:date has a date picker");
+        assertFalse(LiteralGregorianItem.supports(XSD.DATETIME), "xsd:dateTime has its own picker");
+        assertFalse(LiteralGregorianItem.supports(XSD.STRING));
+        assertFalse(LiteralGregorianItem.supports(XSD.INTEGER), "a gYear is not an integer field");
+        assertFalse(LiteralGregorianItem.supports(null), "an untyped literal has no datatype");
+    }
+
+    @Test
+    void partsAssembleIntoTheFormEachDatatypePrescribes() {
+        assertEquals("2026", GregorianType.G_YEAR.assemble("2026", "", "", ""));
+        assertEquals("2026-05", GregorianType.G_YEAR_MONTH.assemble("2026", "05", "", ""));
+        assertEquals("--05", GregorianType.G_MONTH.assemble("", "05", "", ""));
+        assertEquals("--05-17", GregorianType.G_MONTH_DAY.assemble("", "05", "17", ""));
+        assertEquals("---17", GregorianType.G_DAY.assemble("", "", "17", ""));
+    }
+
+    @Test
+    void anIncompleteValueAssemblesToNothing() {
+        // Rather than to "2026-", which would be published as an invalid literal.
+        assertEquals("", GregorianType.G_YEAR_MONTH.assemble("2026", "", "", ""));
+        assertEquals("", GregorianType.G_YEAR_MONTH.assemble("", "05", "", ""));
+        assertEquals("", GregorianType.G_MONTH_DAY.assemble("", "05", "", ""));
+        assertEquals("", GregorianType.G_MONTH_DAY.assemble("", "", "17", ""));
+        assertEquals("", GregorianType.G_YEAR.assemble("", "", "", ""));
+    }
+
+    @Test
+    void everyFormSplitsBackIntoTheSameParts() {
+        assertArrayEquals(new String[]{"2026", "", "", ""}, GregorianType.G_YEAR.split("2026"));
+        assertArrayEquals(new String[]{"2026", "05", "", ""}, GregorianType.G_YEAR_MONTH.split("2026-05"));
+        assertArrayEquals(new String[]{"", "05", "", ""}, GregorianType.G_MONTH.split("--05"));
+        assertArrayEquals(new String[]{"", "05", "17", ""}, GregorianType.G_MONTH_DAY.split("--05-17"));
+        assertArrayEquals(new String[]{"", "", "17", ""}, GregorianType.G_DAY.split("---17"));
+    }
+
+    @Test
+    void aTimezoneIsKeptRatherThanDroppedOnTheWayBack() {
+        // A value filled in from an existing nanopublication may carry one; re-publishing it
+        // without would change what the nanopub says.
+        assertArrayEquals(new String[]{"2026", "", "", "Z"}, GregorianType.G_YEAR.split("2026Z"));
+        assertArrayEquals(new String[]{"", "05", "17", "+02:00"}, GregorianType.G_MONTH_DAY.split("--05-17+02:00"));
+        assertEquals("2026Z", GregorianType.G_YEAR.assemble("2026", "", "", "Z"));
+        assertEquals("--05-17+02:00", GregorianType.G_MONTH_DAY.assemble("", "05", "17", "+02:00"));
+    }
+
+    @Test
+    void yearsOutsideTheOrdinaryRangeAreStillYears() {
+        assertTrue(GregorianType.G_YEAR.isValid("-0044"), "XSD years can be negative");
+        assertTrue(GregorianType.G_YEAR.isValid("12026"), "and can have more than four digits");
+        assertArrayEquals(new String[]{"-0044", "", "", ""}, GregorianType.G_YEAR.split("-0044"));
+    }
+
+    @Test
+    void aValueOfTheWrongShapeIsNotValid() {
+        assertFalse(GregorianType.G_YEAR.isValid("26"), "a year is at least four digits");
+        assertFalse(GregorianType.G_YEAR.isValid("2026-05"), "that is a gYearMonth");
+        assertFalse(GregorianType.G_MONTH.isValid("05"), "a gMonth carries its two leading dashes");
+        assertFalse(GregorianType.G_DAY.isValid("--17"), "a gDay carries three");
+        assertFalse(GregorianType.G_MONTH_DAY.isValid("--05-17-01"));
+        assertFalse(GregorianType.G_YEAR.isValid(""));
+        assertNull(GregorianType.G_YEAR.split(null));
+    }
+
+}


### PR DESCRIPTION
Closes #670.

A literal placeholder typed `xsd:gYear` got a plain text field — nothing offered a year, nothing checked one, and "next spring" typed into it was published as `"next spring"^^xsd:gYear`. The same held for `gYearMonth`, `gMonth`, `gMonthDay` and `gDay`; only `xsd:date` and `xsd:dateTime` had components of their own, with a `// TODO add all date time types` where the rest belonged.

## Why not a date picker

These types name a point on the calendar that is *coarser* than a date. "2026" and "--05-17" are precisely the values a full date has no way to leave unsaid, so a picker cannot stand in for them. Instead each part gets a control that can only produce something the datatype allows:

| Datatype | Controls | Value |
|---|---|---|
| `xsd:gYear` | year | `2026` |
| `xsd:gYearMonth` | year + month | `2026-05` |
| `xsd:gMonth` | month | `--05` |
| `xsd:gMonthDay` | month + day | `--05-17` |
| `xsd:gDay` | day | `---17` |

The year is a number field (spinner, numeric keypad, and a pattern that decides where the input type is ignored); months and days are dropdowns, named rather than numbered.

## What it refuses to publish

As much of the point as what it offers, since a nanopublication cannot be edited afterwards:

- **A half-entered value** is reported, not published. A `gYearMonth` with a year and no month assembles to nothing and the form says "Please also select a month", rather than emitting `"2026-"^^xsd:gYearMonth`.
- **A day its month cannot have** is reported: February 30 says so by name instead of becoming a `gMonthDay` no calendar has.
- **A timezone** on a value filled in from an existing nanopublication is carried back out again. Nothing here offers to add one, but dropping one on re-publication would change what the nanopub says.

The value reaches the rest of the form as the single lexical string it always was, so `TemplateContext` needed no change — it already types the literal from the placeholder's datatype (#564). Keeping the *parts* behind that string is what lets "May" stay on screen in the moment before a day is picked.

## Tests

18 new, 1250 in the suite, all green:

- the lexical forms themselves — what each datatype assembles, what it refuses to assemble, what splits back into the same parts, negative years and five-digit years, and the timezone round-trip;
- the form a user actually gets, through `WicketTester`: each datatype filled in and submitted, the partial and impossible values reported, a `param_` URL seeding the fields, and an untouched optional field staying empty.

Not covered here: `xsd:time` and `xsd:duration`, which are clock and interval rather than calendar types and want a different control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018J1JEopfv4icibN6bGkZ1d

---

**Update — a bug found in review, fixed in the second commit.** A rejected year left the field deaf: every correction was read, stored, and wiped again inside the same request, so the value stayed empty however often it was retyped.

The field carried two updating behaviors — its own, and the `KeepValueAfterRefreshBehavior` every other item adds on top of one. Both are `OnChangeAjaxBehavior`, so both run per change, and the second reaches `updateModel()` when the input it reads is already empty, writing that emptiness over what the first had just stored. A plain text field never shows it: its model takes the same value twice without harm. A value assembled from parts loses the part just set.

The field now keeps one updating behavior — the Ajax round-trip it already makes is what kept values across a refresh, which is all the second was for — and it finds the components to refresh by the value behind the model rather than by the model itself, so a placeholder used in more than one statement stays in step.

Four tests came with it, all driving the Ajax path rather than a form submit, which is where this only ever showed: a corrected year after a rejected one, both parts of a `gMonthDay` picked one at a time, and a value surviving a change to another field.

**Update 2 — the field was still unusable under a template pattern, fixed in the third commit.** Entering `46464` where the template's pattern is `[0-9]{4}` reported `Value '46464' doesn't match the pattern` for every value entered afterwards, the field refusing corrections until the page was left behind.

The pattern was applied to the *stored* value rather than to the entry being made. Nothing had judged the first entry, so it was stored; from then on it was the value every check measured, and no correction could replace it, since a failed check is exactly what stops the entry being stored. Checks now assemble the value from what the controls hold.

Three faults of the same kind came out with it, each with a test:

- **A value-wide check lived on one part.** A pattern that only the month breaks went unapplied when the month was what changed. The template pattern and the impossible-date check now sit on every part, with only the first to report keeping its message.
- **Requiring the other part on every change left both parts unstored.** Each was rejected for the absence of the one the user had not reached yet, so a `gYearMonth` could never be completed at all. A part now requires the other only in a request that carries it — a submit — which is how a language-tagged literal requires its tag in `LiteralTextfieldItem`.
- **The day dropdown submitted the position of the day rather than the day.** A reader of the field saw the 29th where the 30th was picked, and February 30 passed the check meant to catch it.

Suite: 1257 tests, green.

**Update 3 — the year spinner starts at the current year.** Stepping an empty number input lands on 1 or -1, a year nobody means and four keystrokes from any they do. The first press of either arrow on an empty year field now fills in the current year; from there the browser's own stepping takes over, counting up and down from wherever the value stands, and a field that already holds a year is left alone.

Typing carries an `inputType` and using the spinner does not, which is what tells a click on the arrows apart from a `1` the user meant to type. The filled-in year is dispatched as `input` and `change`, so it reaches the form rather than only the field.
