### PR TITLE
feat(publish form): lock pre-filled values and statements (#678)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Status legend: ✅ Implemented · 🚧 In progress · 📋 Proposed
 | [custom-domains](custom-domains.md) | 📋 Proposed | Serve a user's profile from their own domain |
 | [draft-with-ai](draft-with-ai.md) | 📋 Proposed | Server-side "Draft with AI" nanopub authoring |
 | [uri-schemes](uri-schemes.md) | ✅ Implemented | Accepts and renders `ipfs:`, `ipns:`, `did:` and `at:` URIs alongside `http(s)`, with configurable outbound resolvers and scheme-aware short labels ([#655](https://github.com/knowledgepixels/nanodash/issues/655)) |
+| [locked-prefilled-values](locked-prefilled-values.md) | ✅ Implemented | `locked=` states that a value pre-filled via URL args cannot be changed in the form (per field and per repetition, so pre-filled keys can be fixed while more can still be added); `locked-statements=` fixes the set of repetitions ([#678](https://github.com/knowledgepixels/nanodash/issues/678)) |
 | [claude-code-chat](claude-code-chat.md) | 🚧 In progress | Chat panel backed by the user's local Claude Code, acting on Nanodash via an MCP endpoint (Tier 2 of [#434](https://github.com/knowledgepixels/nanodash/issues/434)) |
 
 When a doc's status changes, update both its `**Status:**` line and the row here.

--- a/docs/locked-prefilled-values.md
+++ b/docs/locked-prefilled-values.md
@@ -85,6 +85,29 @@ value already forces it to stay. Forcing an optional statement to stay *absent* 
 different feature — hiding the field rather than locking it — and is deliberately not
 part of this.
 
+## Locks stated by a view action
+
+A view's entry action fills form fields from the row it sits on, through its
+`col:field` query mappings (docs/magic-query-params.md). Writing the field as
+`!field` locks it as well:
+
+```
+local_pubkey:!public-key__.1
+```
+
+The action then fills the field and emits `locked=param_public-key__.1` with it. This
+is for values an action *determines* rather than proposes — the "append my local key to
+this introduction" action fills in the local public key, and a different key would make
+the introduction wrong. It applies to `param_` targets only: a raw `@` key is a
+fill-mode switch, not a form field.
+
+Note the relative repetition name (`__.1`, "one more than what the source had"), which
+the lock follows through the rewrite into an absolute name.
+
+**Deploy order:** a view nanopublication that starts using `!` should be published only
+once the deployment reads it, since an older version treats `!public-key__.1` as a field
+name of its own and silently fills nothing.
+
 ## What locking does *not* do
 
 - **It is not enforcement.** The lock lives in the URL, so anyone can edit the URL before

--- a/docs/locked-prefilled-values.md
+++ b/docs/locked-prefilled-values.md
@@ -1,0 +1,138 @@
+# Locking pre-filled values and statements
+
+**Status:** ✅ Implemented ([#678](https://github.com/knowledgepixels/nanodash/issues/678)).
+
+## Goal
+
+A link into the publish form can pre-fill fields with URL parameters
+(`?template=…&param_public-key=…`). Some of those values are not the user's to change:
+the "Create Introduction" link fills in the public key of the local key pair, and an
+introduction that declares a different key is simply wrong. The `locked` parameter lets
+the link say so: the field is shown with its value, but cannot be edited.
+
+Locking is per field and, for repeatable statements, **per repetition**. That is what
+lets a link pre-fill and fix the keys a user already has while leaving them free to add
+more. A second parameter, `locked-statements`, fixes the *set* of repetitions instead:
+no adding, no removing. The two are independent — a locked value in an unlocked
+statement can still be dropped by removing its repetition, and a locked statement's
+values can still be edited.
+
+## The `locked` parameter
+
+`locked` names the URL parameters it locks, with the same prefixes that set them:
+
+```
+/publish?template=…
+  &param_public-key=<key>
+  &locked=param_public-key
+```
+
+- `param_x` — assertion template, `prparam_x` — provenance template, `piparamN_x` — the
+  Nth publication-info template. A name **without** a prefix refers to the assertion
+  template, so `locked=public-key` and `locked=param_public-key` are the same thing.
+- Several names can be given as a comma-separated list, as repeated `locked` parameters,
+  or both.
+- A lock on a parameter that carries no value is ignored (and logged). Locking an empty
+  field would leave it empty and uneditable — for a required field, unpublishable.
+
+### Repetitions
+
+Repetition suffixes are part of the name, following the convention the pre-fill
+parameters already use: `x` is the first repetition, `x__1` the second, and so on (the
+relative `x__.1` form works too and is translated along with the value). So
+
+```
+&param_public-key=<key A>&param_public-key__1=<key B>
+&locked=param_public-key,param_public-key__1
+```
+
+pre-fills two key groups, fixes both, and leaves any group the user adds with "+" fully
+editable.
+
+Only *narrow-scope* placeholders — those used in a single top-level statement — get
+repetition suffixes. A placeholder used in several statements is wide-scope: it has one
+shared model and no suffix, so locking it locks it everywhere. In the "Introducing a
+user" template that is exactly the intent: `user` is wide-scope (it appears in the name
+statement and in the key group) and locks as a whole, while `public-key` is narrow-scope
+to the repeatable key group and locks per key.
+
+## Locking statements: `locked-statements`
+
+`locked-statements` names the statements whose repetitions are fixed. The `+` and `-`
+buttons of such a statement are not rendered, so the form publishes exactly the
+repetitions the link pre-filled:
+
+```
+&param_public-key=<key A>&param_public-key__1=<key B>
+&locked=param_public-key,param_public-key__1
+&locked-statements=public-key
+```
+
+It takes the same template prefixes as `locked` (`param_` / `prparam_` / `piparamN_`,
+bare = assertion template). A statement is named either by its node in the template
+(`st2`) or by a placeholder that occurs in that statement and no other (`public-key`) —
+the latter is the name a link author is more likely to have at hand. A placeholder used
+in several statements is wide-scope and names none of them. The name is resolved when the
+lock is queried, not when it is parsed, because the statements are only built afterwards.
+
+Unlike a locked value, a locked statement genuinely holds: Wicket does not invoke the
+listener of a component that is not visible, so a hidden `+` cannot be triggered by
+editing the page either.
+
+**Optional statements** need no separate parameter to be kept: an optional statement is
+dropped by leaving one of its fields empty (`StatementItem.addTriplesTo`), so a locked
+value already forces it to stay. Forcing an optional statement to stay *absent* is a
+different feature — hiding the field rather than locking it — and is deliberately not
+part of this.
+
+## What locking does *not* do
+
+- **It is not enforcement.** The lock lives in the URL, so anyone can edit the URL before
+  loading the form. It prevents accidental edits, not deliberate ones. A wrong key in an
+  introduction is caught where it matters anyway: the signature won't match.
+- **A value lock does not lock the statement.** The "-" button still removes a repetition
+  group, locked value and all — you cannot change the value, but you can drop the whole
+  statement. `locked-statements` is what stops that, and it is deliberately a separate
+  decision.
+
+## Implementation
+
+- `TemplateContext` keeps a `lockedParams` set beside its parameter map, with
+  `setLocked`/`isLocked`/`moveLock`/`clearLock`. `isLocked(IRI)` takes the postfix of the
+  placeholder IRI as handed to the form component, which already carries the repetition
+  suffix — that is where per-repetition granularity comes from for free.
+- `PublishForm.applyLocks` parses both parameters into those contexts, right after the
+  loop that reads the `param_`/`prparam_`/`piparamN_` values; `forEachLockedName` holds
+  the prefix handling both share.
+- `TemplateContext.setStatementLocked`/`isStatementLocked` keep the statement locks, whose
+  names are matched against the statement node and against the placeholders narrow-scoped
+  to it. `StatementItem.updateViewElements` hides the repetition buttons of a locked
+  statement.
+- `AbstractContextComponent.lockIfNeeded` attaches a behavior that marks the field
+  uneditable in the browser, adds an explanatory `title` and a `locked-value` class, and
+  decides at **render** time rather than at construction time, because the lock state can
+  change while the form is open (see below). Every editable placeholder item calls it
+  where it registers its form component.
+
+  The component stays **enabled** as far as Wicket is concerned, and its value keeps being
+  submitted with the form. Disabling it in Wicket looks right and is wrong: the browser
+  sends nothing for a disabled control, and the form then reads the field as an emptied
+  one — the locked value disappears from the field and its required-value check fails.
+  (This is what the live check caught; unit tests that only rendered the form did not.)
+  So text inputs and text areas are marked `readonly`, which browsers do submit, and
+  choice fields — which render as `select`, and HTML has no readonly for those — are
+  marked `disabled` with their value mirrored in a hidden field of the same name. Either
+  way the form receives the locked value, unchanged, and publishes it as it would have
+  anyway.
+- `StatementItem.RepetitionGroup.remove()` shifts locks with the values. Removing a
+  repetition group does not delete a slot: it shifts the values of the following groups
+  up through fixed placeholder slots and drops the last one. The lock belongs to the
+  pre-filled value rather than to the slot, so it has to travel with it — otherwise
+  removing a locked repetition would leave the value that slides into its place
+  uneditable. Only IRIs that actually get a repetition suffix are shifted, under the same
+  condition `transform()` applies; the statement's constants are in the same set and one
+  of them can share a placeholder's postfix (`rdfs:comment` and a `comment` placeholder,
+  say), which would shift the same lock twice and undo it.
+
+Tests: `LockedFieldTest` (per-repetition locking, lock shifting on removal, rendering),
+`PublishFormLockTest` (parameter parsing).

--- a/docs/magic-query-params.md
+++ b/docs/magic-query-params.md
@@ -236,6 +236,14 @@ Today an action carries a single `queryVar:templateParam` mapping that only sets
 `"derive_target:@derive-a local_pubkey:public-key__.1"` — the first drives
 visibility (conditional target), the second supplies the key.
 
+A third form was added later (issue #678): a `!` in front of the field name
+(`local_pubkey:!public-key__.1`) also **locks** the field, so the form shows the
+value the action filled in but does not let the user change it — for values an
+action *determines* rather than proposes, such as the local public key an
+introduction is to declare. It emits the `locked` page parameter alongside the
+`param_` one; see docs/locked-prefilled-values.md. It applies to `param_` targets
+only, as a raw `@` key is not a form field.
+
 ### Echo-as-column (no code)
 
 A query may `SELECT` a magic variable back out

--- a/src/main/java/com/knowledgepixels/nanodash/component/AbstractContextComponent.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AbstractContextComponent.java
@@ -1,7 +1,13 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.template.TemplateContext;
+import org.apache.wicket.Component;
+import org.apache.wicket.behavior.Behavior;
+import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.util.string.Strings;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
@@ -12,6 +18,82 @@ public abstract class AbstractContextComponent extends Panel implements ContextC
 
     protected TemplateContext context;
     protected static ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String LOCKED_FIELD_MESSAGE = "This value is set by the link that opened this form and cannot be changed here.";
+
+    /**
+     * Makes the given form component follow the lock state of the given placeholder: a locked
+     * placeholder is shown with its pre-filled value but cannot be edited (issue #678).
+     * <p>
+     * The component stays enabled as far as Wicket is concerned, and the value keeps being
+     * submitted with the form: a locked field is still an ordinary field holding a value, and
+     * disabling it in Wicket would make the browser send nothing for it, which the form then reads
+     * as an emptied field and reports as a missing required value. Text inputs are marked
+     * {@code readonly}, which browsers submit; anything else (the choice fields, which HTML has no
+     * readonly for) is marked {@code disabled} and its value mirrored in a hidden field of the
+     * same name, so that what reaches the form is the locked value either way.
+     * <p>
+     * The state is decided at render time rather than at construction time, because it can change
+     * while the form is open: removing a repetition group shifts the values of the following
+     * groups up into its slot, and the lock travels with the value (see
+     * {@link TemplateContext#moveLock(String, String)}).
+     * <p>
+     * This is a guardrail rather than enforcement: the lock is stated in the URL that opened the
+     * form, so it stops accidental edits, not deliberate ones.
+     *
+     * @param component the form component to lock when its placeholder is locked
+     * @param iri       the placeholder IRI, including any repetition suffix
+     */
+    protected void lockIfNeeded(final FormComponent<?> component, final IRI iri) {
+        final TemplateContext c = context;
+        component.add(new Behavior() {
+
+            // What the tag turned out to be in this render pass, so that afterRender knows
+            // whether the value still needs a hidden mirror field.
+            private boolean renderedAsTextInput = false;
+
+            @Override
+            public void onComponentTag(Component component, ComponentTag tag) {
+                renderedAsTextInput = isTextInput(tag);
+                if (!c.isLocked(iri)) return;
+                // A field that is simply greyed out leaves the user guessing why they can't type
+                // in it, so say where the value came from.
+                tag.put("title", LOCKED_FIELD_MESSAGE);
+                tag.append("class", "locked-value", " ");
+                if (renderedAsTextInput) {
+                    tag.put("readonly", "readonly");
+                } else {
+                    tag.put("disabled", "disabled");
+                }
+            }
+
+            @Override
+            public void afterRender(Component component) {
+                if (!c.isLocked(iri) || renderedAsTextInput) return;
+                // Browsers don't submit a disabled control, so mirror its value in a hidden field
+                // of the same name to keep the form seeing the value it rendered.
+                FormComponent<?> fc = (FormComponent<?>) component;
+                String value = fc.getValue() == null ? "" : fc.getValue();
+                component.getResponse().write("<input type=\"hidden\" name=\""
+                        + Strings.escapeMarkup(fc.getInputName()) + "\" value=\""
+                        + Strings.escapeMarkup(value) + "\" />");
+            }
+
+        });
+    }
+
+    /**
+     * Whether the tag renders as a control that browsers submit while readonly. Decided on the
+     * rendered tag rather than on the Java class, because a choice field can be a text component
+     * that renders as a {@code select} (the select2-based choice fields are).
+     */
+    private static boolean isTextInput(ComponentTag tag) {
+        String name = tag.getName().toLowerCase();
+        if ("textarea".equals(name)) return true;
+        if (!"input".equals(name)) return false;
+        String type = tag.getAttribute("type");
+        return !"checkbox".equalsIgnoreCase(type) && !"radio".equalsIgnoreCase(type) && !"hidden".equalsIgnoreCase(type);
+    }
 
     /**
      * Constructor for AbstractContextComponent.

--- a/src/main/java/com/knowledgepixels/nanodash/component/AgentChoiceItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AgentChoiceItem.java
@@ -210,6 +210,7 @@ public class AgentChoiceItem extends AbstractContextComponent {
         textfield.add(new AttributeAppender("class", " wide"));
         textfield.add(new Validator(iri, template, "", context));
         context.getComponents().add(textfield);
+        lockIfNeeded(textfield, iri);
 
         tooltipDescription = new Label("description", new IModel<String>() {
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/GuidedChoiceItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/GuidedChoiceItem.java
@@ -217,6 +217,7 @@ public class GuidedChoiceItem extends AbstractContextComponent {
         textfield.add(new AttributeAppender("class", " wide"));
         textfield.add(new Validator(iri, template, prefix, context));
         context.getComponents().add(textfield);
+        lockIfNeeded(textfield, iri);
 
         tooltipDescription = new Label("description", new IModel<String>() {
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/IriTextfieldItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/IriTextfieldItem.java
@@ -116,6 +116,7 @@ public class IriTextfieldItem extends AbstractContextComponent {
         }
         textfield.add(new Validator(iri, template, prefixModel, context));
         context.getComponents().add(textfield);
+        lockIfNeeded(textfield, iri);
         if (template.getLabel(iri) != null) {
             textfield.add(new AttributeModifier("placeholder", template.getLabel(iri).replaceFirst(" - .*$", "")));
             textfield.setLabel(Model.of(template.getLabel(iri)));
@@ -214,6 +215,7 @@ public class IriTextfieldItem extends AbstractContextComponent {
 
         });
         context.getComponents().add(prefixChoice);
+        lockIfNeeded(prefixChoice, iri);
         add(prefixChoice);
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralDateItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralDateItem.java
@@ -74,6 +74,7 @@ public class LiteralDateItem extends AbstractContextComponent {
 
         context.getComponentModels().put(iri, dateComponent.getModel());
         context.getComponents().add(dateComponent);
+        lockIfNeeded(dateComponent, iri);
         dateComponent.add(new ValueItem.KeepValueAfterRefreshBehavior());
         dateComponent.add(new InvalidityHighlighting());
         add(dateComponent);

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralDateTimeItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralDateTimeItem.java
@@ -88,6 +88,7 @@ public class LiteralDateTimeItem extends AbstractContextComponent {
 
         context.getComponentModels().put(iri, zonedDateTimePicker.getModel());
         context.getComponents().add(zonedDateTimePicker);
+        lockIfNeeded(zonedDateTimePicker, iri);
         zonedDateTimePicker.add(new ValueItem.KeepValueAfterRefreshBehavior());
         zonedDateTimePicker.add(new InvalidityHighlighting());
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/LiteralTextfieldItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/LiteralTextfieldItem.java
@@ -105,6 +105,7 @@ public class LiteralTextfieldItem extends AbstractContextComponent {
         });
         context.getComponentModels().put(iri, tc.getModel());
         context.getComponents().add(tc);
+        lockIfNeeded(tc, iri);
         tc.add(new ValueItem.KeepValueAfterRefreshBehavior());
         tc.add(new InvalidityHighlighting());
         add(tc);
@@ -180,6 +181,7 @@ public class LiteralTextfieldItem extends AbstractContextComponent {
         langChoice.add(new ValueItem.KeepValueAfterRefreshBehavior());
         langChoice.add(new LangTagValidator(possibleTags));
         context.getComponents().add(langChoice);
+        lockIfNeeded(langChoice, iri);
         add(langChoice);
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/ProfileAccountPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ProfileAccountPanel.java
@@ -65,6 +65,9 @@ public class ProfileAccountPanel extends Panel {
                     + "&param_key-declaration=" + Utils.urlEncode(shortKey)
                     + "&param_key-declaration-ref=" + Utils.urlEncode(shortKey)
                     + "&param_key-location=" + Utils.urlEncode(prefs.getWebsiteUrl())
+                    // The introduction is about this user and this key: an introduction declaring
+                    // anything else is wrong, so both values are shown but fixed (issue #678).
+                    + "&locked=" + Utils.urlEncode("param_user,param_public-key")
                     + "&context=" + Utils.urlEncode(userIriString)
                     + "&postpub-redirect-url=" + Utils.urlEncode(aboutUrl)
                     + "&link-message=" + Utils.urlEncode("Check the checkbox at the end of this page and press 'Publish' to "

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -34,6 +34,7 @@ import org.apache.wicket.markup.repeater.data.ListDataProvider;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.string.StringValue;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
@@ -65,6 +66,7 @@ import org.wicketstuff.select2.Select2Choice;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
+import java.util.function.BiConsumer;
 
 /**
  * Form for publishing a nanopublication.
@@ -391,6 +393,7 @@ public class PublishForm extends Panel {
                 piParamIdMap.get(i).setParam(n, pageParams.get(k).toString());
             }
         }
+        applyLocks(pageParams, assertionContext, provenanceContext, piParamIdMap);
 
         final Nanopub improveNp;
         if (!pageParams.get("improve").isNull()) {
@@ -1148,6 +1151,69 @@ public class PublishForm extends Panel {
         TemplateContext context = new TemplateContext(contextType, templateId, componentId, targetNamespace);
         context.setNavigationContextId(navigationContextId);
         return context;
+    }
+
+    /**
+     * Applies the locks stated by the {@code locked} and {@code locked-statements} page
+     * parameters to the contexts they belong to (issue #678).
+     * <p>
+     * {@code locked} names the pre-filled values that cannot be changed, so that a link can hand
+     * the form a value the user is not meant to touch, such as the public key of an introduction.
+     * {@code locked-statements} names the statements whose repetitions are fixed, so that a link
+     * can also say that its pre-filled repetitions are the ones to publish: no adding, no
+     * removing.
+     * <p>
+     * Both take the names their target is known by, prefixed to say which template it belongs to:
+     * {@code param_} for the assertion template, {@code prparam_} for the provenance template and
+     * {@code piparamN_} for the Nth publication-info template. A name without a prefix belongs to
+     * the assertion template, which is what a link states in nearly all cases. Several names can
+     * be given as a comma-separated list, as repeated parameters, or both.
+     * <p>
+     * A value lock holds per repetition, as the name carries the repetition suffix of the field it
+     * refers to: {@code param_public-key} locks the first repetition and {@code param_public-key__1}
+     * the second, which is what lets a form pre-fill and lock the keys a user already has while
+     * leaving them free to add more. A statement lock is named either by the statement node
+     * ({@code st2}) or by a placeholder that occurs in that statement and no other
+     * ({@code public-key}).
+     */
+    static void applyLocks(PageParameters pageParams, TemplateContext assertionContext,
+            TemplateContext provenanceContext, Map<Integer, TemplateContext> piParamIdMap) {
+        forEachLockedName(pageParams, "locked", assertionContext, provenanceContext, piParamIdMap,
+                TemplateContext::setLocked);
+        forEachLockedName(pageParams, "locked-statements", assertionContext, provenanceContext, piParamIdMap,
+                TemplateContext::setStatementLocked);
+    }
+
+    /**
+     * Reads one lock parameter and hands each name it holds, stripped of its template prefix, to
+     * the context of that template.
+     */
+    private static void forEachLockedName(PageParameters pageParams, String paramName,
+            TemplateContext assertionContext, TemplateContext provenanceContext,
+            Map<Integer, TemplateContext> piParamIdMap, BiConsumer<TemplateContext, String> lock) {
+        for (StringValue lockedValue : pageParams.getValues(paramName)) {
+            if (lockedValue.isNull()) continue;
+            for (String k : lockedValue.toString().split(",")) {
+                k = k.trim();
+                if (k.isEmpty()) continue;
+                if (k.startsWith("prparam_")) {
+                    lock.accept(provenanceContext, k.substring(8));
+                } else if (k.matches("piparam[1-9][0-9]*_.*")) {
+                    Integer i = Integer.parseInt(k.replaceFirst("^piparam([1-9][0-9]*)_.*$", "$1"));
+                    if (!piParamIdMap.containsKey(i)) {
+                        logger.error("Locked name {} of the publication info template not found", i);
+                        continue;
+                    }
+                    lock.accept(piParamIdMap.get(i), k.replaceFirst("^piparam[1-9][0-9]*_(.*)$", "$1"));
+                } else if (k.startsWith("param_")) {
+                    lock.accept(assertionContext, k.substring(6));
+                } else {
+                    // Bare names refer to the assertion template, which is what a link locks in
+                    // nearly all cases.
+                    lock.accept(assertionContext, k);
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/RestrictedChoiceItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/RestrictedChoiceItem.java
@@ -146,6 +146,7 @@ public class RestrictedChoiceItem extends AbstractContextComponent {
         choice.add(new ValueItem.KeepValueAfterRefreshBehavior());
         choice.add(new Validator());
         context.getComponents().add(choice);
+        lockIfNeeded(choice, iri);
 
         tooltipDescription = new Label("description", new IModel<String>() {
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/StatementItem.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.template.ContextType;
 import com.knowledgepixels.nanodash.template.Template;
 import com.knowledgepixels.nanodash.template.TemplateContext;
@@ -120,8 +121,12 @@ public class StatementItem extends Panel {
             viewElements.addAll(r.getShownStatementParts());
             boolean isOnly = repetitionGroups.size() == 1;
             boolean isLast = repetitionGroups.get(repetitionGroups.size() - 1) == r;
-            r.addRepetitionButton.setVisible(!context.isReadOnly() && isRepeatable() && isLast);
-            r.removeRepetitionButton.setVisible(!context.isReadOnly() && isRepeatable() && !isOnly);
+            // A locked statement has the set of repetitions the form was opened with (issue #678):
+            // no adding, no removing. Hiding the buttons is enough to enforce it, as Wicket does
+            // not invoke a listener of a component that is not visible.
+            boolean statementLocked = context.isStatementLocked(statementId);
+            r.addRepetitionButton.setVisible(!context.isReadOnly() && isRepeatable() && isLast && !statementLocked);
+            r.removeRepetitionButton.setVisible(!context.isReadOnly() && isRepeatable() && !isOnly && !statementLocked);
             r.optionalMark.setVisible(isOnly);
             first = false;
         }
@@ -175,6 +180,15 @@ public class StatementItem extends Panel {
      */
     public int getRepetitionCount() {
         return repetitionGroups.size();
+    }
+
+    /**
+     * Returns the IRI of the statement node this item was built from.
+     *
+     * @return the statement IRI
+     */
+    public IRI getStatementId() {
+        return statementId;
     }
 
     /**
@@ -553,6 +567,24 @@ public class StatementItem extends Panel {
                         }
                     }
                 }
+            }
+            // The lock of a pre-filled value belongs to the value, not to the slot it sits in, so
+            // it has to travel with the value that shifts up (issue #678). Without this, removing
+            // a locked repetition would leave the value that slides into its place uneditable.
+            // Only the IRIs that actually get a repetition suffix are shifted, under the same
+            // condition transform() applies: iriSet also holds the constants of the statement,
+            // and one of those can share the postfix of a placeholder (rdfs:comment and a
+            // "comment" placeholder, say), which would shift the same lock twice and undo it.
+            Set<String> shiftedLockBases = new HashSet<>();
+            for (IRI iriBase : iriSet) {
+                if (!context.hasNarrowScope(iriBase)) continue;
+                if (!getTemplate().isPlaceholder(iriBase) && !getTemplate().isLocalResource(iriBase)) continue;
+                String lockBase = Utils.getUriPostfix(iriBase);
+                if (!shiftedLockBases.add(lockBase)) continue;
+                for (int i = getRepeatIndex(); i < repetitionGroups.size() - 1; i++) {
+                    context.moveLock(lockBase + getRepeatSuffix(i + 1), lockBase + getRepeatSuffix(i));
+                }
+                context.clearLock(lockBase + getRepeatSuffix(repetitionGroups.size() - 1));
             }
             RepetitionGroup lastGroup = repetitionGroups.get(repetitionGroups.size() - 1);
             repetitionGroups.remove(lastGroup);

--- a/src/main/java/com/knowledgepixels/nanodash/component/ValueTextfieldItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ValueTextfieldItem.java
@@ -60,6 +60,7 @@ public class ValueTextfieldItem extends AbstractContextComponent {
         if (!optional) textfield.setRequired(true);
         textfield.add(new Validator(iri, template));
         context.getComponents().add(textfield);
+        lockIfNeeded(textfield, iri);
         if (template.getLabel(iri) != null) {
             textfield.add(new AttributeModifier("placeholder", template.getLabel(iri)));
             textfield.setLabel(Model.of(template.getLabel(iri)));

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewActionMappings.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewActionMappings.java
@@ -41,7 +41,11 @@ class ViewActionMappings {
      * <p>Each mapping is {@code "col:target"}: the row's value for result column
      * {@code col} is written to URL parameter {@code param_target}, or — when
      * {@code target} starts with {@code @} — to the raw URL key {@code target}
-     * (fill-mode keys such as {@code @derive-a} / {@code @supersede}). The button is
+     * (fill-mode keys such as {@code @derive-a} / {@code @supersede}). A {@code target}
+     * written as {@code !field} additionally locks the field, so the form shows the
+     * value the action filled in but does not let the user change it
+     * (docs/locked-prefilled-values.md); this is for values an action determines rather
+     * than proposes, such as the local public key an introduction is to declare. The button is
      * <b>hidden</b> (returns false) if any <i>required</i> mapped value is empty: a
      * raw key is always required; a {@code param_} target is required unless its
      * template placeholder is optional. Empty values for optional placeholders are
@@ -197,6 +201,11 @@ class ViewActionMappings {
             String target = mapping.substring(sep + 1);
             boolean rawKey = target.startsWith("@");
             String key = rawKey ? target.substring(1) : target;
+            // A "!" in front of the field name says that what the action fills in is not the
+            // user's to change (issue #678): the field is shown with the value but locked. Only
+            // meaningful for a template field, as a raw key is not a form field.
+            boolean locked = !rawKey && key.startsWith("!");
+            if (locked) key = key.substring(1);
             String value = row.get(col);
             if (value == null || value.isBlank()) {
                 // Empty: hide the action only if the target is required.
@@ -204,6 +213,7 @@ class ViewActionMappings {
                 continue;
             }
             params.set(rawKey ? key : "param_" + key, value);
+            if (locked) params.add("locked", "param_" + key);
         }
         return true;
     }

--- a/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/template/TemplateContext.java
@@ -38,6 +38,8 @@ public class TemplateContext implements Serializable {
     private final Template template;
     private final String componentId;
     private final Map<String, String> params = new HashMap<>();
+    private final Set<String> lockedParams = new HashSet<>();
+    private final Set<String> lockedStatements = new HashSet<>();
     private List<Component> components = new ArrayList<>();
     private final Map<IRI, IModel<?>> componentModels = new HashMap<>();
     private Set<IRI> introducedIris = new HashSet<>();
@@ -140,6 +142,9 @@ public class TemplateContext implements Serializable {
                     String param = postfix + "__" + absPos;
                     if (i - corr == 0) param = postfix;
                     setParam(param, getParam(p));
+                    // A lock stated on the relative name has to follow the value to the
+                    // absolute name it ends up under, or it would never match a placeholder.
+                    if (isLocked(p)) setLocked(param);
                     finalRepetitionCount.put(si, i - corr);
                 } else {
                     break;
@@ -242,6 +247,111 @@ public class TemplateContext implements Serializable {
      */
     public boolean hasParam(String name) {
         return params.containsKey(name);
+    }
+
+    /**
+     * Marks a parameter as locked: the form field it pre-fills is shown but cannot be edited
+     * (issue #678). Locking is per repetition, as the name carries the repetition suffix of the
+     * field it refers to ("key" locks the first repetition, "key__1" the second, and so on).
+     * Locking a value the user cannot see or reach would leave the form unfillable, so only
+     * parameters that actually carry a value can be locked.
+     *
+     * @param name the name of the parameter to lock
+     */
+    public void setLocked(String name) {
+        if (!hasParam(name)) {
+            logger.warn("Ignoring lock on parameter {}, which has no value in this context", name);
+            return;
+        }
+        lockedParams.add(name);
+    }
+
+    /**
+     * Checks whether the given parameter name is locked.
+     *
+     * @param name the name of the parameter
+     * @return true if the parameter is locked, false otherwise
+     */
+    public boolean isLocked(String name) {
+        return lockedParams.contains(name);
+    }
+
+    /**
+     * Checks whether the given placeholder is locked, i.e. pre-filled with a value the user is
+     * not allowed to change. The placeholder IRI carries the repetition suffix of its repetition
+     * group (see {@link StatementItem.RepetitionGroup}), so this holds per repetition: the second
+     * repetition of a locked placeholder is editable unless it was locked in its own right.
+     *
+     * @param iri the placeholder IRI, as handed to the form component
+     * @return true if the placeholder is locked, false otherwise
+     */
+    public boolean isLocked(IRI iri) {
+        if (iri == null) return false;
+        return isLocked(Utils.getUriPostfix(iri));
+    }
+
+    /**
+     * Moves the lock of one parameter to another, used when removing a repetition group shifts
+     * the values of the following groups up into its slot ({@link StatementItem.RepetitionGroup}
+     * shifts values through fixed placeholder slots rather than deleting one). The lock belongs
+     * to the pre-filled value, not to the slot, so it has to travel with the value: otherwise
+     * removing a locked repetition would leave the value that slides up into its place
+     * uneditable.
+     *
+     * @param fromName the parameter name the value is moving away from
+     * @param toName   the parameter name the value is moving to
+     */
+    public void moveLock(String fromName, String toName) {
+        if (lockedParams.remove(fromName)) {
+            lockedParams.add(toName);
+        } else {
+            lockedParams.remove(toName);
+        }
+    }
+
+    /**
+     * Removes the lock of the given parameter, if any.
+     *
+     * @param name the name of the parameter to unlock
+     */
+    public void clearLock(String name) {
+        lockedParams.remove(name);
+    }
+
+    /**
+     * Marks a statement as locked: the user cannot add or remove repetitions of it (issue #678).
+     * Unlike a locked value, which is a guardrail against accidental edits, this one holds:
+     * Wicket does not invoke a listener of a component that is not visible, so the hidden
+     * repetition buttons cannot be triggered from the browser either.
+     * <p>
+     * The name is resolved when the lock is queried rather than here, because the statements are
+     * only built later ({@link #initStatements()}): it matches either the name of the statement
+     * node itself ("st2") or the name of a placeholder used in that statement and no other
+     * ("public-key"), which is the name a link author is more likely to have at hand.
+     *
+     * @param name the name of the statement, or of a placeholder that identifies it
+     */
+    public void setStatementLocked(String name) {
+        lockedStatements.add(name);
+    }
+
+    /**
+     * Checks whether the given statement is locked, i.e. whether its repetitions are fixed.
+     *
+     * @param statementId the IRI of the statement node
+     * @return true if the statement is locked, false otherwise
+     */
+    public boolean isStatementLocked(IRI statementId) {
+        if (statementId == null || lockedStatements.isEmpty()) return false;
+        if (lockedStatements.contains(Utils.getUriPostfix(statementId))) return true;
+        // A placeholder used in a single statement names that statement unambiguously; one used
+        // in several is wide-scope and names none of them.
+        for (Map.Entry<IRI, StatementItem> e : narrowScopeMap.entrySet()) {
+            if (e.getValue() == null) continue;
+            if (!lockedStatements.contains(Utils.getUriPostfix(e.getKey()))) continue;
+            if (statementId.equals(e.getValue().getStatementId())) return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -1773,6 +1773,16 @@ span.nanopub-assertion, span.nanopub-provenance, span.nanopub-pubinfo {
   white-space: pre-wrap;
 }
 
+/* Pre-filled value that the link opening the form stated as locked (issue #678): shown with
+   its value, but not editable. */
+.locked-value,
+input.locked-value,
+textarea.locked-value {
+  background: #f2f2f2;
+  color: #555;
+  cursor: not-allowed;
+}
+
 .litlang {
   font-size: 9pt !important;
   color: #0006 !important;

--- a/src/test/java/com/knowledgepixels/nanodash/component/PublishFormLockTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/PublishFormLockTest.java
@@ -1,0 +1,183 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.template.ContextType;
+import com.knowledgepixels.nanodash.template.Template;
+import com.knowledgepixels.nanodash.template.TemplateContext;
+import com.knowledgepixels.nanodash.template.TemplateData;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the parsing of the {@code locked} page parameter, which states that a pre-filled
+ * value cannot be changed in the form (issue #678).
+ */
+class PublishFormLockTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI COMMENT = vf.createIRI(NP_URI + "/comment");
+
+    private MockedStatic<TemplateData> templateDataMockedStatic;
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+        templateDataMockedStatic = mockStatic(TemplateData.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        templateDataMockedStatic.close();
+    }
+
+    private TemplateContext context() {
+        // The lock parsing only touches parameter names, so a stub template is enough here;
+        // the per-repetition behaviour on real templates is covered by LockedFieldTest.
+        Template template = mock(Template.class);
+        TemplateData templateDataMock = mock(TemplateData.class);
+        templateDataMockedStatic.when(TemplateData::get).thenReturn(templateDataMock);
+        when(templateDataMock.getTemplate(NP_URI)).thenReturn(template);
+        return new TemplateContext(ContextType.ASSERTION, NP_URI, "statement", (String) null);
+    }
+
+    /**
+     * Applies the given {@code locked} values to three prepared contexts, each holding the same
+     * two parameters, and returns them as [assertion, provenance, pubinfo].
+     */
+    private TemplateContext[] applyLocks(String... lockedValues) {
+        TemplateContext assertion = context();
+        TemplateContext provenance = context();
+        TemplateContext pubinfo = context();
+        for (TemplateContext c : new TemplateContext[]{assertion, provenance, pubinfo}) {
+            c.setParam("comment", "first");
+            c.setParam("comment__1", "second");
+        }
+        Map<Integer, TemplateContext> piParamIdMap = new HashMap<>();
+        piParamIdMap.put(1, pubinfo);
+        PageParameters params = new PageParameters();
+        for (String v : lockedValues) params.add("locked", v);
+        PublishForm.applyLocks(params, assertion, provenance, piParamIdMap);
+        return new TemplateContext[]{assertion, provenance, pubinfo};
+    }
+
+    /**
+     * Same, for the statement lock: statement names need no value in the context, so the contexts
+     * are handed the names straight from the parameter.
+     */
+    private TemplateContext[] applyStatementLocks(String... lockedValues) {
+        TemplateContext assertion = context();
+        TemplateContext provenance = context();
+        TemplateContext pubinfo = context();
+        Map<Integer, TemplateContext> piParamIdMap = new HashMap<>();
+        piParamIdMap.put(1, pubinfo);
+        PageParameters params = new PageParameters();
+        for (String v : lockedValues) params.add("locked-statements", v);
+        PublishForm.applyLocks(params, assertion, provenance, piParamIdMap);
+        return new TemplateContext[]{assertion, provenance, pubinfo};
+    }
+
+    @Test
+    void statementLocksGoToTheirOwnContext() {
+        TemplateContext[] c = applyStatementLocks("st1,prparam_st2", "piparam1_st3");
+        assertTrue(c[0].isStatementLocked(vf.createIRI(NP_URI + "/st1")));
+        assertFalse(c[0].isStatementLocked(vf.createIRI(NP_URI + "/st2")));
+        assertTrue(c[1].isStatementLocked(vf.createIRI(NP_URI + "/st2")));
+        assertTrue(c[2].isStatementLocked(vf.createIRI(NP_URI + "/st3")));
+        assertFalse(c[2].isStatementLocked(vf.createIRI(NP_URI + "/st1")));
+    }
+
+    /**
+     * The two parameters are independent: locking a value does not fix the repetitions of the
+     * statement holding it, and locking a statement does not make its values uneditable.
+     */
+    @Test
+    void theTwoLockParametersDoNotAffectEachOther() {
+        TemplateContext assertion = context();
+        assertion.setParam("comment", "a value");
+        Map<Integer, TemplateContext> piParamIdMap = new HashMap<>();
+        PageParameters params = new PageParameters();
+        params.add("locked", "param_comment");
+        PublishForm.applyLocks(params, assertion, context(), piParamIdMap);
+        assertTrue(assertion.isLocked("comment"));
+        assertFalse(assertion.isStatementLocked(vf.createIRI(NP_URI + "/st1")));
+
+        TemplateContext other = context();
+        other.setParam("comment", "a value");
+        PageParameters stParams = new PageParameters();
+        stParams.add("locked-statements", "st1");
+        PublishForm.applyLocks(stParams, other, context(), piParamIdMap);
+        assertTrue(other.isStatementLocked(vf.createIRI(NP_URI + "/st1")));
+        assertFalse(other.isLocked("comment"));
+    }
+
+    @Test
+    void bareNameLocksAssertionParam() {
+        TemplateContext[] c = applyLocks("comment");
+        assertTrue(c[0].isLocked("comment"));
+        assertFalse(c[1].isLocked("comment"));
+        assertFalse(c[2].isLocked("comment"));
+    }
+
+    @Test
+    void prefixedNamesLockTheirOwnContext() {
+        TemplateContext[] c = applyLocks("param_comment,prparam_comment__1,piparam1_comment");
+        assertTrue(c[0].isLocked("comment"));
+        assertFalse(c[0].isLocked("comment__1"));
+        assertTrue(c[1].isLocked("comment__1"));
+        assertFalse(c[1].isLocked("comment"));
+        assertTrue(c[2].isLocked("comment"));
+    }
+
+    /**
+     * A locked repetition must not lock the others: pre-filling and locking the keys a user
+     * already has has to leave them free to add more (issue #678).
+     */
+    @Test
+    void lockingOneRepetitionLeavesTheOthersEditable() {
+        TemplateContext[] c = applyLocks("param_comment");
+        assertTrue(c[0].isLocked(COMMENT));
+        assertFalse(c[0].isLocked(vf.createIRI(NP_URI + "/comment__1")));
+    }
+
+    @Test
+    void repeatedAndListedNamesAreBothAccepted() {
+        TemplateContext[] c = applyLocks("param_comment", " param_comment__1 ");
+        assertTrue(c[0].isLocked("comment"));
+        assertTrue(c[0].isLocked("comment__1"));
+    }
+
+    /**
+     * Locking a field the form has no value for would leave it empty and uneditable, which for a
+     * required field means the form can never be published.
+     */
+    @Test
+    void lockOnParamWithoutValueIsIgnored() {
+        TemplateContext[] c = applyLocks("param_nosuchparam");
+        assertFalse(c[0].isLocked("nosuchparam"));
+    }
+
+    @Test
+    void emptyAndUnknownPubinfoLocksAreIgnored() {
+        TemplateContext[] c = applyLocks("", "piparam9_comment,,param_comment");
+        assertTrue(c[0].isLocked("comment"));
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/component/ViewActionMappingsTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/ViewActionMappingsTest.java
@@ -106,4 +106,61 @@ class ViewActionMappingsTest {
         assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, mock(ApiResponseEntry.class), params));
     }
 
+
+    /**
+     * A "!" in front of the field name locks it: the action fills the value in and the form does
+     * not let the user change it (issue #678). Used for values an action determines rather than
+     * proposes, such as the local public key an introduction is to declare.
+     */
+    @Test
+    void lockMarkerFillsTheFieldAndLocksIt() {
+        View view = viewWith(List.of("col:!foo"), templateWhereRequired("foo"));
+        PageParameters params = new PageParameters();
+        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", "v"), params));
+        assertEquals("v", params.get("param_foo").toString());
+        assertEquals("param_foo", params.get("locked").toString());
+    }
+
+    @Test
+    void severalLockedMappingsAccumulate() {
+        Template template = templateWhereRequired("foo", "bar", "baz");
+        View view = mock(View.class);
+        when(view.getTemplateQueryMappings(ACTION)).thenReturn(List.of("c1:!foo", "c2:bar", "c3:!baz"));
+        when(view.getTemplateForAction(ACTION)).thenReturn(template);
+        ApiResponseEntry e = mock(ApiResponseEntry.class);
+        when(e.get("c1")).thenReturn("v1");
+        when(e.get("c2")).thenReturn("v2");
+        when(e.get("c3")).thenReturn("v3");
+        PageParameters params = new PageParameters();
+        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, e, params));
+        assertEquals(List.of("param_foo", "param_baz"),
+                params.getValues("locked").stream().map(Object::toString).toList());
+        assertEquals("v2", params.get("param_bar").toString());
+    }
+
+    /**
+     * The marker must not leak into the field name: an unlocked mapping of the same field is
+     * unaffected, and a locked field that is empty is judged required-or-not by its real name.
+     */
+    @Test
+    void lockMarkerIsStrippedFromTheFieldName() {
+        View view = viewWith(List.of("col:!foo"), templateWhereRequired("foo"));
+        PageParameters params = new PageParameters();
+        assertFalse(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", ""), params));
+        assertTrue(params.get("param_foo").isNull());
+        assertTrue(params.get("locked").isNull());
+    }
+
+    /**
+     * Raw keys are fill-mode switches rather than form fields, so the marker does not apply to
+     * them and stays part of the key.
+     */
+    @Test
+    void lockMarkerDoesNotApplyToRawKeys() {
+        View view = viewWith(List.of("col:@derive-a"), templateWhereRequired());
+        PageParameters params = new PageParameters();
+        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", "np123"), params));
+        assertTrue(params.get("locked").isNull());
+    }
+
 }

--- a/src/test/java/com/knowledgepixels/nanodash/template/LockedFieldTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/template/LockedFieldTest.java
@@ -1,0 +1,412 @@
+package com.knowledgepixels.nanodash.template;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.component.StatementItem;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for locked pre-filled fields (issue #678): locking holds per repetition, and the lock
+ * belongs to the pre-filled value rather than to the repetition slot it sits in, so it travels
+ * with the value when a repetition group is removed.
+ */
+public class LockedFieldTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+    private static final IRI ST1 = vf.createIRI(NP_URI + "/st1");
+    private static final IRI COMMENT = vf.createIRI(NP_URI + "/comment");
+    private static final IRI COMMENT_REP1 = vf.createIRI(NP_URI + "/comment__1");
+    private static final IRI COMMENT_REP2 = vf.createIRI(NP_URI + "/comment__2");
+
+    private MockedStatic<TemplateData> templateDataMockedStatic;
+    private WicketTester tester;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester(new WicketApplication());
+        templateDataMockedStatic = mockStatic(TemplateData.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        templateDataMockedStatic.close();
+    }
+
+    /**
+     * A template with one repeatable statement holding a single literal placeholder, mirroring
+     * the repeatable key group of the "Introducing a user" template.
+     */
+    private TemplateContext repeatableContext() throws Exception {
+        NanopubCreator creator = new NanopubCreator(NP_URI);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Lock test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, ST1);
+        creator.addAssertionStatement(ST1, RDF.TYPE, NTEMPLATE.REPEATABLE_STATEMENT);
+        creator.addAssertionStatement(ST1, RDF.SUBJECT, vf.createIRI("http://example.com/subject"));
+        creator.addAssertionStatement(ST1, RDF.PREDICATE, RDFS.COMMENT);
+        creator.addAssertionStatement(ST1, RDF.OBJECT, COMMENT);
+        creator.addAssertionStatement(COMMENT, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(COMMENT, RDFS.LABEL, vf.createLiteral("comment"));
+        Template template = new Template(creator.finalizeNanopub());
+
+        TemplateData templateDataMock = mock(TemplateData.class);
+        templateDataMockedStatic.when(TemplateData::get).thenReturn(templateDataMock);
+        when(templateDataMock.getTemplate(NP_URI)).thenReturn(template);
+
+        return new TemplateContext(ContextType.ASSERTION, NP_URI, "statement", (String) null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private IModel<Object> model(TemplateContext context, IRI key) {
+        return (IModel<Object>) context.getComponentModels().get(key);
+    }
+
+    private void removeRepetitionGroup(StatementItem si, int index) throws Exception {
+        Field rgsField = StatementItem.class.getDeclaredField("repetitionGroups");
+        rgsField.setAccessible(true);
+        List<?> rgs = (List<?>) rgsField.get(si);
+        Object rg = rgs.get(index);
+        Method removeMethod = rg.getClass().getDeclaredMethod("remove");
+        removeMethod.setAccessible(true);
+        removeMethod.invoke(rg);
+    }
+
+    /**
+     * Two pre-filled repetitions produce two repetition groups, so a link can hand the form the
+     * values a user already has.
+     */
+    @Test
+    void prefilledRepetitionsProduceTheirOwnGroups() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment", "first");
+        context.setParam("comment__1", "second");
+        context.initStatements();
+        context.finalizeStatements();
+        assertEquals(2, context.getStatementItems().get(0).getRepetitionCount());
+    }
+
+    /**
+     * The point of the issue: the pre-filled repetitions are locked, but a repetition the user
+     * adds afterwards is theirs to fill.
+     */
+    @Test
+    void lockHoldsPerRepetition() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment", "first");
+        context.setParam("comment__1", "second");
+        context.setLocked("comment");
+        context.setLocked("comment__1");
+        context.initStatements();
+        context.finalizeStatements();
+
+        StatementItem si = context.getStatementItems().get(0);
+        si.addRepetitionGroup();
+
+        assertTrue(context.isLocked(COMMENT));
+        assertTrue(context.isLocked(COMMENT_REP1));
+        assertFalse(context.isLocked(COMMENT_REP2), "a repetition the user adds must stay editable");
+    }
+
+    /**
+     * Removing a repetition group shifts the values of the following groups up into its slot, so
+     * the lock has to shift with them: the value that lands in the locked slot is the user's own
+     * and must stay editable.
+     */
+    @Test
+    void removingTheLockedRepetitionUnlocksTheSlot() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment", "locked value");
+        context.setLocked("comment");
+        context.initStatements();
+        context.finalizeStatements();
+
+        StatementItem si = context.getStatementItems().get(0);
+        si.addRepetitionGroup();
+        model(context, COMMENT_REP1).setObject("user value");
+
+        removeRepetitionGroup(si, 0);
+
+        assertEquals("user value", model(context, COMMENT).getObject());
+        assertFalse(context.isLocked(COMMENT), "the user's own value must not inherit the lock of the removed one");
+        assertFalse(context.isLocked(COMMENT_REP1));
+    }
+
+    /**
+     * Removing an unrelated repetition leaves the locked one alone.
+     */
+    @Test
+    void removingAnotherRepetitionKeepsTheLock() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment", "locked value");
+        context.setLocked("comment");
+        context.initStatements();
+        context.finalizeStatements();
+
+        StatementItem si = context.getStatementItems().get(0);
+        si.addRepetitionGroup();
+        model(context, COMMENT_REP1).setObject("user value");
+
+        removeRepetitionGroup(si, 1);
+
+        assertEquals("locked value", model(context, COMMENT).getObject());
+        assertTrue(context.isLocked(COMMENT));
+        assertFalse(context.isLocked(COMMENT_REP1));
+    }
+
+    /**
+     * With the second of three repetitions locked, removing the first has to carry the lock down
+     * to the slot the locked value moves into.
+     */
+    @Test
+    void lockFollowsTheValueItBelongsTo() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment", "free value");
+        context.setParam("comment__1", "locked value");
+        context.setLocked("comment__1");
+        context.initStatements();
+        context.finalizeStatements();
+
+        StatementItem si = context.getStatementItems().get(0);
+        assertEquals(2, si.getRepetitionCount());
+
+        removeRepetitionGroup(si, 0);
+
+        assertEquals("locked value", model(context, COMMENT).getObject());
+        assertTrue(context.isLocked(COMMENT), "the lock must travel with the value that moved up");
+        assertFalse(context.isLocked(COMMENT_REP1));
+    }
+
+    /**
+     * A lock stated on the relative repetition name has to end up on the absolute name the value
+     * is filed under, or it would never match a placeholder.
+     */
+    @Test
+    void relativeRepetitionNameLockIsCarriedOver() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment__.1", "locked value");
+        context.setLocked("comment__.1");
+        context.initStatements();
+        context.finalizeStatements();
+
+        assertTrue(context.isLocked(COMMENT));
+    }
+
+    /**
+     * The rendered field carries the pre-filled value and is marked readonly, with a title saying
+     * where the value came from. Readonly rather than disabled: browsers submit readonly fields,
+     * and a field the browser does not submit is read by the form as an emptied one.
+     */
+    @Test
+    void lockedFieldRendersReadonlyWithItsValue() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment", "locked value");
+        context.setLocked("comment");
+        context.initStatements();
+        context.finalizeStatements();
+
+        tester.startComponentInPage(context.getStatementItems().get(0));
+        String html = tester.getLastResponseAsString();
+        assertTrue(html.contains("locked value"), html);
+        assertTrue(html.contains("readonly=\"readonly\""), html);
+        assertTrue(html.contains("locked-value"), html);
+        assertTrue(html.contains("cannot be changed here"), html);
+    }
+
+    /**
+     * The repetition the user adds next to a locked one renders as an ordinary editable field.
+     */
+    @Test
+    void unlockedRepetitionRendersEditable() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment", "locked value");
+        context.setLocked("comment");
+        context.initStatements();
+        context.finalizeStatements();
+        StatementItem si = context.getStatementItems().get(0);
+        si.addRepetitionGroup();
+
+        tester.startComponentInPage(si);
+        String html = tester.getLastResponseAsString();
+        assertEquals(1, html.split("readonly=\"readonly\"", -1).length - 1,
+                "only the locked repetition may render as readonly: " + html);
+    }
+
+    /**
+     * A choice field renders as a {@code select}, which HTML has no readonly for, so it is
+     * disabled and its value mirrored in a hidden field of the same name — without that mirror
+     * the browser would submit nothing for it and the form would read the field as emptied.
+     */
+    @Test
+    void lockedChoiceFieldIsDisabledWithAHiddenMirror() throws Exception {
+        String npUri = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Choice";
+        IRI st1 = vf.createIRI(npUri + "/st1");
+        IRI colour = vf.createIRI(npUri + "/colour");
+        NanopubCreator creator = new NanopubCreator(npUri);
+        creator.addProvenanceStatement(vf.createStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri()));
+        creator.addPubinfoStatement(vf.createStatement(creator.getNanopubUri(), RDFS.SEEALSO, creator.getNanopubUri()));
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Choice lock test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st1);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, vf.createIRI("http://example.com/subject"));
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.SEEALSO);
+        creator.addAssertionStatement(st1, RDF.OBJECT, colour);
+        creator.addAssertionStatement(colour, RDF.TYPE, NTEMPLATE.RESTRICTED_CHOICE_PLACEHOLDER);
+        creator.addAssertionStatement(colour, RDFS.LABEL, vf.createLiteral("colour"));
+        creator.addAssertionStatement(colour, NTEMPLATE.POSSIBLE_VALUE, vf.createIRI("http://example.com/red"));
+        creator.addAssertionStatement(colour, NTEMPLATE.POSSIBLE_VALUE, vf.createIRI("http://example.com/blue"));
+        Template template = new Template(creator.finalizeNanopub());
+        TemplateData templateDataMock = mock(TemplateData.class);
+        templateDataMockedStatic.when(TemplateData::get).thenReturn(templateDataMock);
+        when(templateDataMock.getTemplate(npUri)).thenReturn(template);
+
+        TemplateContext context = new TemplateContext(ContextType.ASSERTION, npUri, "statement", (String) null);
+        context.setParam("colour", "http://example.com/red");
+        context.setLocked("colour");
+        context.initStatements();
+        context.finalizeStatements();
+
+        tester.startComponentInPage(context.getStatementItems().get(0));
+        String html = tester.getLastResponseAsString();
+        assertTrue(html.contains("disabled=\"disabled\""), html);
+        assertTrue(html.contains("type=\"hidden\""), html);
+        assertTrue(html.contains("http://example.com/red"), html);
+    }
+
+    /**
+     * A locked statement keeps the repetitions the form was opened with: the buttons that add and
+     * remove them are gone. Hiding them is enough — Wicket does not invoke a listener of a
+     * component that is not visible — so unlike a locked value this one is not just a guardrail.
+     */
+    @Test
+    void lockedStatementHidesTheRepetitionButtons() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment", "first");
+        context.setParam("comment__1", "second");
+        context.setStatementLocked("st1");
+        context.initStatements();
+        context.finalizeStatements();
+
+        StatementItem si = context.getStatementItems().get(0);
+        assertEquals(2, si.getRepetitionCount());
+        tester.startComponentInPage(si);
+        String html = tester.getLastResponseAsString();
+        assertFalse(html.contains(">+<"), "the add-repetition button must be gone: " + html);
+        assertFalse(html.contains(">-<"), "the remove-repetition button must be gone: " + html);
+        assertTrue(html.contains("first") && html.contains("second"), html);
+    }
+
+    /**
+     * Without the lock the same statement shows both buttons, so the assertion above is about the
+     * lock and not about the markup.
+     */
+    @Test
+    void unlockedStatementShowsTheRepetitionButtons() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment", "first");
+        context.setParam("comment__1", "second");
+        context.initStatements();
+        context.finalizeStatements();
+
+        tester.startComponentInPage(context.getStatementItems().get(0));
+        String html = tester.getLastResponseAsString();
+        assertTrue(html.contains(">+<"), html);
+        assertTrue(html.contains(">-<"), html);
+    }
+
+    /**
+     * A statement can also be named by a placeholder that occurs in it and no other, which is the
+     * name a link author is more likely to have at hand.
+     */
+    @Test
+    void statementCanBeLockedByOneOfItsPlaceholders() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment", "first");
+        context.setStatementLocked("comment");
+        context.initStatements();
+        context.finalizeStatements();
+
+        StatementItem si = context.getStatementItems().get(0);
+        assertTrue(context.isStatementLocked(si.getStatementId()));
+        tester.startComponentInPage(si);
+        assertFalse(tester.getLastResponseAsString().contains(">+<"));
+    }
+
+    /**
+     * A name that matches neither the statement nor one of its placeholders locks nothing.
+     */
+    @Test
+    void unrelatedStatementLockDoesNothing() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment", "first");
+        context.setStatementLocked("nosuchthing");
+        context.initStatements();
+        context.finalizeStatements();
+
+        StatementItem si = context.getStatementItems().get(0);
+        assertFalse(context.isStatementLocked(si.getStatementId()));
+        tester.startComponentInPage(si);
+        assertTrue(tester.getLastResponseAsString().contains(">+<"));
+    }
+
+    /**
+     * Locking the value and locking the statement are independent: a locked value in a statement
+     * that is not locked can still be dropped by removing its repetition, which is the split the
+     * two parameters are there to make.
+     */
+    @Test
+    void valueLockAndStatementLockAreIndependent() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setParam("comment", "locked value");
+        context.setParam("comment__1", "free value");
+        context.setLocked("comment");
+        context.initStatements();
+        context.finalizeStatements();
+
+        StatementItem si = context.getStatementItems().get(0);
+        assertFalse(context.isStatementLocked(si.getStatementId()));
+        tester.startComponentInPage(si);
+        String html = tester.getLastResponseAsString();
+        assertTrue(html.contains("readonly=\"readonly\""), html);
+        assertTrue(html.contains(">-<"), "a locked value must not by itself fix the repetitions: " + html);
+    }
+
+    /**
+     * Locking a name the form has no value for would leave a field empty and uneditable, and a
+     * required one would make the form unpublishable.
+     */
+    @Test
+    void lockWithoutValueIsIgnored() throws Exception {
+        TemplateContext context = repeatableContext();
+        context.setLocked("comment");
+        assertFalse(context.isLocked(COMMENT));
+    }
+
+}


