### PR TITLE
fix(cold start): serve pages when a service cannot answer

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ApiCache.java
@@ -304,6 +304,28 @@ public class ApiCache {
         ApiCachePersistence.storeEntry(cacheId, response, timeNow);
     }
 
+    /**
+     * The response for a query if it can be had, and null if it cannot — nothing cached yet,
+     * or a query the service could not answer.
+     * <p>
+     * For the callers that hold the state whole pages are built from, where a query that
+     * cannot be answered means "nothing to show yet" rather than an error to raise. They
+     * already treat a missing response that way; without this they would treat a failing one
+     * as fatal, and a cold instance whose query service is unavailable could then not build a
+     * page at all, its own error page included (issue #684).
+     *
+     * @param queryRef The query reference
+     * @return the response, or null if there is none to be had
+     */
+    public static ApiResponse retrieveResponseIfAvailable(QueryRef queryRef) {
+        try {
+            return retrieveResponseSync(queryRef, false);
+        } catch (Exception ex) {
+            logger.error("Could not retrieve {}: {}", queryRef.getAsUrlString(), ex.toString());
+            return null;
+        }
+    }
+
     public static ApiResponse retrieveResponseSync(QueryRef queryRef, boolean forced) {
         long timeNow = System.currentTimeMillis();
         String cacheId = queryRef.getAsUrlString();

--- a/src/main/java/com/knowledgepixels/nanodash/NanodashSession.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanodashSession.java
@@ -76,7 +76,41 @@ public class NanodashSession extends WebSession {
         setLocale(Locale.US);
         httpSession = ((HttpServletRequest) request.getContainerRequest()).getSession();
         bind();
-        loadProfileInfo();
+        try {
+            loadProfileInfo();
+        } catch (Exception ex) {
+            // A session that cannot be constructed is not one failed page but no page at all:
+            // the error page needs a session of its own, so its construction fails the same
+            // way and the request ends in an unhandled exception (issue #684). Profile
+            // information that cannot be loaded leaves an anonymous session, which is a
+            // serviceable state, and the retry below picks it up once it can be had.
+            logger.error("Could not load the profile information for this session", ex);
+            profileInfoIncomplete = true;
+        }
+    }
+
+    /**
+     * Loads the profile information again when the last attempt had to make do with user data
+     * that was not fully loaded, and that data has since come in. Called at the start of each
+     * page render, so a session that came up during a service outage (issue #684) shows the
+     * user's introductions as soon as the service answers, instead of staying as it was for as
+     * long as the session lives.
+     */
+    public void refreshProfileInfoIfIncomplete() {
+        if (!profileInfoIncomplete) return;
+        try {
+            if (!User.getUserData().isComplete()) return;
+            logger.info("User data is complete again; reloading the profile information");
+            // Cleared first: the load only rebuilds the introductions when there are none
+            // held, and it sets the flag again if the data is incomplete after all.
+            profileInfoIncomplete = false;
+            introNps = null;
+            loadProfileInfo();
+        } catch (Exception ex) {
+            // Every page runs through here, so this must not be what fails one.
+            logger.error("Could not reload the profile information for this session", ex);
+            profileInfoIncomplete = true;
+        }
     }
 
     @Override
@@ -97,6 +131,10 @@ public class NanodashSession extends WebSession {
     private ConcurrentMap<IRI, IntroNanopub> introNps;
 //	private Boolean isOrcidLinked;
 //	private String orcidLinkError;
+
+    // Set when the profile information was built from user data that could not be loaded in
+    // full, so that it is built again once it can be (issue #684).
+    private boolean profileInfoIncomplete = false;
 
     private Integer localIntroCount = null;
     private IntroNanopub localIntro = null;
@@ -144,6 +182,9 @@ public class NanodashSession extends WebSession {
         }
         if (userIri != null && keyPair != null && introNps == null) {
             introNps = new ConcurrentHashMap<>(User.getIntroNanopubs(getPubkeyString()));
+            // Remember when this was built from user data that a service could not fully
+            // answer for, so that it is built again once it can be (issue #684).
+            profileInfoIncomplete = !User.getUserData().isComplete();
         }
 //		checkOrcidLink();
     }

--- a/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/JustPublishedMessagePanel.java
@@ -79,7 +79,12 @@ public class JustPublishedMessagePanel extends Panel {
         // having a local key + ORCID, so users who cannot yet publish one (no
         // profile set up) are not nagged. A just-published introduction takes a
         // moment to register, so it is suppressed for 5 minutes after publishing. ---
-        boolean canPublishIntro = session.getUserIri() != null && session.getKeyPair() != null;
+        // Both notices below say something about the user's introductions, so neither can be
+        // said while the user data is only as much as a failing service could tell (issue
+        // #684): "you haven't published an introduction yet" would then be about what could
+        // not be loaded rather than about what the user has done.
+        boolean userDataKnown = User.getUserData().isComplete();
+        boolean canPublishIntro = userDataKnown && session.getUserIri() != null && session.getKeyPair() != null;
         boolean hasLocalIntro = session.getLocalIntroCount() > 0;
         boolean recentlyPublishedIntro = session.getTimeSinceLastIntroPublished() <= 5 * 60 * 1000;
         if (canPublishIntro && !hasLocalIntro && session.hasIntroPublished()) User.refreshUsers();

--- a/src/main/java/com/knowledgepixels/nanodash/domain/User.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/User.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.domain;
 
+import com.knowledgepixels.nanodash.NanodashThreadPool;
 import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.Nanopub;
 import org.nanopub.extra.setting.IntroNanopub;
@@ -21,7 +22,12 @@ public class User {
     private static final Logger logger = LoggerFactory.getLogger(User.class);
     private static volatile UserData userData;
     private static final long REFRESH_INTERVAL = 60 * 1000; // 1 minute
+    // How long incomplete data is kept before another load is attempted. Short, because such
+    // data is a stand-in for what a service could not tell us and the instance should come
+    // right as soon as it can answer; not immediate, so an outage is not hammered.
+    private static final long INCOMPLETE_RETRY_INTERVAL = 30 * 1000; // 30 seconds
     private static transient long lastRefresh = 0L;
+    private static transient long lastIncompleteRetry = 0L;
 
     /**
      * Refreshes the user data by creating a new UserData instance.
@@ -31,7 +37,7 @@ public class User {
         synchronized (User.class) {
             if (userData == null || System.currentTimeMillis() - lastRefresh > REFRESH_INTERVAL) {
                 lastRefresh = System.currentTimeMillis();
-                userData = new UserData(true);
+                install(new UserData(true));
             }
         }
     }
@@ -42,16 +48,79 @@ public class User {
      * restart (issue #570) — instead of forcing the fetches like the periodic
      * {@link #refreshUsers()} cycle does, which would stall the first request (session
      * creation runs through here) on the network.
+     * <p>
+     * Data that could not be built in full — a service that could not answer (issue #684) —
+     * is kept and used, and another load is attempted in the background.
      */
     public static void ensureLoaded() {
         if (userData == null) {
             synchronized (User.class) {
                 if (userData == null) {
                     lastRefresh = System.currentTimeMillis();
-                    userData = new UserData(false);
+                    install(new UserData(false));
                 }
             }
         }
+        retryIfIncomplete();
+    }
+
+    /**
+     * Takes on the given user data, unless it would replace what we have with less. A load
+     * that a service could not answer for yields {@link UserData#isComplete() incomplete}
+     * data (issue #684): that is worth having when there is nothing at all — it is what lets
+     * a cold instance serve pages while its query service is unavailable — but never worth
+     * overwriting a full load with, as a passing outage would then empty out user data that
+     * was perfectly good.
+     */
+    private static void install(UserData newData) {
+        if (!shouldReplace(userData, newData)) {
+            logger.warn("Keeping the user data we have: the new load could not be completed");
+            return;
+        }
+        if (!newData.isComplete()) logger.warn("User data is incomplete; will retry");
+        userData = newData;
+    }
+
+    /**
+     * Whether a freshly built set of user data should take the place of what is held now:
+     * anything is better than nothing, and complete data is better than incomplete, but
+     * incomplete data never replaces complete data. Package-private for testing.
+     *
+     * @param current the data held now, or null if none
+     * @param loaded  the data just built
+     * @return true if the new data should be installed
+     */
+    static boolean shouldReplace(UserData current, UserData loaded) {
+        return current == null || !current.isComplete() || loaded.isComplete();
+    }
+
+    /**
+     * Attempts another load when what we hold is incomplete, at most every
+     * {@link #INCOMPLETE_RETRY_INTERVAL}. The attempt runs in the background: the callers of
+     * this are request threads serving pages from the partial data, and they must not wait on
+     * the very service that is failing to answer.
+     */
+    private static void retryIfIncomplete() {
+        UserData data = userData;
+        if (data == null || data.isComplete()) return;
+        synchronized (User.class) {
+            if (userData == null || userData.isComplete()) return;
+            long now = System.currentTimeMillis();
+            if (now - lastIncompleteRetry < INCOMPLETE_RETRY_INTERVAL) return;
+            lastIncompleteRetry = now;
+        }
+        NanodashThreadPool.submit(() -> {
+            logger.info("Retrying the incomplete user-data load...");
+            try {
+                UserData reloaded = new UserData(false);
+                synchronized (User.class) {
+                    lastRefresh = System.currentTimeMillis();
+                    install(reloaded);
+                }
+            } catch (Exception ex) {
+                logger.error("Retry of the incomplete user-data load failed", ex);
+            }
+        });
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/domain/UserData.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/UserData.java
@@ -13,6 +13,7 @@ import org.nanopub.extra.security.MalformedCryptoElementException;
 import org.nanopub.extra.security.NanopubSignatureElement;
 import org.nanopub.extra.security.SignatureUtils;
 import org.nanopub.extra.server.GetNanopub;
+import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
 import org.nanopub.extra.setting.IntroNanopub;
@@ -48,6 +49,8 @@ public class UserData implements Serializable {
     private final HashMap<IRI, ProfilePicture> profilePictures = new HashMap<>();
     private final HashMap<IRI, IRI> defaultLicense = new HashMap<>();
 
+    private boolean complete = true;
+
     /**
      * Constructor for UserData.
      * Initializes the user data by fetching nanopublications settings.
@@ -63,10 +66,20 @@ public class UserData implements Serializable {
         final NanodashPreferences pref = NanodashPreferences.get();
 
         // TODO Make nanopublication setting configurable:
-        NanopubSetting setting;
+        NanopubSetting setting = null;
         if (pref.getSettingUri() != null) {
-            setting = new NanopubSetting(GetNanopub.get(pref.getSettingUri(), Utils.getRegistryHttpClient()));
-        } else {
+            try {
+                setting = new NanopubSetting(GetNanopub.get(pref.getSettingUri(), Utils.getRegistryHttpClient()));
+            } catch (Exception ex) {
+                // Retrieving it goes to the registry, which a cold instance may not be able to
+                // reach (issue #684); the local setting stands in until it answers.
+                logger.warn("Could not retrieve the configured nanopublication setting {}: {}", pref.getSettingUri(), ex.toString());
+                complete = false;
+            }
+        }
+        if (setting == null) {
+            // No fallback beyond this one, and its failure is a misconfiguration rather than a
+            // service that cannot answer, so it stays fatal.
             try {
                 setting = NanopubSetting.getLocalSetting();
             } catch (RDF4JException | MalformedNanopubException | IOException ex) {
@@ -74,11 +87,19 @@ public class UserData implements Serializable {
             }
         }
         String settingId = setting.getNanopub().getUri().stringValue();
-        if (setting.getUpdateStrategy().equals(NPX.UPDATES_BY_CREATOR)) {
-            settingId = QueryApiAccess.getLatestVersionId(settingId);
-            setting = new NanopubSetting(GetNanopub.get(settingId, Utils.getRegistryHttpClient()));
+        try {
+            if (setting.getUpdateStrategy().equals(NPX.UPDATES_BY_CREATOR)) {
+                settingId = QueryApiAccess.getLatestVersionId(settingId);
+                setting = new NanopubSetting(GetNanopub.get(settingId, Utils.getRegistryHttpClient()));
+            }
+            logger.info("Using nanopublication setting: {}", settingId);
+        } catch (Exception ex) {
+            // Resolving the latest version goes to the query service and the registry, so it
+            // fails on a cold instance whose services are unavailable. The setting itself is
+            // not read below, so the local one carries us until the services answer.
+            logger.warn("Could not resolve the latest version of the nanopublication setting {}: {}", settingId, ex.toString());
+            complete = false;
         }
-        logger.info("Using nanopublication setting: {}", settingId);
 
 //		// Get users that are listed directly in the authority index, and consider them approved:
 //		ByteArrayOutputStream out = new ByteArrayOutputStream(); // TODO use piped out-in stream here
@@ -118,16 +139,17 @@ public class UserData implements Serializable {
                 registerApproved(rai);
             }
         } catch (Exception ex) {
-            throw new RuntimeException(ex);
+            logger.error("Could not load the approved users from the registry: {}", ex.toString());
+            complete = false;
         }
 
         logger.info("Loading user details...");
         // Get latest introductions for all users, including unapproved ones:
-        for (ApiResponseEntry entry : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_ALL_USER_INTROS), forced).getData()) {
+        for (ApiResponseEntry entry : entriesOf(QueryApiAccess.GET_ALL_USER_INTROS, forced)) {
             register(entry);
         }
 
-        for (ApiResponseEntry entry : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_ALL_USER_PROFILE_PICS), forced).getData()) {
+        for (ApiResponseEntry entry : entriesOf(QueryApiAccess.GET_ALL_USER_PROFILE_PICS, forced)) {
             // The value can be a link or SVG markup (issue #634), and nothing stops a user
             // from declaring something unusable as either — hence the null check rather
             // than a bare parse, which would abort the whole user-data load.
@@ -135,9 +157,44 @@ public class UserData implements Serializable {
             if (picture != null) profilePictures.put(Values.iri(entry.get("user")), picture);
         }
 
-        for (ApiResponseEntry entry : ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_ALL_USER_DEFAULT_LICENSE), forced).getData()) {
+        for (ApiResponseEntry entry : entriesOf(QueryApiAccess.GET_ALL_USER_DEFAULT_LICENSE, forced)) {
             defaultLicense.put(Values.iri(entry.get("user")), Values.iri(entry.get("license")));
         }
+    }
+
+    /**
+     * The entries of one of the user-detail queries, or none when the query service cannot
+     * answer, in which case the data is marked as {@link #isComplete() not complete}.
+     * <p>
+     * Nothing here is worth failing the whole load for. A cold instance whose query service is
+     * unavailable could not build user data at all, and since session construction needs it,
+     * that left the instance unable to serve any page, its own error page included (issue
+     * #684). What it can build is partial data — whoever the registry says is approved, and
+     * no introductions — which is a serviceable state to render from and is replaced as soon
+     * as the service answers.
+     */
+    private List<ApiResponseEntry> entriesOf(String queryId, boolean forced) {
+        try {
+            ApiResponse response = ApiCache.retrieveResponseSync(new QueryRef(queryId), forced);
+            if (response != null) return response.getData();
+            logger.warn("No response yet for {}; user data stays incomplete", queryId);
+        } catch (Exception ex) {
+            logger.error("Could not load {}: {}", queryId, ex.toString());
+        }
+        complete = false;
+        return Collections.emptyList();
+    }
+
+    /**
+     * Whether this user data could be built in full. It cannot when a service it is built from
+     * is unavailable (issue #684): what is here is then only as much as the services that did
+     * answer could tell, and the data is meant to be replaced by a complete load rather than
+     * kept for the usual refresh interval.
+     *
+     * @return true if every source answered
+     */
+    public boolean isComplete() {
+        return complete;
     }
 
     private IntroNanopub toIntroNanopub(IRI iri) {

--- a/src/main/java/com/knowledgepixels/nanodash/page/ErrorPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ErrorPage.java
@@ -9,9 +9,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.request.Request;
 import org.apache.wicket.request.http.WebResponse;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -27,6 +30,8 @@ import java.util.Locale;
  * @see Kind
  */
 public class ErrorPage extends NanodashPage {
+
+    private static final Logger logger = LoggerFactory.getLogger(ErrorPage.class);
 
     /**
      * The mount path for the error page.
@@ -206,7 +211,7 @@ public class ErrorPage extends NanodashPage {
      */
     public ErrorPage(final PageParameters parameters) {
         super(parameters);
-        add(new TitleBar("titlebar", this));
+        addTitleBar();
 
         HttpServletRequest containerRequest = getContainerRequest();
         kind = resolveKind(parameters, containerRequest);
@@ -226,6 +231,24 @@ public class ErrorPage extends NanodashPage {
         add(new BookmarkablePageLink<Void>("home-link", HomePage.class));
         add(new ExternalLink("report-link", getReportUrl(message, address, backUrl))
                 .setVisible(kind == Kind.MALFUNCTION));
+    }
+
+    /**
+     * Adds the title bar, or, if it cannot be built, an empty placeholder in its place.
+     * <p>
+     * This page is where the errors of all the other ones end up, so it is the one page that
+     * has to render whatever state the instance is in. The title bar draws on the session and
+     * the user data, and when those are what went wrong — an instance that cannot reach its
+     * services (issue #684) — a failure here would turn the message this page exists to show
+     * into another unhandled exception. A page without its title bar still says what happened.
+     */
+    private void addTitleBar() {
+        try {
+            add(new TitleBar("titlebar", this));
+        } catch (Exception ex) {
+            logger.error("Could not build the title bar of the error page", ex);
+            add(new EmptyPanel("titlebar"));
+        }
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/page/NanodashPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/NanodashPage.java
@@ -64,6 +64,9 @@ public abstract class NanodashPage extends WebPage {
         super(parameters);
         markIfBrowserReload();
         ensureRefreshed();
+        // A session built while a service was unavailable holds no profile information
+        // (issue #684); this picks it up once the service answers.
+        NanodashSession.get().refreshProfileInfoIfIncomplete();
         add(new ClaudeChatPanel("claudechat", true) {
 
             @Override

--- a/src/main/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepository.java
+++ b/src/main/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepository.java
@@ -57,7 +57,7 @@ public class MaintainedResourceRepository {
     private volatile Snapshot snapshot = Snapshot.EMPTY;
 
     private Snapshot current() {
-        ApiResponse resp = ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_MAINTAINED_RESOURCES), false);
+        ApiResponse resp = ApiCache.retrieveResponseIfAvailable(new QueryRef(QueryApiAccess.GET_MAINTAINED_RESOURCES));
         if (resp == null) {
             return snapshot;
         }

--- a/src/main/java/com/knowledgepixels/nanodash/repository/SpaceRepository.java
+++ b/src/main/java/com/knowledgepixels/nanodash/repository/SpaceRepository.java
@@ -70,7 +70,7 @@ public class SpaceRepository {
     private volatile Snapshot snapshot = Snapshot.EMPTY;
 
     private Snapshot current() {
-        ApiResponse resp = ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_SPACES_REF), false);
+        ApiResponse resp = ApiCache.retrieveResponseIfAvailable(new QueryRef(QueryApiAccess.GET_SPACES_REF));
         if (resp == null) {
             return snapshot;
         }
@@ -265,7 +265,7 @@ public class SpaceRepository {
             Map<String, Space> spacesById,
             Map<Space, Set<Space>> subspaceMap,
             Map<Space, Set<Space>> superspaceMap) {
-        ApiResponse resp = ApiCache.retrieveResponseSync(new QueryRef(QueryApiAccess.GET_SUB_SPACE_LINKS), false);
+        ApiResponse resp = ApiCache.retrieveResponseIfAvailable(new QueryRef(QueryApiAccess.GET_SUB_SPACE_LINKS));
         if (resp == null) return;
         for (ApiResponseEntry r : resp.getData()) {
             Space child = spacesById.get(r.get("child"));

--- a/src/test/java/com/knowledgepixels/nanodash/ApiCacheTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ApiCacheTest.java
@@ -209,6 +209,27 @@ class ApiCacheTest {
     }
 
     @Test
+    @DisplayName("retrieveResponseIfAvailable should answer with null instead of throwing after three consecutive failures (issue #684)")
+    void retrieveResponseIfAvailable_answersWithNullAfterThreeFailures() throws Exception {
+        putFailed(3);
+
+        try (MockedStatic<QueryApiAccess> queryApiAccess = mockStatic(QueryApiAccess.class)) {
+            // The callers of this hold the state whole pages are built from: a query that
+            // cannot be answered has to read as "nothing to show yet", not as a failed page.
+            assertNull(ApiCache.retrieveResponseIfAvailable(mockQueryRef));
+        }
+    }
+
+    @Test
+    @DisplayName("retrieveResponseIfAvailable should hand back a cached response like retrieveResponseSync")
+    void retrieveResponseIfAvailable_returnsCachedResponse() throws Exception {
+        ApiResponse cached = mock(ApiResponse.class);
+        putCachedResponse(cached, 0L);
+
+        assertSame(cached, ApiCache.retrieveResponseIfAvailable(mockQueryRef));
+    }
+
+    @Test
     @DisplayName("retrieveResponseSync should skip refresh when a refresh is already running for the same cache ID")
     void retrieveResponseSync_skipsRefreshWhenAlreadyRunning() throws Exception {
         ApiResponse cached = mock(ApiResponse.class);

--- a/src/test/java/com/knowledgepixels/nanodash/domain/UserDataResilienceTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/domain/UserDataResilienceTest.java
@@ -1,0 +1,137 @@
+package com.knowledgepixels.nanodash.domain;
+
+import com.knowledgepixels.nanodash.ApiCache;
+import com.knowledgepixels.nanodash.RegistryAccountInfo;
+import com.knowledgepixels.nanodash.Utils;
+import org.eclipse.rdf4j.model.util.Values;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.Nanopub;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.QueryRef;
+import org.nanopub.extra.setting.NanopubSetting;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.*;
+
+/**
+ * What user data does when a service it is built from cannot answer (issue #684): a cold
+ * instance whose query service is unavailable has to come up all the same, since session
+ * construction goes through here and a session that cannot be built means no page at all.
+ */
+class UserDataResilienceTest {
+
+    private static final String REGISTRY_URL = "http://localhost:19292/";
+
+    /**
+     * A setting that needs no lookups of its own, so that these tests are about the user
+     * data rather than about resolving the setting's latest version.
+     */
+    private NanopubSetting staticSetting() {
+        Nanopub np = mock(Nanopub.class);
+        when(np.getUri()).thenReturn(Values.iri("http://example.org/np/setting"));
+        NanopubSetting setting = mock(NanopubSetting.class);
+        when(setting.getNanopub()).thenReturn(np);
+        when(setting.getUpdateStrategy()).thenReturn(Values.iri("http://example.org/no-updates"));
+        return setting;
+    }
+
+    private ApiResponse emptyResponse() {
+        return new ApiResponse(Collections.emptyList());
+    }
+
+    @Test
+    void aFailingQueryServiceYieldsIncompleteDataRatherThanAnException() {
+        NanopubSetting setting = staticSetting();
+        try (MockedStatic<NanopubSetting> settings = mockStatic(NanopubSetting.class);
+             MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<RegistryAccountInfo> registry = mockStatic(RegistryAccountInfo.class);
+             MockedStatic<ApiCache> apiCache = mockStatic(ApiCache.class)) {
+            settings.when(NanopubSetting::getLocalSetting).thenReturn(setting);
+            utils.when(Utils::getMainRegistryUrl).thenReturn(REGISTRY_URL);
+            registry.when(() -> RegistryAccountInfo.fromUrl(any())).thenReturn(List.of());
+            apiCache.when(() -> ApiCache.retrieveResponseSync(any(QueryRef.class), anyBoolean()))
+                    .thenThrow(new RuntimeException("Query failed"));
+
+            UserData userData = new UserData(false);
+
+            assertFalse(userData.isComplete());
+            // Serviceable all the same: the lookups the pages make answer with nothing.
+            assertTrue(userData.getIntroNanopubs(Values.iri("https://orcid.org/0000-0000-0000-0000")).isEmpty());
+            assertTrue(userData.getIntroNanopubs("some-pubkey").isEmpty());
+            assertNull(userData.getProfilePicture(Values.iri("https://orcid.org/0000-0000-0000-0000")));
+        }
+    }
+
+    @Test
+    void anUnreachableQueryServiceYieldsIncompleteDataWhenItAnswersWithNothingAtAll() {
+        NanopubSetting setting = staticSetting();
+        try (MockedStatic<NanopubSetting> settings = mockStatic(NanopubSetting.class);
+             MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<RegistryAccountInfo> registry = mockStatic(RegistryAccountInfo.class);
+             MockedStatic<ApiCache> apiCache = mockStatic(ApiCache.class)) {
+            settings.when(NanopubSetting::getLocalSetting).thenReturn(setting);
+            utils.when(Utils::getMainRegistryUrl).thenReturn(REGISTRY_URL);
+            registry.when(() -> RegistryAccountInfo.fromUrl(any())).thenReturn(List.of());
+            // Nothing cached and nothing fetched: the cache hands back null.
+            apiCache.when(() -> ApiCache.retrieveResponseSync(any(QueryRef.class), anyBoolean())).thenReturn(null);
+
+            assertFalse(new UserData(false).isComplete());
+        }
+    }
+
+    @Test
+    void anUnreachableRegistryYieldsIncompleteDataRatherThanAnException() {
+        NanopubSetting setting = staticSetting();
+        try (MockedStatic<NanopubSetting> settings = mockStatic(NanopubSetting.class);
+             MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<RegistryAccountInfo> registry = mockStatic(RegistryAccountInfo.class);
+             MockedStatic<ApiCache> apiCache = mockStatic(ApiCache.class)) {
+            settings.when(NanopubSetting::getLocalSetting).thenReturn(setting);
+            utils.when(Utils::getMainRegistryUrl).thenReturn(REGISTRY_URL);
+            registry.when(() -> RegistryAccountInfo.fromUrl(any())).thenThrow(new IOException("connection refused"));
+            apiCache.when(() -> ApiCache.retrieveResponseSync(any(QueryRef.class), anyBoolean())).thenReturn(emptyResponse());
+
+            assertFalse(new UserData(false).isComplete());
+        }
+    }
+
+    @Test
+    void dataIsCompleteWhenEverySourceAnswers() {
+        NanopubSetting setting = staticSetting();
+        try (MockedStatic<NanopubSetting> settings = mockStatic(NanopubSetting.class);
+             MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<RegistryAccountInfo> registry = mockStatic(RegistryAccountInfo.class);
+             MockedStatic<ApiCache> apiCache = mockStatic(ApiCache.class)) {
+            settings.when(NanopubSetting::getLocalSetting).thenReturn(setting);
+            utils.when(Utils::getMainRegistryUrl).thenReturn(REGISTRY_URL);
+            registry.when(() -> RegistryAccountInfo.fromUrl(any())).thenReturn(List.of());
+            apiCache.when(() -> ApiCache.retrieveResponseSync(any(QueryRef.class), anyBoolean())).thenReturn(emptyResponse());
+
+            assertTrue(new UserData(false).isComplete());
+        }
+    }
+
+    @Test
+    void incompleteDataNeverReplacesCompleteData() {
+        UserData complete = mock(UserData.class);
+        when(complete.isComplete()).thenReturn(true);
+        UserData incomplete = mock(UserData.class);
+        when(incomplete.isComplete()).thenReturn(false);
+
+        // Anything is better than nothing, and a full load always wins:
+        assertTrue(User.shouldReplace(null, incomplete));
+        assertTrue(User.shouldReplace(null, complete));
+        assertTrue(User.shouldReplace(incomplete, complete));
+        assertTrue(User.shouldReplace(incomplete, incomplete));
+        assertTrue(User.shouldReplace(complete, complete));
+        // ... but a passing outage must not empty out user data that was perfectly good:
+        assertFalse(User.shouldReplace(complete, incomplete));
+    }
+}

--- a/src/test/java/com/knowledgepixels/nanodash/page/ErrorPageTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/page/ErrorPageTest.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.page;
 
+import com.knowledgepixels.nanodash.ServiceMode;
 import com.knowledgepixels.nanodash.WicketApplication;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.HttpServletResponse;
@@ -7,9 +8,11 @@ import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.util.tester.WicketTester;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
 
 class ErrorPageTest {
 
@@ -39,6 +42,21 @@ class ErrorPageTest {
         tester.assertContains("Something went wrong here");
         assertEquals(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, tester.getLastResponse().getStatus());
         assertTrue(renderedPage().contains("https://github.com/knowledgepixels/nanodash/issues/new"), renderedPage());
+    }
+
+    // This page is where the other pages' errors end up, so it has to render whatever state
+    // the instance is in — including one where the title bar itself cannot be built, which is
+    // what an instance that cannot reach its services ran into (#684).
+    @Test
+    void rendersEvenWhenTheTitleBarCannotBeBuilt() {
+        try (MockedStatic<ServiceMode> serviceMode = mockStatic(ServiceMode.class)) {
+            serviceMode.when(ServiceMode::isRestricted).thenThrow(new RuntimeException("no services"));
+
+            tester.startPage(ErrorPage.class, params(ErrorPage.Kind.REQUEST, "That identifier is not valid."));
+
+            tester.assertRenderedPage(ErrorPage.class);
+            tester.assertContains("That identifier is not valid.");
+        }
     }
 
     // Details about what went wrong are shown to the user, so that e.g. a mistyped


### PR DESCRIPTION
Closes #684.

## The failure

Reproduced on master with an empty API cache and a query service the library does not admit: the home page hung, `/publish` answered 500, and the log carried **37 unhandled exceptions** — the chain from the issue, `UserData.<init>` ← `NanodashSession.loadProfileInfo` ← page construction, with the error page needing a session of its own and failing the same way.

Behind it was a second one the issue does not name: with the session fixed, `HomePage` still 500s in `MaintainedResourceRepository.findById` → `ApiCache.retrieveResponseSync`. Both repositories already treated a *missing* response as "nothing yet" but a *failing* one as fatal.

## The fix

- **`UserData`** builds from whatever answered and carries `isComplete()`. Nothing in it is fatal any more except an unreadable local setting file — a misconfiguration, not an outage.
- **`User.install` / `shouldReplace`** never let incomplete data replace complete data (a passing outage must not empty out good data); `retryIfIncomplete` reloads in the background, at most every 30s, never on a request thread (PR #600's rule).
- **`NanodashSession`** construction cannot fail on profile loading; `refreshProfileInfoIfIncomplete()`, called from the `NanodashPage` constructor, reloads the profile once the user data is whole again.
- **`ApiCache.retrieveResponseIfAvailable`** — null instead of throw, for the callers holding state whole pages are built from (`SpaceRepository`, `MaintainedResourceRepository`). `retrieveResponseSync` still throws, so a single view keeps reporting its own failure.
- **`ErrorPage`** renders without its title bar rather than not at all.
- **`JustPublishedMessagePanel`**: the missing-introduction and pending-approval notices are held back while the user data is incomplete — a degraded page must not tell users something false about their own account.

## Verification

A second jetty on :37374 against a stub query service answering `503` + `Nanopub-Query-Status: LOADING_INITIAL`, with `NANODASH_API_CACHE_FILE=none` — the issue's fresh-deployment scenario — then the stub switched to forwarding to the real service:

| | master | with fix |
|---|---|---|
| `/` | hang / 500 | **200**, showing "The query service is still loading. Lists and status information are incomplete." |
| `/publish`, `/profile`, `/error` | 500 | **200** |
| after the service came up | — | **full home page** (templates, events, all view sections), no restart |

Recovery was watched end to end in the browser: degraded page → service becomes ready → the instance serves its full home page again.

**Tests: 1299 pass** (8 new — `UserDataResilienceTest`, two in `ApiCacheTest`, one in `ErrorPageTest`). The error-page test was checked against unfixed code: it fails there with the issue's own "Can't instantiate page" error.

## Two notes for the reviewer

1. **Recovery follows the library's clock, not ours.** nanopub-java evicts an unhealthy query instance for `NANOPUB_QUERY_EVICTION_COOLDOWN_SECONDS` (default 300), so the 30-second retry can only succeed once that lapses. It does recover unattended — just up to five minutes after the service is ready.
2. **`ServiceHealth.checkQuery` can report HEALTHY while dispatch still fails.** `QueryCall.getApiInstances()` returned non-empty the moment the cooldown lapsed while actual calls still threw `NotEnoughAPIInstancesException`, so the #681 note can clear before queries work. Left alone here — that is the note's own logic and deserves its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqfrG3VXH5tzWXPvYJzXML