### PR TITLE
fix(choice fields): no locally minted option for external URI placeholders

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/AgentChoiceItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AgentChoiceItem.java
@@ -185,8 +185,9 @@ public class AgentChoiceItem extends AbstractContextComponent {
                 // Anything else the validator accepts is offered as a locally minted identifier
                 // (issue #652): typing "john-doe" mints it under the namespace of the
                 // nanopublication being published. It comes last, so that the known users the
-                // term matches keep the top of the list.
-                if (isLocalName(typedTerm) && !response.getResults().contains(typedTerm)) {
+                // term matches keep the top of the list. An external URI placeholder refers to an
+                // agent that exists outside this nanopublication, so it gets none (issue #676).
+                if (!template.isExternalUriPlaceholder(iri) && isLocalName(typedTerm) && !response.getResults().contains(typedTerm)) {
                     response.add(typedTerm);
                 }
             }

--- a/src/main/java/com/knowledgepixels/nanodash/component/GuidedChoiceItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/GuidedChoiceItem.java
@@ -192,8 +192,9 @@ public class GuidedChoiceItem extends AbstractContextComponent {
                 // a resource that has no identifier yet can be entered as well (issue #652): it is
                 // minted under the prefix of the field, or under the namespace of the
                 // nanopublication when the field has none. It comes last, so that the suggestions
-                // the term matches keep the top of the list.
-                if (Utils.isPlainName(typedTerm) && !response.getResults().contains(typedTerm)) {
+                // the term matches keep the top of the list. An external URI placeholder refers to
+                // something outside this nanopublication, so it gets no such name (issue #676).
+                if (!template.isExternalUriPlaceholder(iri) && Utils.isPlainName(typedTerm) && !response.getResults().contains(typedTerm)) {
                     response.add(typedTerm);
                 }
             }

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
@@ -385,6 +385,9 @@ public class TemplateContext implements Serializable {
         // The same rule processValue applies: a plain name (no colon, hash or space) gets the
         // target namespace put in front of it. The colon also rules out anything that is a URI.
         if (value == null || !value.matches("[^:# ]+")) return false;
+        // An external URI placeholder points at something that exists outside this
+        // nanopublication, so there is nothing to mint for it (issue #676).
+        if (template.isExternalUriPlaceholder(iri)) return false;
         // A space-/namespace-dependent prefix mints the resource under the space or maintained
         // resource instead, so it is not a local identifier of this nanopublication.
         if (hasDynamicPrefix(iri)) return false;

--- a/src/test/java/com/knowledgepixels/nanodash/component/AgentChoiceItemTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/AgentChoiceItemTest.java
@@ -70,6 +70,14 @@ public class AgentChoiceItemTest {
      * initialized context for it.
      */
     private TemplateContext agentContext() throws Exception {
+        return agentContext(false);
+    }
+
+    /**
+     * Builds a one-statement template whose object is an agent placeholder, optionally also typed
+     * as an external URI placeholder, and returns an initialized context for it.
+     */
+    private TemplateContext agentContext(boolean external) throws Exception {
         NanopubCreator creator = new NanopubCreator(NP_URI);
         creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
         creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
@@ -82,6 +90,9 @@ public class AgentChoiceItemTest {
         creator.addAssertionStatement(st1, RDF.PREDICATE, vf.createIRI("http://example.com/hasAgent"));
         creator.addAssertionStatement(st1, RDF.OBJECT, AGENT);
         creator.addAssertionStatement(AGENT, RDF.TYPE, NTEMPLATE.AGENT_PLACEHOLDER);
+        if (external) {
+            creator.addAssertionStatement(AGENT, RDF.TYPE, NTEMPLATE.EXTERNAL_URI_PLACEHOLDER);
+        }
         creator.addAssertionStatement(AGENT, RDFS.LABEL, vf.createLiteral("agent"));
         Template template = TemplateTestUtil.parseTemplate(creator.finalizeNanopub());
 
@@ -156,6 +167,33 @@ public class AgentChoiceItemTest {
     @Test
     void plainNameIsOfferedAsLocallyMintedIdentifier() throws Exception {
         assertTrue(suggestionsFor(agentContext(), "john-doe").contains("john-doe"));
+    }
+
+    /**
+     * An agent placeholder that is also an external URI placeholder refers to an agent that exists
+     * outside this nanopublication, so no name to be minted is offered for it (issue #676).
+     */
+    @Test
+    void externalAgentOffersNoPlainName() throws Exception {
+        assertFalse(suggestionsFor(agentContext(true), "john-doe").contains("john-doe"));
+    }
+
+    /**
+     * Only the minting is gone for an external agent placeholder: URIs and ORCIDs stay on offer.
+     */
+    @Test
+    void externalAgentOffersUriAndOrcid() throws Exception {
+        assertTrue(suggestionsFor(agentContext(true), "did:plc:z72i7hdynmk6r22z27h6tvur").contains("did:plc:z72i7hdynmk6r22z27h6tvur"));
+        assertTrue(suggestionsFor(agentContext(true), "0000-0002-1267-0234").contains("https://orcid.org/0000-0002-1267-0234"));
+    }
+
+    /**
+     * Nothing is minted for an external agent placeholder, so a bare word held for it is not
+     * marked as a local identifier either (issue #676).
+     */
+    @Test
+    void externalAgentNameIsNotShownAsMintedLocally() throws Exception {
+        assertEquals("john-doe", displayValueFor(agentContext(true), "john-doe"));
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/nanodash/component/GuidedChoiceItemTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/GuidedChoiceItemTest.java
@@ -69,6 +69,15 @@ public class GuidedChoiceItemTest {
      * prefix (none if null), and returns an initialized context for it.
      */
     private TemplateContext guidedContext(String prefix) throws Exception {
+        return guidedContext(prefix, false);
+    }
+
+    /**
+     * Builds a one-statement template whose object is a guided choice placeholder with the given
+     * prefix (none if null), optionally also typed as an external URI placeholder, and returns an
+     * initialized context for it.
+     */
+    private TemplateContext guidedContext(String prefix, boolean external) throws Exception {
         NanopubCreator creator = new NanopubCreator(NP_URI);
         creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
         creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
@@ -81,6 +90,9 @@ public class GuidedChoiceItemTest {
         creator.addAssertionStatement(st1, RDF.PREDICATE, vf.createIRI("http://example.com/hasThing"));
         creator.addAssertionStatement(st1, RDF.OBJECT, THING);
         creator.addAssertionStatement(THING, RDF.TYPE, NTEMPLATE.GUIDED_CHOICE_PLACEHOLDER);
+        if (external) {
+            creator.addAssertionStatement(THING, RDF.TYPE, NTEMPLATE.EXTERNAL_URI_PLACEHOLDER);
+        }
         creator.addAssertionStatement(THING, RDFS.LABEL, vf.createLiteral("thing"));
         if (prefix != null) {
             creator.addAssertionStatement(THING, NTEMPLATE.HAS_PREFIX, vf.createLiteral(prefix));
@@ -145,6 +157,32 @@ public class GuidedChoiceItemTest {
         TemplateContext context = guidedContext("https://example.org/");
         assertTrue(suggestionsFor(context, "john").contains("john"));
         assertEquals("john", fieldOf(context).getProvider().getDisplayValue("john"));
+    }
+
+    /**
+     * A guided choice that is also an external URI placeholder refers to something outside the
+     * nanopublication, so a name that would have to be minted for it is not on offer (issue #676).
+     */
+    @Test
+    void externalGuidedChoiceOffersNoPlainName() throws Exception {
+        assertFalse(suggestionsFor(guidedContext(null, true), "john").contains("john"));
+    }
+
+    /**
+     * A URI stays on offer for an external guided choice -- only the minting is gone.
+     */
+    @Test
+    void externalGuidedChoiceOffersUri() throws Exception {
+        assertTrue(suggestionsFor(guidedContext(null, true), "https://example.com/thing").contains("https://example.com/thing"));
+    }
+
+    /**
+     * Nothing is minted for an external guided choice, so a bare word held for it is not marked as
+     * a local identifier either (issue #676).
+     */
+    @Test
+    void externalGuidedChoiceIsNotShownAsMintedLocally() throws Exception {
+        assertEquals("john", fieldOf(guidedContext(null, true)).getProvider().getDisplayValue("john"));
     }
 
     /**


### PR DESCRIPTION
Closes #676.

## The problem

Guided choice and agent fields offer a typed plain name as an identifier to be minted, shown as `local:john (mint locally)` (from #652). When the placeholder is *also* an `nt:ExternalUriPlaceholder`, the value has to refer to something that already exists outside the nanopublication — the validator rejects such a name with "Not an external IRI", so the option was only ever there to fail on submit.

## The change

Everything is gated on `Template.isExternalUriPlaceholder`, which also covers `nt:TrustyUriPlaceholder` (equally unmintable).

- `TemplateContext.isToBeMinted` returns false for an external URI placeholder, so a bare word held for such a field is no longer labelled "(mint locally)".
- `GuidedChoiceItem` skips the plain-name suggestion for them.
- `AgentChoiceItem` does the same, keeping URI and ORCID suggestions intact.

Placeholders without the tag are unaffected.

## Tests

Both component test classes gained an `external` variant of their template builder plus three cases each: no plain name offered, URIs/ORCIDs still offered, no "mint locally" label. `mvn test -Dtest=AgentChoiceItemTest,GuidedChoiceItemTest` → 21 tests, 0 failures.

## Not in this PR

The issue's second half — "templates, like view display declarations should then be changed to include ExternalPlaceholder tag" — means superseding published template nanopubs, which is a separate, non-code step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UToMqDvcVRgpwHojAx69t1