### PR DESCRIPTION
Closes #678.

A link into the publish form can pre-fill fields with URL parameters, but some of those values are not the user's to change: the "Create Introduction" link fills in the public key of the local key pair, and an introduction declaring a different key is simply wrong.

## Two new page parameters

**`locked`** names the pre-filled values that cannot be changed:

```
/publish?template=…&param_public-key=<key>&locked=param_public-key
```

It holds **per repetition**, as the name carries the repetition suffix of the field it refers to (`param_public-key` is the first key group, `param_public-key__1` the second). That is what lets a link pre-fill and fix the keys a user already has while leaving them free to add more with "+".

**`locked-statements`** names the statements whose repetitions are fixed — no adding, no removing:

```
&param_public-key=<key A>&param_public-key__1=<key B>
&locked=param_public-key,param_public-key__1&locked-statements=public-key
```

A statement is named either by its node in the template (`st2`) or by a placeholder that occurs in it and no other (`public-key`). Resolved when the lock is queried rather than when it is parsed, since the statements are only built afterwards.

Both take the same template prefixes as the pre-fill parameters (`param_` / `prparam_` / `piparamN_`; a bare name means the assertion template), accept comma-separated lists and repetition, and are independent of each other: a locked value in an unlocked statement can still be dropped by removing its repetition, and a locked statement's values stay editable unless `locked` names them too.

