### PR TITLE
fix(version check): remember a failed lookup and keep it off the render path

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
+++ b/src/main/java/com/knowledgepixels/nanodash/WicketApplication.java
@@ -19,6 +19,7 @@ import com.knowledgepixels.nanodash.page.*;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.repository.SpaceRepository;
 import de.agilecoders.wicket.webjars.WicketWebjars;
+import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -47,6 +48,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 
@@ -65,7 +67,18 @@ public class WicketApplication extends WebApplication implements NanopubPublishe
 
     private final List<NanopubPublishedListener> publishListeners = Collections.synchronizedList(new ArrayList<>());
 
-    private static String latestVersion = null;
+    private static volatile String latestVersion = null;
+
+    /**
+     * When the latest version may be asked for again. GitHub allows 60 unauthenticated requests
+     * an hour per address, and a developer restarting the app, or several instances behind one
+     * address, run through those: a failed lookup has to be remembered as such, or the home page
+     * asks again on every render and keeps the limit spent (issue #686). An hour is GitHub's own
+     * window; a rate-limited answer says when it resets, and that is used when it does.
+     */
+    private static volatile long nextVersionLookup = 0L;
+
+    private static final long VERSION_LOOKUP_RETRY_MS = 60 * 60 * 1000; // 1 hour
 
     @Override
     public void registerListener(NanopubPublishedListener listener) {
@@ -103,7 +116,11 @@ public class WicketApplication extends WebApplication implements NanopubPublishe
             }
         }
         String v = getThisVersion();
-        String lv = getLatestVersion();
+        // Looked up here and now, so the banner below can say it. This is startup, before
+        // anything is served, which is the one place where waiting for it costs nobody
+        // anything; everywhere else reads whatever this left behind (issue #686).
+        if (claimVersionLookup()) lookUpLatestVersion();
+        String lv = latestVersion == null ? "unknown" : latestVersion;
         System.err.println("");
         System.err.println("----------------------------------------");
         System.err.println("               Nanodash");
@@ -286,16 +303,51 @@ public class WicketApplication extends WebApplication implements NanopubPublishe
     }
 
     /**
-     * Retrieves the latest version of the application from the GitHub API.
+     * The latest publicly released version of Nanodash, as far as it is known here, and null
+     * while it is not.
+     * <p>
+     * Answers with what the last lookup left behind rather than making one: this is read while
+     * a page is being built (see {@link com.knowledgepixels.nanodash.page.HomePage}), and an
+     * unreachable or slow api.github.com must not be a slow home page. A lookup that is due is
+     * handed to the background, so what it finds is there for the next render. Not knowing the
+     * latest version is a perfectly ordinary state — it only means one line of the home page is
+     * left unsaid.
      *
-     * @return The latest version as a string.
+     * @return the latest released version, or null if it is not known
      */
     public static String getLatestVersion() {
-        if (latestVersion != null) return latestVersion;
+        if (latestVersion == null && claimVersionLookup()) {
+            NanodashThreadPool.submit(WicketApplication::lookUpLatestVersion);
+        }
+        return latestVersion;
+    }
+
+    /**
+     * Claims the right to make the next lookup, at most once per {@link #VERSION_LOOKUP_RETRY_MS}
+     * and only while the version is unknown. Claiming it also postpones the one after, so a
+     * lookup that fails is not immediately tried again (issue #686). Package-private for testing.
+     *
+     * @return true if the caller should make the lookup
+     */
+    static synchronized boolean claimVersionLookup() {
+        long now = System.currentTimeMillis();
+        if (latestVersion != null || now < nextVersionLookup) return false;
+        nextVersionLookup = now + VERSION_LOOKUP_RETRY_MS;
+        return true;
+    }
+
+    /**
+     * Asks GitHub for the releases and remembers the latest one. Failing is not an error worth a
+     * stack trace: the version check is there to tell the user that a newer version exists, and
+     * not reaching GitHub — a rate limit spent, no network — leaves that unsaid and nothing else
+     * undone (issue #686).
+     */
+    private static void lookUpLatestVersion() {
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
             HttpResponse resp = client.execute(new HttpGet(LATEST_RELEASE_URL));
             int c = resp.getStatusLine().getStatusCode();
             if (c < 200 || c >= 300) {
+                postponeUntilRateLimitReset(resp);
                 throw new HttpStatusException(c);
             }
 
@@ -310,9 +362,30 @@ public class WicketApplication extends WebApplication implements NanopubPublishe
                 }
             }
         } catch (Exception ex) {
-            logger.error("Error in fetching latest version", ex);
+            logger.warn("Could not fetch the latest version from {}: {}", LATEST_RELEASE_URL, ex.toString());
         }
