### PR TITLE
fix(view tables): make ordering by a column visible and correct

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/FilteredQueryResultDataProvider.java
+++ b/src/main/java/com/knowledgepixels/nanodash/FilteredQueryResultDataProvider.java
@@ -73,6 +73,8 @@ public class FilteredQueryResultDataProvider implements ISortableDataProvider<Ap
             String prop = sortParam.getProperty();
             String labelProp = prop + "_label";
             String sortProp = Arrays.asList(response.getHeader()).contains(labelProp) ? labelProp : prop;
+            // Values are compared with Utils.compareValues rather than as plain text, so
+            // that a column of numbers does not come out with "10" above "9" (issue #673).
             data.sort((o1, o2) -> {
                 String v1 = o1.get(sortProp);
                 String v2 = o2.get(sortProp);
@@ -80,7 +82,7 @@ public class FilteredQueryResultDataProvider implements ISortableDataProvider<Ap
                 if (v1 == null && v2 == null) result = 0;
                 else if (v1 == null) result = 1;
                 else if (v2 == null) result = -1;
-                else result = v1.compareToIgnoreCase(v2);
+                else result = Utils.compareValues(v1, v2);
                 if (!sortParam.isAscending()) result = -result;
                 return result;
             });

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import org.wicketstuff.select2.Select2Choice;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
@@ -1124,6 +1125,98 @@ public class Utils {
             return uri.substring(0, 30) + "..." + uri.substring(uri.length() - 30);
         }
         return uriLabel;