## Two things worth reviewing

**The field stays enabled in Wicket.** Disabling it looks right and is wrong: the browser sends nothing for a disabled control, and the form then reads the field as an emptied one — the value disappears and its required check fails. Text inputs get `readonly`, which browsers submit; choice fields render as `select`, which HTML has no readonly for, so they are `disabled` with the value mirrored in a hidden field of the same name. This was caught by driving the running app, not by the tests.

**Locks shift with values on removal.** `RepetitionGroup.remove()` does not delete a slot; it shifts the following groups' values up through fixed placeholder slots. The lock belongs to the pre-filled value rather than the slot, so it travels with it — otherwise removing a locked repetition would leave the value that slides into its place uneditable. Only IRIs that actually get a repetition suffix are shifted: `iriSet` holds the statement's constants too, and one can share a placeholder's postfix (`rdfs:comment` beside a `comment` placeholder), which shifted the same lock twice and undid it.

A value lock is a guardrail — it is stated in the URL, so it stops accidental edits, not deliberate ones. A statement lock genuinely holds: Wicket does not invoke the listener of an invisible component, so a hidden "+" cannot be triggered from the page either.

## Also

- The "Create Introduction" link in `ProfileAccountPanel` now locks `param_user` and `param_public-key`.
- Optional statements need no separate lock to be kept present: one is dropped by leaving a field empty, and a locked value cannot be cleared. Forcing an optional statement to stay *absent* would be a hide-the-field feature and is deliberately not part of this.
- Design notes in `docs/locked-prefilled-values.md`.

## Testing

- `LockedFieldTest` (15) — per-repetition locking, lock shifting on removal, readonly/hidden-mirror rendering, statement locks.
- `PublishFormLockTest` (8) — parameter parsing for both locks.
- Full suite: 1259 passing, 0 failures.
- Verified end-to-end against the "Introducing a user" template on a local instance: locked key readonly with its value, second and added groups editable, "-" on the locked group shifting the neighbour up as editable, `locked-statements` removing the group's "+"/"-", and Preview producing a signed nanopub containing the locked key. Nothing published.

Note: previewing after removing a key group reports "Invalid choice" on "has key location", which still references the removed declaration. That is pre-existing — the control run with no locking at all behaves identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01An6DWbMvqQM7z312vC7apK