-        return latestVersion;
+    }
+
+    /**
+     * Waits out a spent rate limit for as long as the answer says it lasts, when it says so.
+     * {@code x-ratelimit-reset} is a Unix timestamp in seconds; anything else in that header, or
+     * a reset already in the past, leaves the standard interval in place. Package-private for
+     * testing.
+     *
+     * @param resp the answer that was refused
+     */
+    static synchronized void postponeUntilRateLimitReset(HttpResponse resp) {
+        Header header = resp.getFirstHeader("x-ratelimit-reset");
+        if (header == null || header.getValue() == null) return;
+        try {
+            long resetAt = Long.parseLong(header.getValue().trim()) * 1000L;
+            if (resetAt > nextVersionLookup) {
+                logger.info("Rate limit for {} is spent until {}", LATEST_RELEASE_URL, new Date(resetAt));
+                nextVersionLookup = resetAt;
+            }
+        } catch (NumberFormatException ex) {
+            // Not a timestamp: the standard interval stands.
+        }
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -65,7 +65,11 @@ public class HomePage extends NanodashPage {
         if (NanodashPreferences.get().isOrcidLoginMode()) {
             add(new Label("warning", ""));
         } else if (v.endsWith("-SNAPSHOT")) {
-            add(new Label("warning", "You are running a temporary snapshot version of Nanodash (" + v + "). The latest public version is " + lv + "."));
+            // The latest public version is not always known — GitHub may not have answered yet,
+            // or at all (issue #686) — and "the latest public version is null" says nothing.
+            String warning = "You are running a temporary snapshot version of Nanodash (" + v + ").";
+            if (lv != null) warning += " The latest public version is " + lv + ".";
+            add(new Label("warning", warning));
         } else if (lv != null && !v.equals(lv)) {
             add(new Label("warning", "There is a new version available: " + lv + ". You are currently using " + v + ". " +
                                      "Run 'update' (Unix/Mac) or 'update-under-windows.bat' (Windows) to update to the latest version, or manually download it " +

--- a/src/test/java/com/knowledgepixels/nanodash/LatestVersionLookupTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/LatestVersionLookupTest.java
@@ -1,0 +1,105 @@
+package com.knowledgepixels.nanodash;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * How often the latest published version is asked for (issue #686). GitHub allows 60
+ * unauthenticated requests an hour per address, so a lookup that fails has to be remembered as
+ * such: otherwise the home page asks again on every render and keeps the limit spent.
+ */
+class LatestVersionLookupTest {
+
+    @BeforeEach
+    @AfterEach
+    void forgetWhatWasLookedUp() throws Exception {
+        set("latestVersion", null);
+        set("nextVersionLookup", 0L);
+    }
+
+    private void set(String fieldName, Object value) throws Exception {
+        Field f = WicketApplication.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(null, value);
+    }
+
+    private long get(String fieldName) throws Exception {
+        Field f = WicketApplication.class.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        return (long) f.get(null);
+    }
+
+    private HttpResponse answerWithRateLimitReset(String headerValue) {
+        HttpResponse resp = mock(HttpResponse.class);
+        Header header = headerValue == null ? null : new BasicHeader("x-ratelimit-reset", headerValue);
+        when(resp.getFirstHeader("x-ratelimit-reset")).thenReturn(header);
+        return resp;
+    }
+
+    @Test
+    void theLookupIsClaimedOnceAndThenLeftAlone() {
+        assertTrue(WicketApplication.claimVersionLookup());
+        // A failed lookup must not be tried again straight away: that is what spent the limit.
+        assertFalse(WicketApplication.claimVersionLookup());
+    }
+
+    @Test
+    void nothingIsLookedUpOnceTheVersionIsKnown() throws Exception {
+        set("latestVersion", "5.13.0");
+
+        assertFalse(WicketApplication.claimVersionLookup());
+        assertEquals("5.13.0", WicketApplication.getLatestVersion());
+    }
+
+    @Test
+    void anUnknownVersionIsAnsweredWithNullRatherThanWaitedFor() throws Exception {
+        // A lookup is not due, so this can only answer with what is held: null, and at once —
+        // it is read while a page is being built, and must not go to the network there.
+        set("nextVersionLookup", System.currentTimeMillis() + 60 * 60 * 1000);
+
+        assertNull(WicketApplication.getLatestVersion());
+    }
+
+    @Test
+    void aSpentRateLimitIsWaitedOutForAsLongAsItSays() throws Exception {
+        long resetAt = System.currentTimeMillis() + 3 * 60 * 60 * 1000; // beyond the usual hour
+
+        WicketApplication.postponeUntilRateLimitReset(answerWithRateLimitReset(Long.toString(resetAt / 1000)));
+
+        assertEquals(resetAt / 1000, get("nextVersionLookup") / 1000);
+        assertFalse(WicketApplication.claimVersionLookup());
+    }
+
+    @Test
+    void aResetAlreadyPastDoesNotShortenTheWait() throws Exception {
+        long inAnHour = System.currentTimeMillis() + 60 * 60 * 1000;
+        set("nextVersionLookup", inAnHour);
+
+        WicketApplication.postponeUntilRateLimitReset(
+                answerWithRateLimitReset(Long.toString((System.currentTimeMillis() - 60000) / 1000)));
+
+        assertEquals(inAnHour, get("nextVersionLookup"));
+    }
+
+    @Test
+    void anAnswerWithoutAUsableResetHeaderLeavesTheIntervalAlone() throws Exception {
+        long inAnHour = System.currentTimeMillis() + 60 * 60 * 1000;
+        set("nextVersionLookup", inAnHour);
+
+        WicketApplication.postponeUntilRateLimitReset(answerWithRateLimitReset(null));
+        assertEquals(inAnHour, get("nextVersionLookup"));
+
+        WicketApplication.postponeUntilRateLimitReset(answerWithRateLimitReset("soon"));
+        assertEquals(inAnHour, get("nextVersionLookup"));
+    }
+}


### PR DESCRIPTION
Closes #686.

## What was wrong

`WicketApplication.getLatestVersion()` asks the unauthenticated GitHub API for the release list — 60 requests an hour per address. Once those are spent, the 403 was handled in three unhelpful ways:

- **A failed lookup was not remembered.** `latestVersion` stayed null and only success was cached, so `HomePage.java:64` re-issued the request on *every render* — which is what kept the limit spent. Caching success forever and failure not at all is the wrong way round.
- **It ran on the request thread**, inline during page construction, so a slow or unreachable api.github.com was a slow home page. This is the wait PR #600 set out to remove; the version check was missed there because it is not an API-cache query.
- **It was logged as an error with a full stack trace** — sixty lines of Wicket/Jetty/Maven frames for "could not reach GitHub", which reads like a broken startup when nothing is wrong.

## The change

- A lookup is claimed at most once an hour (`claimVersionLookup`), whether it succeeds or fails; a rate-limited answer is waited out for as long as its `x-ratelimit-reset` says.
- Startup keeps looking the version up in the foreground — that is where the banner needs it, and nothing is being served yet. `getLatestVersion()` answers with whatever that left behind and hands a due lookup to the background.
- A failure is a `warn` with its message.
- Not knowing the version now reads as `unknown` in the banner and leaves the sentence unsaid on the home page, instead of "The latest public version is null."

## Verification

Ran a second jetty on :37374 both ways.

**Unreachable release API** (constant pointed at a dead port for the run):

```
WARN WicketApplication - Could not fetch the latest version from http://localhost:1/releases:
    org.apache.http.conn.HttpHostConnectException: Connect to localhost:1 ... Connection refused
```

one line, no trace — and across **three home-page renders**: all 200, **1 lookup attempted in total** (before this change each render would have made another). The home page said "You are running a temporary snapshot version of Nanodash (5.13.1-SNAPSHOT)." with no trailing "null".

**Real API**: banner `Latest public version: 5.13.0`, home page "…(5.13.1-SNAPSHOT). The latest public version is 5.13.0." — unchanged behaviour when GitHub answers.

**Tests: 1297 pass**, 6 new in `LatestVersionLookupTest` covering the once-an-hour claim, no lookup once the version is known, an unknown version answered with null rather than waited for, and the `x-ratelimit-reset` handling (honoured when later, ignored when past or unparseable).

Branched from master, independent of #687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqfrG3VXH5tzWXPvYJzXML