+    }
+
+    /**
+     * Compares two result-table values the way a reader expects a column to be ordered.
+     * Plain text order alone puts "10" before "9", because it never gets past the first
+     * digit (issue #673); this compares numbers by their value instead. Values that are
+     * numbers throughout are compared as numbers, and text with numbers in it run by run,
+     * so that "Session #9" comes before "Session #34" too. Anything else is ordered as
+     * text, ignoring case, as before.
+     *
+     * @param value1 the first value
+     * @param value2 the second value
+     * @return a negative number, zero or a positive number as the first value orders
+     * before, with, or after the second
+     */
+    public static int compareValues(String value1, String value2) {
+        String s1 = value1 == null ? "" : value1.trim();
+        String s2 = value2 == null ? "" : value2.trim();
+        BigDecimal n1 = asNumber(s1);
+        BigDecimal n2 = asNumber(s2);
+        if (n1 != null && n2 != null) {
+            // Whole values that are numbers are compared as such, which is the only way to
+            // get decimals right: run by run, "1.25" would come out below "1.5".
+            int c = n1.compareTo(n2);
+            return c != 0 ? c : s1.compareToIgnoreCase(s2);
+        }
+        return compareAlphanumerically(s1, s2);
+    }
+
+    // The value as a number, or null if it is not one throughout.
+    private static BigDecimal asNumber(String value) {
+        if (value.isEmpty()) return null;
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    // Text order, except that two runs of digits meeting at the same position are compared
+    // by their numeric value. Kept to plain character comparisons: this runs once per pair
+    // of rows compared, for every column sorted.
+    private static int compareAlphanumerically(String s1, String s2) {
+        int i1 = 0;
+        int i2 = 0;
+        while (i1 < s1.length() && i2 < s2.length()) {
+            char c1 = s1.charAt(i1);
+            char c2 = s2.charAt(i2);
+            if (isAsciiDigit(c1) && isAsciiDigit(c2)) {
+                int end1 = digitRunEnd(s1, i1);
+                int end2 = digitRunEnd(s2, i2);
+                // Leading zeros carry no value, so they are skipped before the two runs are
+                // compared; the shorter run is then the smaller number, and equally long
+                // runs compare digit by digit.
+                int start1 = skipZeros(s1, i1, end1);
+                int start2 = skipZeros(s2, i2, end2);
+                if (end1 - start1 != end2 - start2) return (end1 - start1) - (end2 - start2);
+                int c = s1.substring(start1, end1).compareTo(s2.substring(start2, end2));
+                if (c != 0) return c;
+                i1 = end1;
+                i2 = end2;
+            } else {
+                int c = Character.compare(fold(c1), fold(c2));
+                if (c != 0) return c;
+                i1++;
+                i2++;
+            }
+        }
+        // Whatever is left over of the longer value orders after the shorter one.
+        return (s1.length() - i1) - (s2.length() - i2);
+    }
+
+    private static boolean isAsciiDigit(char c) {
+        return c >= '0' && c <= '9';
+    }
+
+    private static int digitRunEnd(String s, int from) {
+        int i = from;
+        while (i < s.length() && isAsciiDigit(s.charAt(i))) i++;
+        return i;
+    }
+
+    // The first digit that carries value, keeping the last one so that "000" stays a digit.
+    private static int skipZeros(String s, int from, int end) {
+        int i = from;
+        while (i < end - 1 && s.charAt(i) == '0') i++;
+        return i;
+    }
+
+    // Case folded the same way String.compareToIgnoreCase does it.
+    private static char fold(char c) {
+        return Character.toLowerCase(Character.toUpperCase(c));
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -254,7 +254,10 @@ public class QueryResultTable extends QueryResult {
         }
 
         public Column(String title, String dataKey, String key, String cssClass) {
-            super(new Model<String>(title), dataKey);
+            // Only a column with a header label is sortable: an empty header is nothing to
+            // click, and the actions column would otherwise offer to order the table by a
+            // property no row has, giving a round trip that changes nothing (issue #673).
+            super(new Model<String>(title), Strings.isEmpty(title) ? null : dataKey);
             this.key = key;
             this.dataKey = dataKey;
             this.cssClass = cssClass;

--- a/src/main/java/com/knowledgepixels/nanodash/script/nanodash.js
+++ b/src/main/java/com/knowledgepixels/nanodash/script/nanodash.js
@@ -206,6 +206,11 @@ var UPDATE_SPINNER_MAX_MS = 30000;
    about a tenth of a second, which is why the delay alone left them silent. */
 var REQUESTED_SPINNER_MIN_MS = 600;
 var updatingPanels = new Map();
+/* The panel each call in flight was started from, remembered by the id of the control that
+   triggered it. The control itself can be gone by the time the call completes — a table
+   re-renders its own header and paging links with fresh ids — and looking the panel up
+   again would then find nothing, leaving the spinner turning until the backstop. */
+var pendingCalls = new Map();
 
 function isVisible(el) {
   return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
@@ -225,6 +230,18 @@ function isRequestedRefresh(attributes) {
   if (!id || typeof id !== "string") return false;
   var el = document.getElementById(id);
   return !!(el && el.classList.contains("refresh-request"));
+}
+
+/* Whether an Ajax call is a table reordering a column header was clicked for. The rows
+   are already on the page and no query is made; the round trip only re-renders them in a
+   different order. Answering that with the "updating" spinner suggested data was being
+   fetched, and made a reordering look like a refresh (issue #673), so these calls stay
+   out of the indicator. Header sort links are the only Ajax triggers inside a <th>. */
+function isTableReordering(attributes) {
+  var id = attributes && attributes.c;
+  if (!id || typeof id !== "string") return false;
+  var el = document.getElementById(id);
+  return !!(el && el.closest("th"));
 }
 
 /* The view panel an Ajax call was triggered from, or null for calls that belong to no
@@ -312,11 +329,23 @@ function onUpdateEnd(panel) {
 function trackAjaxUpdates() {
   if (typeof Wicket === "undefined" || !Wicket.Event) return;
   Wicket.Event.subscribe("/ajax/call/before", function (jqEvent, attributes) {
+    if (isTableReordering(attributes)) return;
     var panel = findUpdatingPanel(attributes);
-    if (panel) onUpdateStart(panel, isRequestedRefresh(attributes));
+    if (!panel) return;
+    var id = attributes && attributes.c;
+    if (typeof id === "string") pendingCalls.set(id, panel);
+    onUpdateStart(panel, isRequestedRefresh(attributes));
   });
   Wicket.Event.subscribe("/ajax/call/complete", function (jqEvent, attributes) {
-    var panel = findUpdatingPanel(attributes);
+    if (isTableReordering(attributes)) return;
+    var id = attributes && attributes.c;
+    var panel = null;
+    if (typeof id === "string" && pendingCalls.has(id)) {
+      panel = pendingCalls.get(id);
+      pendingCalls.delete(id);
+    } else {
+      panel = findUpdatingPanel(attributes);
+    }
     if (panel) onUpdateEnd(panel);
   });
 }

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -508,6 +508,39 @@ th {
   border-bottom: 1px solid #888;
 }
 
+/* Sort state of a result table's columns (issue #673). Wicket marks the header
+   cell with wicket_orderUp/wicket_orderDown/wicket_orderNone but ships no styling
+   for them, so ordering a column left no visible trace and it was easy to doubt
+   whether the click had done anything. The caret sits after the header label: solid
+   on the column the table is ordered by, and shown only on hover for the others, so
+   the header row stays quiet while still advertising that a column can be ordered.
+   The space is reserved either way, so nothing shifts as the caret appears. */
+.result-table th.wicket_orderUp > a::after,
+.result-table th.wicket_orderDown > a::after,
+.result-table th.wicket_orderNone > a::after {
+  font-size: 0.8em;
+  margin-left: 4px;
+  vertical-align: 1px;
+}
+
+.result-table th.wicket_orderUp > a::after {
+  content: "\25B2";
+}
+
+.result-table th.wicket_orderDown > a::after {
+  content: "\25BC";
+}
+
+.result-table th.wicket_orderNone > a::after {
+  content: "\25B2";
+  color: #aaa;
+  visibility: hidden;
+}
+
+.result-table th.wicket_orderNone > a:hover::after {
+  visibility: visible;
+}
+
 tbody tr:nth-child(even) {
   /* Alpha-based so the zebra stripe darkens whatever is behind it (≈ #efefef
      on white), instead of looking brighter than darker backgrounds (e.g. on

--- a/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
@@ -1074,4 +1074,46 @@ class UtilsTest {
         assertFalse(Utils.isDate("2026-01-30 12:00:00")); // missing T
     }
 
+    @Test
+    void compareValues_ordersNumbersByValue() {
+        assertTrue(Utils.compareValues("9", "10") < 0);
+        assertTrue(Utils.compareValues("10", "9") > 0);
+        assertTrue(Utils.compareValues("2", "10") < 0);
+        assertEquals(0, Utils.compareValues("42", "42"));
+        assertTrue(Utils.compareValues("007", "8") < 0);
+        assertTrue(Utils.compareValues("1.25", "1.5") < 0);
+        assertTrue(Utils.compareValues("-3", "2") < 0);
+        // Whitespace around a value is not part of it.
+        assertEquals(0, Utils.compareValues(" 7 ", "7"));
+    }
+
+    @Test
+    void compareValues_ordersNumbersInsideText() {
+        assertTrue(Utils.compareValues("Session #9", "Session #34") < 0);
+        assertTrue(Utils.compareValues("item2", "item10") < 0);
+        assertTrue(Utils.compareValues("v1.9.0", "v1.10.0") < 0);
+        assertTrue(Utils.compareValues("2026-09-02", "2026-09-10") < 0);
+    }
+
+    @Test
+    void compareValues_ordersTextIgnoringCase() {
+        assertTrue(Utils.compareValues("apple", "Banana") < 0);
+        assertTrue(Utils.compareValues("Banana", "apple") > 0);
+        assertEquals(0, Utils.compareValues("Apple", "apple"));
+        assertTrue(Utils.compareValues("apple", "applesauce") < 0);
+        assertTrue(Utils.compareValues("", "a") < 0);
+    }
+
+    @Test
+    void compareValues_isConsistentInBothDirections() {
+        List<String> values = List.of("10", "9", "Session #34", "Session #9", "", "apple", "1.5", "1.25");
+        for (String a : values) {
+            for (String b : values) {
+                assertEquals(Integer.signum(Utils.compareValues(a, b)),
+                        -Integer.signum(Utils.compareValues(b, a)),
+                        "asymmetric for '" + a + "' / '" + b + "'");
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #673.

Clicking a column header showed the "updating" spinner and gave no sign of what had been ordered.

### The spinner

A sort is a reorder of rows the page already has — no query is made — but the click goes through Ajax like any other, and the client-side indicator in `nanodash.js` lights up for every Ajax call started inside a view panel. Worse, the response re-renders the header with fresh markup ids, so at `/ajax/call/complete` the trigger element is gone and the panel could not be found again; once shown, the spinner ran on until the 30s backstop, which is why a fast reorder looked like a long refresh.

- Sort calls are left out of the indicator (`isTableReordering`; header sort links are the only Ajax triggers inside a `<th>`).
- The panel a call belongs to is remembered from its start (`pendingCalls`), so no control that disappears in its own response can strand a spinner again — this also covers paging links.

### The sign that something happened

Wicket marks the header cell with `wicket_orderUp`/`wicket_orderDown`/`wicket_orderNone`, but `style.css` had no rules for those classes, so nothing on screen changed except the row order. A caret now sits after the header label: solid ▲/▼ on the ordered column, greyed and only on hover for the others, with the space reserved so nothing shifts.

Columns with no header label are no longer sortable: an empty header was a live sort link, and the actions column offered to order the table by a property no row has.

### Numeric ordering

Cells were compared with `compareToIgnoreCase`, i.e. digit by digit, so `"10"` came out above `"9"`. The new `Utils.compareValues` compares values that are numbers throughout as numbers (decimals included — run-by-run comparison would put `1.5` below `1.25`), and otherwise falls back to text order with each run of digits compared by value, so `Session #9` < `Session #34` and `v1.9.0` < `v1.10.0`. Leading zeros are skipped, case is ignored as before, and ISO dates keep sorting correctly.

### Verification

Driven in a browser against a local instance:

- with the Ajax round trip artificially slowed to 1.2s, sorting produced no spinner at any point, while filtering and paging still start *and* end theirs;
- the ordered header flips to `wicket_orderUp`/`Down` with a visible caret, and the actions headers are no longer links;
- a numeric column now reads `0, 1, 1, …` ascending and `73, 12, 12, 12, 10, 9, 8, 8, 7, 7` descending (text order gave `9, 8, 8, 73, 7, 7, 12, …`).

Four comparator tests added to `UtilsTest`; full suite 1236 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UToMqDvcVRgpwHojAx69t1