### PR TITLE
fix(config): let an explicitly configured main registry/query URL win

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -34,17 +34,29 @@ Report is then generated here: target/site/dependencies.html
     $ mvn versions:use-latest-versions && mvn versions:update-properties
 
 
-## Pin to a single Nanopub Query instance
+## Pointing nanodash at particular services
 
-To make a local run use only one query instance (e.g. `https://query.nanodash.net/`):
+Two pairs of environment variables are involved, and both pairs are needed to move a deployment
+as a whole -- for example onto a private registry and query service:
 
-    $ NANOPUB_QUERY_INSTANCES=https://query.nanodash.net/ \
-      NANODASH_MAIN_QUERY=https://query.nanodash.net/ \
+    $ NANOPUB_QUERY_INSTANCES=https://query.example.org/ \
+      NANOPUB_REGISTRY_INSTANCES=https://registry.example.org/ \
+      NANODASH_MAIN_QUERY=https://query.example.org/ \
+      NANODASH_MAIN_REGISTRY=https://registry.example.org/ \
       ./run-dev.sh
 
-`NANOPUB_QUERY_INSTANCES` (whitespace-separated, from the `nanopub` library) restricts which
-instances queries are dispatched to. `NANODASH_MAIN_QUERY` pins the URL nanodash uses when
-building query-related links.
+`NANOPUB_QUERY_INSTANCES` and `NANOPUB_REGISTRY_INSTANCES` (whitespace-separated lists, read by
+the `nanopub` library) decide where queries are actually dispatched and where nanopubs are
+fetched from and published to. Without them the library keeps using the public instances it
+discovers, whatever nanodash is configured with.
+
+`NANODASH_MAIN_QUERY` and `NANODASH_MAIN_REGISTRY` pin the single service nanodash itself names:
+outgoing links to the query and registry UIs, the account list, and the health and restricted-mode
+probes. An explicitly set value always wins; if it is not in the library's instance list, that is
+logged as a warning -- it usually means the library pair above is missing -- but the configured
+URL is still used.
+
+To make a local run use only one query instance, set just the query pair.
 
 
 ## Backup archive of user data

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -1443,10 +1443,9 @@ public class Utils {
     /**
      * Returns the URL of the main Nanopub Registry for this nanodash instance.
      * <p>
-     * If {@code NANODASH_MAIN_REGISTRY} is set and matches an entry in the library's
-     * discovered registry instance list, that URL is used. Otherwise the first entry
-     * of the library list is used. If the library list is empty, the env var value
-     * (or built-in default) is used unvalidated. The result is cached for the JVM lifetime.
+     * If {@code NANODASH_MAIN_REGISTRY} is set, that URL is used. Otherwise the first entry
+     * of the library's discovered registry instance list is used, or the built-in default if
+     * that list is empty. The result is cached for the JVM lifetime.
      *
      * @return Nanopub Registry URL (with trailing slash)
      */
@@ -1464,10 +1463,9 @@ public class Utils {
     /**
      * Returns the URL of the main Nanopub Query API for this nanodash instance.
      * <p>
-     * If {@code NANODASH_MAIN_QUERY} is set and matches an entry in the library's
-     * discovered query instance list, that URL is used. Otherwise the first entry
-     * of the library list is used. If the library list is empty, the env var value
-     * (or built-in default) is used unvalidated. The result is cached for the JVM lifetime.
+     * If {@code NANODASH_MAIN_QUERY} is set, that URL is used. Otherwise the first entry of the
+     * library's discovered query instance list is used, or the built-in default if that list is
+     * empty. The result is cached for the JVM lifetime.
      *
      * @return Nanopub Query URL (with trailing slash)
      */
@@ -1491,7 +1489,7 @@ public class Utils {
             logger.warn("Could not retrieve registry instance list from nanopub library: {}", ex.toString());
             instances = Collections.emptyList();
         }
-        return resolveMainUrl("NANODASH_MAIN_REGISTRY", envValue, instances, DEFAULT_MAIN_REGISTRY_URL);
+        return resolveMainUrl("NANODASH_MAIN_REGISTRY", envValue, instances, "NANOPUB_REGISTRY_INSTANCES", DEFAULT_MAIN_REGISTRY_URL);
     }
 
     private static String resolveMainQueryUrl() {
@@ -1506,21 +1504,28 @@ public class Utils {
             logger.warn("Could not retrieve query instance list from nanopub library: {}", ex.toString());
             instances = Collections.emptyList();
         }
-        return resolveMainUrl("NANODASH_MAIN_QUERY", envValue, instances, DEFAULT_MAIN_QUERY_URL);
+        return resolveMainUrl("NANODASH_MAIN_QUERY", envValue, instances, "NANOPUB_QUERY_INSTANCES", DEFAULT_MAIN_QUERY_URL);
     }
 
-    private static String resolveMainUrl(String envVarName, String envValue, List<String> instances, String builtInDefault) {
+    /**
+     * Resolves one main URL. An explicitly configured value always wins: an operator who names a
+     * service -- a private registry or query API, say -- must not have that overruled by a list
+     * discovered from the public ones (issue #680). The list is still consulted, but only to warn
+     * that the library will keep dispatching elsewhere unless it is pointed at the same service.
+     * Package-private for testing.
+     */
+    static String resolveMainUrl(String envVarName, String envValue, List<String> instances, String libraryVarName, String builtInDefault) {
         if (envValue != null) {
             if (containsNormalized(instances, envValue)) {
-                logger.info("Using main URL from {} (validated against library instance list): {}", envVarName, envValue);
-                return ensureTrailingSlash(envValue);
+                logger.info("Using main URL from {} (also in the library instance list): {}", envVarName, envValue);
+            } else if (instances.isEmpty()) {
+                logger.info("Using main URL from {}; library instance list is empty: {}", envVarName, envValue);
+            } else {
+                logger.warn("Using main URL from {}={}, but it is not in the library instance list {}; the library itself " +
+                        "(nanopub retrieval, query dispatch) keeps using that list, so set {} to the same service as well",
+                        envVarName, envValue, instances, libraryVarName);
             }
-            if (instances.isEmpty()) {
-                logger.warn("Library instance list is empty; using {} unvalidated: {}", envVarName, envValue);
-                return ensureTrailingSlash(envValue);
-            }
-            logger.warn("{}={} is not in the library instance list {}; falling back to first library instance", envVarName, envValue, instances);
-            return ensureTrailingSlash(instances.get(0));
+            return ensureTrailingSlash(envValue);
         }
         if (!instances.isEmpty()) {
             String first = instances.get(0);

--- a/src/test/java/com/knowledgepixels/nanodash/MainUrlResolutionTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/MainUrlResolutionTest.java
@@ -1,0 +1,55 @@
+package com.knowledgepixels.nanodash;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Resolution of the main registry/query URLs from NANODASH_MAIN_* and the library instance list.
+ */
+class MainUrlResolutionTest {
+
+    private static final String VAR = "NANODASH_MAIN_REGISTRY";
+    private static final String LIB_VAR = "NANOPUB_REGISTRY_INSTANCES";
+    private static final String DEFAULT = "https://registry.knowledgepixels.com/";
+    private static final List<String> PUBLIC_INSTANCES =
+            List.of("https://registry.knowledgepixels.com/", "https://registry.petapico.org/");
+
+    private static String resolve(String envValue, List<String> instances) {
+        return Utils.resolveMainUrl(VAR, envValue, instances, LIB_VAR, DEFAULT);
+    }
+
+    @Test
+    void configuredUrlOutsideTheLibraryListIsStillUsed() {
+        // Issue #680: a private service named by the operator must not be replaced by a public one.
+        assertEquals("https://registry.example.org/", resolve("https://registry.example.org/", PUBLIC_INSTANCES));
+    }
+
+    @Test
+    void configuredUrlWinsWithoutATrailingSlash() {
+        assertEquals("https://registry.example.org/", resolve("https://registry.example.org", PUBLIC_INSTANCES));
+    }
+
+    @Test
+    void configuredUrlIsUsedWhenTheLibraryListIsEmpty() {
+        assertEquals("https://registry.example.org/", resolve("https://registry.example.org/", Collections.emptyList()));
+    }
+
+    @Test
+    void configuredUrlInTheLibraryListIsUsed() {
+        assertEquals("https://registry.petapico.org/", resolve("https://registry.petapico.org", PUBLIC_INSTANCES));
+    }
+
+    @Test
+    void firstLibraryInstanceIsUsedWhenNothingIsConfigured() {
+        assertEquals("https://registry.knowledgepixels.com/", resolve(null, PUBLIC_INSTANCES));
+    }
+
+    @Test
+    void builtInDefaultIsUsedWhenNothingIsConfiguredAndNoInstancesAreKnown() {
+        assertEquals(DEFAULT, resolve(null, Collections.emptyList()));
+    }
+}


### PR DESCRIPTION
Closes #680.

## The bug

`Utils.resolveMainUrl` validated `NANODASH_MAIN_REGISTRY` / `NANODASH_MAIN_QUERY` against the instance list discovered by nanopub-java, and **replaced** the configured URL with the first library instance when it did not appear there:

```java
logger.warn("{}={} is not in the library instance list {}; falling back to first library instance", ...);
return ensureTrailingSlash(instances.get(0));
```

So pointing an instance at a private registry or query service with those variables alone had no effect — a public instance was used instead, visible only as a log warning. The setting only worked if `NANOPUB_REGISTRY_INSTANCES` / `NANOPUB_QUERY_INSTANCES` were set too, which was undocumented and the wrong way round.

Same shape as Nanopublication/nanopub-java#145, fixed there the same way.

## The fix

The configured URL always wins. The instance-list check stays, but as a log line only — and when the URL is not in the list, the warning now names the remedy (set the library variables to the same service) instead of substituting.

## Wider reach than the issue records

Since #683 merged, `ServiceMode.probeRegistry`/`probeQuery` and `ServiceHealth.checkQuery`/`checkRegistry` also read these URLs — not just link building and the account list. On a restricted deployment the bug meant restricted-mode detection and the health probes were interrogating a *public* service, i.e. exactly the deployment where the restricted flag matters. Fixed by the same change.

## Also

- `NOTES.md`: "Pin to a single Nanopub Query instance" → "Pointing nanodash at particular services", documenting both pairs and that the library pair is what actually governs query dispatch and nanopub retrieval/publishing.
- New `MainUrlResolutionTest` (6 cases): private URL outside the list survives, trailing-slash normalisation, empty list, in-list value, unset-with-list, unset-with-empty-list. `resolveMainUrl` is package-private for this.

## Not in scope

Query dispatch (`QueryCall`) and nanopub retrieval (`GetNanopub`/`ServerIterator`) still read only their own env vars, so a restricted deployment genuinely needs all four variables — that is a nanopub-java-side concern (nanopub-java#126).

## Testing

Full suite: 1291 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqfrG3VXH5tzWXPvYJzXML