### PR TITLE
Flag protected nanopublications, and say when the services are restricted or unavailable

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/NanopubElement.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanopubElement.java
@@ -9,6 +9,7 @@ import org.nanopub.SimpleTimestampPattern;
 import org.nanopub.extra.security.MalformedCryptoElementException;
 import org.nanopub.extra.security.NanopubSignatureElement;
 import org.nanopub.extra.security.SignatureUtils;
+import org.nanopub.extra.server.NanopubServerUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -160,6 +161,18 @@ public class NanopubElement implements Serializable {
             seemsToHaveSignature = SignatureUtils.seemsToHaveSignature(nanopub);
         }
         return seemsToHaveSignature;
+    }
+
+    /**
+     * Checks whether the Nanopub is protected, i.e. typed {@code npx:ProtectedNanopub} in its own
+     * publication info. Such a nanopub is only accepted by registries and query services that are
+     * configured as local/private instances, so it is not part of the public network.
+     *
+     * @return True if the Nanopub is protected, false otherwise.
+     */
+    public boolean isProtected() {
+        if (nanopub == null) return false;
+        return NanopubServerUtils.isProtectedNanopub(nanopub);
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/ServiceHealth.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ServiceHealth.java
@@ -1,0 +1,197 @@
+package com.knowledgepixels.nanodash;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+import org.nanopub.NanopubUtils;
+import org.nanopub.extra.server.NanopubServerUtils;
+import org.nanopub.extra.server.RegistryInfo;
+import org.nanopub.extra.services.QueryCall;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Watches whether the registry and the query service this instance talks to are in a state in
+ * which they can actually answer, so that the interface can say so once instead of letting every
+ * query-driven part of a page fail on its own with "API call failed." (issue #681).
+ * <p>
+ * A service that is still loading is filtered out by the nanopub library before any call is
+ * attempted: {@link QueryCall} admits a query instance only when it reports {@code READY} or
+ * {@code LOADING_UPDATES}, and {@code ServerIterator} skips a registry that is not {@code ready}
+ * or {@code updating}. That state changes while an instance is running — a service that starts
+ * with the deployment spends its first minutes loading — so the check is repeated in the
+ * background rather than made once at startup, and request threads only read the last answer.
+ */
+public class ServiceHealth {
+
+    private ServiceHealth() {
+    }  // no instances allowed
+
+    /**
+     * How a service is doing, from the point of view of a caller that wants an answer from it.
+     */
+    public enum State {
+
+        /**
+         * Calls can be made: the service reports a status the nanopub library accepts.
+         */
+        HEALTHY,
+
+        /**
+         * The service answers but is still loading, so calls to it are not attempted yet. This
+         * passes by itself, and the content it would serve is incomplete rather than wrong.
+         */
+        LOADING,
+
+        /**
+         * The service could not be reached at all.
+         */
+        UNREACHABLE,
+
+        /**
+         * Not established yet, or the check itself failed. Treated as "nothing to report": not
+         * knowing must not turn into claiming an outage.
+         */
+        UNKNOWN
+
+    }
+
+    private static final long CHECK_INTERVAL_SECONDS = 30;
+
+    private static volatile State queryState = State.UNKNOWN;
+    private static volatile State registryState = State.UNKNOWN;
+
+    private static ScheduledExecutorService scheduler;
+
+    /**
+     * Starts the periodic check. Meant to run once at application startup.
+     */
+    public static synchronized void init() {
+        if (scheduler != null) return;
+        scheduler = Executors.newSingleThreadScheduledExecutor((r) -> {
+            Thread t = new Thread(r, "nanodash-service-health");
+            t.setDaemon(true);
+            return t;
+        });
+        scheduler.scheduleWithFixedDelay(ServiceHealth::check, 0, CHECK_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Stops the periodic check. Meant to run once at application shutdown.
+     */
+    public static synchronized void shutdown() {
+        if (scheduler == null) return;
+        scheduler.shutdownNow();
+        scheduler = null;
+    }
+
+    /**
+     * Returns the state of the query service as of the last check.
+     *
+     * @return the state of the query service
+     */
+    public static State getQueryState() {
+        return queryState;
+    }
+
+    /**
+     * Returns the state of the registry as of the last check.
+     *
+     * @return the state of the registry
+     */
+    public static State getRegistryState() {
+        return registryState;
+    }
+
+    /**
+     * Returns what to tell the user about the services, or null when there is nothing to say
+     * because both are fine or their state is unknown.
+     * <p>
+     * A service that is loading and one that cannot be reached get different wording on purpose:
+     * the first passes by itself and asks the reader to wait, the second is an outage.
+     *
+     * @return the note to show, or null if there is nothing to report
+     */
+    public static String getNote() {
+        String query = switch (queryState) {
+            case LOADING -> "The query service is still loading. Lists and status information are incomplete.";
+            case UNREACHABLE -> "The query service cannot be reached. Lists and status information are unavailable.";
+            default -> null;
+        };
+        String registry = switch (registryState) {
+            case LOADING -> "The registry is still loading. Some nanopublications cannot be retrieved yet.";
+            case UNREACHABLE -> "The registry cannot be reached. Nanopublications cannot be retrieved or published.";
+            default -> null;
+        };
+        if (query == null) return registry;
+        if (registry == null) return query;
+        return query + " " + registry;
+    }
+
+    /**
+     * Runs both checks and records their outcome. Package-private so that a test can run a check
+     * without waiting for the scheduler.
+     */
+    static void check() {
+        State newQueryState = checkQuery();
+        State newRegistryState = checkRegistry();
+        if (newQueryState != queryState || newRegistryState != registryState) {
+            logger.info("Service health changed: query {} -> {}, registry {} -> {}",
+                    queryState, newQueryState, registryState, newRegistryState);
+        }
+        queryState = newQueryState;
+        registryState = newRegistryState;
+    }
+
+    private static State checkQuery() {
+        try {
+            // The authoritative question is not what one instance reports but whether the library
+            // would dispatch a call at all, which is what every failing page element ran into.
+            if (!QueryCall.getApiInstances().isEmpty()) return State.HEALTHY;
+        } catch (Exception ex) {
+            logger.debug("No query instance available: {}", ex.toString());
+        }
+        // None admitted: ask the configured service directly to tell loading from unreachable.
+        return stateFromStatusHeader(Utils.getMainQueryUrl(), "Nanopub-Query-Status",
+                status -> "READY".equalsIgnoreCase(status) || "LOADING_UPDATES".equalsIgnoreCase(status));
+    }
+
+    private static State checkRegistry() {
+        String url = Utils.getMainRegistryUrl();
+        try {
+            String status = RegistryInfo.load(url).getStatus();
+            return NanopubServerUtils.isReadyRegistryStatus(status) ? State.HEALTHY : State.LOADING;
+        } catch (Exception ex) {
+            logger.debug("Could not load registry info from {}: {}", url, ex.toString());
+            return State.UNREACHABLE;
+        }
+    }
+
+    private static State stateFromStatusHeader(String url, String headerName, java.util.function.Predicate<String> isReady) {
+        try {
+            HttpResponse response = NanopubUtils.getHttpClient().execute(new HttpGet(url));
+            try {
+                var header = response.getFirstHeader(headerName);
+                String status = header == null ? null : header.getValue();
+                if (status == null || status.isEmpty()) {
+                    // An instance that reports no status at all is an older one, which the library
+                    // treats as usable; whatever kept it out of the list is not its loading state.
+                    return State.UNKNOWN;
+                }
+                return isReady.test(status) ? State.HEALTHY : State.LOADING;
+            } finally {
+                EntityUtils.consumeQuietly(response.getEntity());
+            }
+        } catch (Exception ex) {
+            logger.debug("Could not reach {}: {}", url, ex.toString());
+            return State.UNREACHABLE;
+        }
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(ServiceHealth.class);
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/ServiceMode.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ServiceMode.java
@@ -1,0 +1,109 @@
+package com.knowledgepixels.nanodash;
+
+import org.apache.http.client.methods.HttpGet;
+import org.nanopub.NanopubUtils;
+import org.nanopub.extra.server.RegistryInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tells whether the services this instance is connected to are local/private ones, i.e. instances
+ * that accept and serve nanopublications typed {@code npx:ProtectedNanopub} instead of rejecting
+ * them. Such content is not part of the public network, so it is worth saying so in the interface
+ * rather than letting it look like everything else (issue #671).
+ * <p>
+ * The Registry reports the mode as {@code isLocalInstance} in its info JSON (from version 1.12.0),
+ * the Query service as the response header {@code Nanopub-Query-Local-Instance} (from version
+ * 1.26.0). Both are probed once at startup and the answers are kept for the lifetime of the
+ * process: pointing an instance at a different service means restarting it anyway, and a request
+ * thread must never wait on these two calls.
+ */
+public class ServiceMode {
+
+    private ServiceMode() {
+    }  // no instances allowed
+
+    /**
+     * The header a Query service sets, and only sets, when it is configured as a local instance.
+     */
+    private static final String QUERY_LOCAL_INSTANCE_HEADER = "Nanopub-Query-Local-Instance";
+
+    private static volatile Boolean registryIsLocal;
+    private static volatile Boolean queryIsLocal;
+
+    /**
+     * Probes both services for their mode. Called at application startup, from where the (possibly
+     * slow, possibly failing) requests do not delay any user request.
+     */
+    public static void init() {
+        registryIsLocal = probeRegistry();
+        queryIsLocal = probeQuery();
+        if (isRestricted()) {
+            logger.info("Connected to restricted services (registry local: {}, query local: {}); " +
+                        "protected nanopublications are part of this deployment", registryIsLocal, queryIsLocal);
+        }
+    }
+
+    /**
+     * Returns whether this instance is connected to at least one local/private service, and
+     * therefore is a deployment in which protected nanopublications can exist.
+     *
+     * @return true if the registry or the query service reports itself as a local instance
+     */
+    public static boolean isRestricted() {
+        return isRegistryLocal() || isQueryLocal();
+    }
+
+    /**
+     * Returns whether the main registry reports itself as a local/private instance. A registry
+     * older than 1.12.0 does not report the field at all, which is read as "not local".
+     *
+     * @return true if the registry is a local instance
+     */
+    public static boolean isRegistryLocal() {
+        if (registryIsLocal == null) registryIsLocal = probeRegistry();
+        return registryIsLocal;
+    }
+
+    /**
+     * Returns whether the main query service reports itself as a local/private instance. A query
+     * service older than 1.26.0 does not send the header at all, which is read as "not local".
+     *
+     * @return true if the query service is a local instance
+     */
+    public static boolean isQueryLocal() {
+        if (queryIsLocal == null) queryIsLocal = probeQuery();
+        return queryIsLocal;
+    }
+
+    private static boolean probeRegistry() {
+        String url = Utils.getMainRegistryUrl();
+        try {
+            return RegistryInfo.load(url).isLocalInstance();
+        } catch (Exception ex) {
+            // Not knowing the mode is the same as not being restricted: the flag is additional
+            // information, and its absence must never keep the interface from working.
+            logger.warn("Could not determine the mode of registry {}: {}", url, ex.toString());
+            return false;
+        }
+    }
+
+    private static boolean probeQuery() {
+        String url = Utils.getMainQueryUrl();
+        try {
+            var response = NanopubUtils.getHttpClient().execute(new HttpGet(url));
+            try {
+                var header = response.getFirstHeader(QUERY_LOCAL_INSTANCE_HEADER);
+                return header != null && "true".equalsIgnoreCase(header.getValue());
+            } finally {
+                org.apache.http.util.EntityUtils.consumeQuietly(response.getEntity());
+            }
+        } catch (Exception ex) {
+            logger.warn("Could not determine the mode of query service {}: {}", url, ex.toString());
+            return false;
+        }
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(ServiceMode.class);
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -1071,6 +1071,13 @@ public class Utils {
             if (t.equals(FIP.FAIR_SUPPORTING_RESOURCE_TO_BE_DEVELOPED)) {
                 continue;
             }
+            if (t.equals(NPX.PROTECTED_NANOPUB)) {
+                // Not a type of the content but a statement about where the nanopub may be
+                // stored, and shown as its own flag instead (see NanopubItem). As a type tag
+                // it would also link to a listing of all nanopubs of that type, which says
+                // nothing about them beyond that they are all protected.
+                continue;
+            }
             l.add(t);
         }
         return l;

--- a/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
+++ b/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
@@ -140,6 +140,7 @@ public class WicketApplication extends WebApplication implements NanopubPublishe
         WicketWebjars.install(this);
 
         Utils.initMainUrls();
+        ServiceMode.init();
 
         getMarkupSettings().setDefaultMarkupEncoding("UTF-8");
 

--- a/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
+++ b/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
@@ -141,6 +141,7 @@ public class WicketApplication extends WebApplication implements NanopubPublishe
 
         Utils.initMainUrls();
         ServiceMode.init();
+        ServiceHealth.init();
 
         getMarkupSettings().setDefaultMarkupEncoding("UTF-8");
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.html
@@ -16,6 +16,7 @@
       <span class="nanopub-icon"></span> &nbsp;<a wicket:id="nanopub-id-link"
                                                   href=".">link-ID</a>
     </span>
+    <span class="protectedtag" wicket:id="protected-flag">🔒 protected</span>
     <span class="typetag-container" wicket:id="typespan">
       <span class="typetag"><a wicket:id="type" href=".">type</a></span>
     </span>

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.java
@@ -8,6 +8,7 @@ import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.page.ListPage;
 import com.knowledgepixels.nanodash.page.UserPage;
 import com.knowledgepixels.nanodash.template.*;
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
@@ -127,6 +128,13 @@ public class NanopubItem extends Panel {
             } else {
                 header.add(new Label("action-menu", "").setVisible(false));
             }
+            // A protected nanopub lives only on local/private instances and is never part of the
+            // public network, which is worth showing next to its ID rather than leaving it to be
+            // spotted among the pubinfo statements.
+            Label protectedFlag = new Label("protected-flag", "🔒 protected");
+            protectedFlag.add(new AttributeModifier("title",
+                    "Protected nanopublication: only stored and served by local/private instances, not by the public network."));
+            header.add(protectedFlag.setVisible(n.isProtected()));
             header.add(new DataView<IRI>("typespan", new ListDataProvider<IRI>(Utils.getTypes(n.getNanopub()))) {
 
                 @Override

--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.html
@@ -21,6 +21,8 @@
 
 </div>
 
+<div class="service-health-note" wicket:id="service-health-note">The query service is still loading.</div>
+
 <div id="content-pane" class="plain breadcrumbpath" wicket:id="breadcrumbpath">
 <div class="row-section">
 <div class="col-12 breadcrumb-tab-row">

--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.html
@@ -14,6 +14,7 @@
 
 <div class="alignleft">
 <a class="logo" href="/" title="Home"></a>
+<span class="restricted-marker" wicket:id="restricted-marker">🔒 restricted</span>
 </div>
 
 <div class="titlebar-message" wicket:id="justPublishedMessage"></div>

--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
@@ -18,6 +18,7 @@ import org.apache.wicket.request.mapper.parameter.PageParameters;
 
 import com.knowledgepixels.nanodash.NanodashPageRef;
 import com.knowledgepixels.nanodash.NavigationContext;
+import com.knowledgepixels.nanodash.ServiceHealth;
 import com.knowledgepixels.nanodash.ServiceMode;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.page.ExplorePage;
@@ -61,6 +62,11 @@ public class TitleBar extends Panel {
                 "This instance is connected to a local/private registry or query service. Its content is not " +
                 "(only) the public nanopublication network, and it can hold protected nanopublications."));
         add(restrictedMarker.setVisible(ServiceMode.isRestricted()));
+
+        // Services that cannot answer: said once here, rather than left to each query-driven part
+        // of the page to report as its own "API call failed." (#681).
+        String serviceHealthNote = ServiceHealth.getNote();
+        add(new Label("service-health-note", serviceHealthNote).setVisible(serviceHealthNote != null));
 
         breadcrumbPath = new WebMarkupContainer("breadcrumbpath");
         if (page.hasFullWidthContent()) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
@@ -4,8 +4,10 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.markup.repeater.Item;
@@ -16,6 +18,7 @@ import org.apache.wicket.request.mapper.parameter.PageParameters;
 
 import com.knowledgepixels.nanodash.NanodashPageRef;
 import com.knowledgepixels.nanodash.NavigationContext;
+import com.knowledgepixels.nanodash.ServiceMode;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.page.ExplorePage;
 import com.knowledgepixels.nanodash.page.HomePage;
@@ -49,6 +52,15 @@ public class TitleBar extends Panel {
         // Centered title-bar message: the post-publish confirmation and/or the
         // always-on "you haven't published an introduction yet" warning.
         add(new JustPublishedMessagePanel("justPublishedMessage", page.getPageParameters()));
+
+        // Restricted deployment: this instance talks to a local/private registry or query service,
+        // so what it shows is not (only) the public network, and protected nanopublications can be
+        // part of it. Shown on every page, as it is a property of the instance, not of a page.
+        Label restrictedMarker = new Label("restricted-marker", "🔒 restricted");
+        restrictedMarker.add(new AttributeModifier("title",
+                "This instance is connected to a local/private registry or query service. Its content is not " +
+                "(only) the public nanopublication network, and it can hold protected nanopublications."));
+        add(restrictedMarker.setVisible(ServiceMode.isRestricted()));
 
         breadcrumbPath = new WebMarkupContainer("breadcrumbpath");
         if (page.hasFullWidthContent()) {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -1545,6 +1545,15 @@ select {
   white-space: nowrap;
 }
 
+.service-health-note {
+  padding: 6px 20px;
+  font-size: 13px;
+  text-align: center;
+  color: #7a4a00;
+  background-color: #fff4d6;
+  border-bottom: 1px solid #e0b055;
+}
+
 .restricted-marker {
   display: inline-block;
   vertical-align: middle;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -1545,6 +1545,32 @@ select {
   white-space: nowrap;
 }
 
+.restricted-marker {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 10px;
+  padding: 2px 7px;
+  font-size: 12px;
+  color: #7a4a00;
+  background-color: #ffe6b3;
+  border: 1px solid #e0b055;
+  border-radius: 3px;
+  white-space: nowrap;
+  cursor: help;
+}
+
+.protectedtag {
+  color: #7a4a00;
+  font-size: 12px;
+  padding: 2px 6px;
+  margin-right: 4px;
+  background-color: #ffe6b3;
+  border: 1px solid #e0b055;
+  border-radius: 3px;
+  white-space: nowrap;
+  cursor: help;
+}
+
 .positivetag {
   font-size: 14px;
   padding: 4px 10px;

--- a/src/test/java/com/knowledgepixels/nanodash/NanopubElementTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/NanopubElementTest.java
@@ -3,10 +3,12 @@ package com.knowledgepixels.nanodash;
 import com.knowledgepixels.nanodash.utils.TestUtils;
 import jakarta.xml.bind.DatatypeConverter;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
 import org.nanopub.NanopubImpl;
 import org.nanopub.extra.security.MalformedCryptoElementException;
 import org.nanopub.extra.security.SignatureUtils;
@@ -157,6 +159,33 @@ class NanopubElementTest {
         NanopubElement nanopubElement = NanopubElement.get(nanopub);
         List<IRI> expectedTypes = List.of(NPX.EXAMPLE_NANOPUB);
         assertEquals(expectedTypes, nanopubElement.getTypes());
+    }
+
+    @Test
+    void isProtectedForTypeInPubinfo() throws Exception {
+        NanopubCreator creator = TestUtils.getNanopubCreator("http://example.org/protected-np/");
+        creator.addAssertionStatement(TestUtils.anyIri, TestUtils.anyIri, TestUtils.anyIri);
+        TestUtils.fillProvenanceGraph(creator);
+        creator.addPubinfoStatement(RDF.TYPE, NPX.PROTECTED_NANOPUB);
+
+        assertTrue(NanopubElement.get(creator.finalizeNanopub()).isProtected());
+    }
+
+    @Test
+    void isNotProtectedForTypeOutsidePubinfo() throws Exception {
+        // Only the type of the nanopub itself, in its own publication info, marks it protected:
+        // the same triple in the assertion is a statement about something else.
+        NanopubCreator creator = TestUtils.getNanopubCreator("http://example.org/unprotected-np/");
+        creator.addAssertionStatement(TestUtils.anyIri, RDF.TYPE, NPX.PROTECTED_NANOPUB);
+        TestUtils.fillProvenanceGraph(creator);
+        TestUtils.fillPubInfoGraph(creator);
+
+        assertFalse(NanopubElement.get(creator.finalizeNanopub()).isProtected());
+    }
+
+    @Test
+    void isNotProtectedForPlainNanopub() throws Exception {
+        assertFalse(NanopubElement.get(TestUtils.createNanopub()).isProtected());
     }
 
 }

--- a/src/test/java/com/knowledgepixels/nanodash/ServiceHealthTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ServiceHealthTest.java
@@ -1,0 +1,76 @@
+package com.knowledgepixels.nanodash;
+
+import com.knowledgepixels.nanodash.ServiceHealth.State;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ServiceHealthTest {
+
+    @BeforeEach
+    @AfterEach
+    void resetStates() throws Exception {
+        setState("queryState", State.UNKNOWN);
+        setState("registryState", State.UNKNOWN);
+    }
+
+    private void setState(String field, State state) throws Exception {
+        Field f = ServiceHealth.class.getDeclaredField(field);
+        f.setAccessible(true);
+        f.set(null, state);
+    }
+
+    @Test
+    void healthyServicesHaveNothingToReport() throws Exception {
+        setState("queryState", State.HEALTHY);
+        setState("registryState", State.HEALTHY);
+        assertNull(ServiceHealth.getNote());
+    }
+
+    @Test
+    void unknownStateIsNotReportedAsAnOutage() {
+        // Both states start out unknown, and a failing check leaves them that way: saying nothing
+        // is the only safe thing to say when the health of a service could not be established.
+        assertNull(ServiceHealth.getNote());
+    }
+
+    @Test
+    void aLoadingQueryServiceIsDistinguishedFromAnUnreachableOne() throws Exception {
+        setState("registryState", State.HEALTHY);
+
+        setState("queryState", State.LOADING);
+        String loading = ServiceHealth.getNote();
+        assertNotNull(loading);
+        assertTrue(loading.contains("still loading"), loading);
+
+        setState("queryState", State.UNREACHABLE);
+        String unreachable = ServiceHealth.getNote();
+        assertNotNull(unreachable);
+        assertTrue(unreachable.contains("cannot be reached"), unreachable);
+        assertNotEquals(loading, unreachable);
+    }
+
+    @Test
+    void anUnreachableRegistryIsReported() throws Exception {
+        setState("queryState", State.HEALTHY);
+        setState("registryState", State.UNREACHABLE);
+        String note = ServiceHealth.getNote();
+        assertNotNull(note);
+        assertTrue(note.contains("registry"), note);
+    }
+
+    @Test
+    void bothServicesFailingAreReportedTogether() throws Exception {
+        setState("queryState", State.UNREACHABLE);
+        setState("registryState", State.UNREACHABLE);
+        String note = ServiceHealth.getNote();
+        assertNotNull(note);
+        assertTrue(note.contains("query service"), note);
+        assertTrue(note.contains("registry"), note);
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/ServiceModeTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ServiceModeTest.java
@@ -1,0 +1,98 @@
+package com.knowledgepixels.nanodash;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.extra.server.RegistryInfo;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class ServiceModeTest {
+
+    private static final String REGISTRY_URL = "http://localhost:19292/";
+
+    @BeforeEach
+    @AfterEach
+    void clearProbedModes() throws Exception {
+        // The probes are cached for the lifetime of the process, so each test starts from unprobed.
+        for (String name : new String[]{"registryIsLocal", "queryIsLocal"}) {
+            Field f = ServiceMode.class.getDeclaredField(name);
+            f.setAccessible(true);
+            f.set(null, null);
+        }
+    }
+
+    /**
+     * Sets the query answer directly rather than serving a header: the query probe makes a plain
+     * HTTP call, and what it does with the header is the Query service's contract, not ours.
+     */
+    private void setQueryIsLocal(boolean value) throws Exception {
+        Field f = ServiceMode.class.getDeclaredField("queryIsLocal");
+        f.setAccessible(true);
+        f.set(null, value);
+    }
+
+    @Test
+    void registryReportingLocalInstanceMakesTheDeploymentRestricted() throws Exception {
+        setQueryIsLocal(false);
+        RegistryInfo info = mock(RegistryInfo.class);
+        when(info.isLocalInstance()).thenReturn(true);
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<RegistryInfo> registryInfo = mockStatic(RegistryInfo.class)) {
+            utils.when(Utils::getMainRegistryUrl).thenReturn(REGISTRY_URL);
+            registryInfo.when(() -> RegistryInfo.load(REGISTRY_URL)).thenReturn(info);
+
+            assertTrue(ServiceMode.isRegistryLocal());
+            assertTrue(ServiceMode.isRestricted());
+        }
+    }
+
+    @Test
+    void publicServicesAreNotRestricted() throws Exception {
+        setQueryIsLocal(false);
+        RegistryInfo info = mock(RegistryInfo.class);
+        when(info.isLocalInstance()).thenReturn(false);
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<RegistryInfo> registryInfo = mockStatic(RegistryInfo.class)) {
+            utils.when(Utils::getMainRegistryUrl).thenReturn(REGISTRY_URL);
+            registryInfo.when(() -> RegistryInfo.load(REGISTRY_URL)).thenReturn(info);
+
+            assertFalse(ServiceMode.isRestricted());
+        }
+    }
+
+    @Test
+    void anUnreachableRegistryIsReadAsNotLocal() throws Exception {
+        // Not knowing the mode must never propagate as an error: the flag is extra information.
+        setQueryIsLocal(false);
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<RegistryInfo> registryInfo = mockStatic(RegistryInfo.class)) {
+            utils.when(Utils::getMainRegistryUrl).thenReturn(REGISTRY_URL);
+            registryInfo.when(() -> RegistryInfo.load(REGISTRY_URL))
+                    .thenThrow(new RegistryInfo.RegistryInfoException(REGISTRY_URL));
+
+            assertFalse(ServiceMode.isRegistryLocal());
+            assertFalse(ServiceMode.isRestricted());
+        }
+    }
+
+    @Test
+    void aLocalQueryServiceAloneMakesTheDeploymentRestricted() throws Exception {
+        setQueryIsLocal(true);
+        RegistryInfo info = mock(RegistryInfo.class);
+        when(info.isLocalInstance()).thenReturn(false);
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<RegistryInfo> registryInfo = mockStatic(RegistryInfo.class)) {
+            utils.when(Utils::getMainRegistryUrl).thenReturn(REGISTRY_URL);
+            registryInfo.when(() -> RegistryInfo.load(REGISTRY_URL)).thenReturn(info);
+
+            assertTrue(ServiceMode.isRestricted());
+        }
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/UtilsTest.java
@@ -288,6 +288,20 @@ class UtilsTest {
     }
 
     @Test
+    void getTypesExcludesProtectedNanopubType() {
+        // npx:ProtectedNanopub is shown as its own flag in NanopubItem, not as a type tag.
+        Nanopub nanopub = mock(Nanopub.class);
+        MockedStatic<NanopubUtils> mockStatic = mockStatic(NanopubUtils.class);
+        IRI includedType = Values.iri("http://knowledgepixels.com/nanopubIri#ValidType");
+        mockStatic.when(() -> NanopubUtils.getTypes(nanopub)).thenReturn(Set.of(NPX.PROTECTED_NANOPUB, includedType));
+
+        List<IRI> result = Utils.getTypes(nanopub);
+
+        assertEquals(List.of(includedType), result);
+        mockStatic.close();
+    }
+
+    @Test
     void getTypesReturnsEmptyListForNoTypes() {
         Nanopub nanopub = mock(Nanopub.class);
         MockedStatic<NanopubUtils> mockStatic = mockStatic(NanopubUtils.class);

--- a/src/test/java/com/knowledgepixels/nanodash/component/NanopubItemTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/NanopubItemTest.java
@@ -1,0 +1,69 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.NanopubElement;
+import com.knowledgepixels.nanodash.utils.TestUtils;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.trusty.MakeTrustyNanopub;
+import org.nanopub.vocabulary.NPX;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class NanopubItemTest {
+
+    private WicketTester tester;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester();
+    }
+
+    /**
+     * The nanopub is made trusty because the header renders its artifact code when it has no
+     * label, which a plain nanopub does not have.
+     */
+    private Nanopub nanopub(String uri, boolean isProtected) throws Exception {
+        NanopubCreator creator = TestUtils.getNanopubCreator(uri);
+        creator.addAssertionStatement(TestUtils.anyIri, TestUtils.anyIri, TestUtils.anyIri);
+        TestUtils.fillProvenanceGraph(creator);
+        TestUtils.fillPubInfoGraph(creator);
+        if (isProtected) creator.addPubinfoStatement(RDF.TYPE, NPX.PROTECTED_NANOPUB);
+        return MakeTrustyNanopub.transform(creator.finalizeNanopub());
+    }
+
+    private NanopubItem minimalItem(Nanopub np) {
+        return new NanopubItem("item", NanopubElement.get(np)).setMinimal().setFooterHidden(true);
+    }
+
+    @Test
+    void protectedNanopubShowsTheFlag() throws Exception {
+        tester.startComponentInPage(minimalItem(nanopub("http://example.org/protected-item/", true)));
+
+        tester.assertComponent("item:header:protected-flag", Label.class);
+        tester.assertVisible("item:header:protected-flag");
+        tester.assertLabel("item:header:protected-flag", "🔒 protected");
+    }
+
+    @Test
+    void plainNanopubShowsNoFlag() throws Exception {
+        tester.startComponentInPage(minimalItem(nanopub("http://example.org/plain-item/", false)));
+
+        tester.assertInvisible("item:header:protected-flag");
+    }
+
+    @Test
+    void protectedTypeIsNotAlsoShownAsATypeTag() throws Exception {
+        // The type tags come from Utils.getTypes, which leaves npx:ProtectedNanopub out so that it
+        // is not shown twice, once as a flag and once as an ordinary grey type tag linking to a
+        // listing of everything else that happens to be protected.
+        tester.startComponentInPage(minimalItem(nanopub("http://example.org/protected-item-tags/", true)));
+
+        assertFalse(tester.getLastResponseAsString().contains("ProtectedNanopub"));
+    }
+
+}


### PR DESCRIPTION
Two related things a Nanodash instance never said out loud: what kind of deployment it is talking to, and when that deployment cannot answer. Both surface in the title bar, one commit each.

## Protected nanopublications and restricted services (#671)

Registry 1.12.0 and Query 1.26.0 accept and serve nanopubs typed `npx:ProtectedNanopub` when configured as local/private instances, and nanopub-java 1.94.0 exposes both facts to clients (Nanopublication/nanopub-java#143, #144, #145).

* A protected nanopub gets its own 🔒 flag next to its ID. Until now `NanopubUtils.getTypes` picked the type up from the publication info and `NanopubItem` rendered it as an ordinary grey type tag — indistinguishable from a domain type, and linking to a listing of everything else that happens to be protected. The type is now left out of the tags; the publication info still shows the underlying triple, since the flag replaces the tag, not the RDF.
* `ServiceMode` probes both services once at startup — the registry through `RegistryInfo.isLocalInstance()`, the query service through its `Nanopub-Query-Local-Instance` response header — and a `🔒 restricted` marker says when either is local. It is a property of the instance, not of a page, so it shows on all of them. A service that cannot be reached reads as "not restricted": the marker is additional information and must never keep the interface from working.

## A note when a service cannot answer (#681)

`QueryCall` admits a query instance only when it reports `READY` or `LOADING_UPDATES`, and `ServerIterator` skips a registry that is not `ready`/`updating`. When nothing is admitted, every query-driven part of a page fails separately with a bare `API call failed.` and nothing says why. `ServiceHealth` now watches both and the title bar says it once.

A service that is still loading and one that cannot be reached get different wording, because what the reader should do differs: the first passes by itself, the second is an outage. The check runs on its own scheduled thread, since health changes while an instance runs; request threads only read the last answer, keeping the probes off the request path (#600). A state that could not be established stays `UNKNOWN` and shows nothing.

## Verification

Built a local/private stack for this — Registry 1.12.1 with `REGISTRY_LOCAL_INSTANCE=true` and Query 1.28.0 with `NANOPUB_QUERY_LOCAL_INSTANCE=true`, mirroring the public network (89,433 nanopubs) — and drove Nanodash against it:

* A protected nanopublication signed with a throwaway key published to the local registry and read back, still protected. The same publication attempt against the public registries is refused by nanopub-java without contacting them for anything but their info, as intended.
* Both markers render: `🔒 restricted` in the title bar, `🔒 protected` on the nanopub, with no `ProtectedNanopub` type tag left.
* The health note appeared while the query service was doing its initial load, and cleared by itself within one check interval of it becoming ready:
  ```
  13:20:30  query UNKNOWN -> LOADING,  registry UNKNOWN -> HEALTHY
  13:22:01  query LOADING -> HEALTHY,  registry HEALTHY -> HEALTHY
  ```

Full suite: 1285 tests, 0 failures, 0 errors. New tests cover `isProtected` (including the type sitting outside the publication info, which does not count), the type-tag exclusion, the rendered flag, the mode probes, and the note wording for each state.

## Two findings this turned up, filed separately

* #682 — the persistent API cache is keyed by query and parameters alone, with a fixed path per home directory, so a restricted deployment and a public one share it. Protected content cached from a local stack is read back by an instance pointed at public services. Not fixed here.
* With a cold cache and no healthy query service, `NanodashSession`'s constructor throws in `UserData` and every page 500s, the error page included — which also defeats the note in this PR, since nothing renders. Pre-existing; not filed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqfrG3VXH5tzWXPvYJzXML