### PR TITLE
Publish protected nanopublications from local instances (#671)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Status legend: ✅ Implemented · 🚧 In progress · 📋 Proposed
 | [draft-with-ai](draft-with-ai.md) | 📋 Proposed | Server-side "Draft with AI" nanopub authoring |
 | [uri-schemes](uri-schemes.md) | ✅ Implemented | Accepts and renders `ipfs:`, `ipns:`, `did:` and `at:` URIs alongside `http(s)`, with configurable outbound resolvers and scheme-aware short labels ([#655](https://github.com/knowledgepixels/nanodash/issues/655)) |
 | [locked-prefilled-values](locked-prefilled-values.md) | ✅ Implemented | `locked=` states that a value pre-filled via URL args cannot be changed in the form (per field and per repetition, so pre-filled keys can be fixed while more can still be added); `locked-statements=` fixes the set of repetitions ([#678](https://github.com/knowledgepixels/nanodash/issues/678)) |
+| [protected-nanopublications](protected-nanopublications.md) | ✅ Implemented | Publishing nanopublications typed `npx:ProtectedNanopub` from a deployment connected to a local/private registry: an unlisted pubinfo template behind its own checkbox, a deployment default, and the cases where protection is not the user's to turn off ([#671](https://github.com/knowledgepixels/nanodash/issues/671)) |
 | [claude-code-chat](claude-code-chat.md) | 🚧 In progress | Chat panel backed by the user's local Claude Code, acting on Nanodash via an MCP endpoint (Tier 2 of [#434](https://github.com/knowledgepixels/nanodash/issues/434)) |
 
 When a doc's status changes, update both its `**Status:**` line and the row here.

--- a/docs/protected-nanopublications.md
+++ b/docs/protected-nanopublications.md
@@ -1,0 +1,140 @@
+# Publishing protected nanopublications
+
+**Status:** ✅ Implemented ([#671](https://github.com/knowledgepixels/nanodash/issues/671)).
+
+## Goal
+
+A local/private Nanopub Registry accepts, stores and serves nanopublications typed
+`npx:ProtectedNanopub`; the public network refuses them. Nanodash already *recognizes*
+protected nanopublications (the 🔒 flag on a nanopublication, the 🔒 restricted marker in
+the title bar). This is the other half: letting users of such a deployment **create** them.
+
+## The marker
+
+What registries look at is exactly one triple in the publication info:
+
+```turtle
+this: a npx:ProtectedNanopub .
+```
+
+`NanopubServerUtils.isProtectedNanopub` (nanopub-java) checks for that triple, with the
+nanopublication itself as the subject, and `PublishNanopub.publish` then skips every
+registry that is not a local instance — refusing outright, without sending the content,
+when none is left.
+
+Two near-misses do **not** count, and both look right in a form:
+
+- `npx:hasNanopubType npx:ProtectedNanopub`, which is what the generic "Nanopublication
+  type" pubinfo element produces.
+- The same `rdf:type` triple with a subject other than the nanopublication.
+
+A nanopublication carrying only a near-miss is published to the public network. The
+publish form therefore refuses to build one (`PublishForm.checkProtectedMarker`).
+
+## The template
+
+The marker is added by an ordinary pubinfo template,
+[`RAjTlfGJgWb8K7cOspGdwodPpnu859q78Rps40xDGdgZs`](https://w3id.org/np/RAjTlfGJgWb8K7cOspGdwodPpnu859q78Rps40xDGdgZs)
+("Protected nanopublication"), hard-coded as `ProtectedNanopubs.TEMPLATE_ID`. It has no
+placeholders: adding it adds the marker.
+
+Going through a template rather than emitting the triple in code buys two things: the
+statement has a `nt:wasCreatedFromPubinfoTemplate` link like every other one, and
+`ValueFiller` claims it when a protected nanopublication is superseded, instead of
+sweeping it into the hand-coded catch-all.
+
+The template is `nt:UnlistedTemplate`, so it does not appear in the "add element…"
+dropdown. Where a nanopublication may be stored is not a description of its content, and
+the publication info section is behind "show more" — this decision gets its own control
+instead.
+
+The template nanopublication itself is published **publicly**: a local registry mirrors
+the public network, so a public template resolves everywhere, while a protected one would
+make every nanopublication built on it unresolvable outside the local instance. A copy is
+in `src/test/resources/np-protected-nanopub-template.trig`, which the tests check against
+the hard-coded ID.
+
+## The control
+
+A checkbox where the consent checkbox is, "🔒 Protected nanopublication". Toggling it adds
+or removes the pubinfo context, so the RDF still comes out of the template machinery.
+
+**The consent checkbox is about open publication, so it is shown only for a
+nanopublication that will be openly published.** Where protection is possible it says so
+explicitly:
+
+> I understand that this will be openly published, that published data cannot be fully
+> removed (only retracted or superseded by new versions), and that it will be publicly
+> connected to my personal identifier.
+
+Ticking the protected box therefore takes that checkbox away rather than rewording it:
+nothing goes to the public network, so there is nothing to consent to. The user has one
+box, and it carries a plain statement of fact instead of a second consent text:
+
+> This nanopublication will stay on the local instance this Nanodash is connected to.
+
+Unticked, there is no note at all — the consent checkbox already says where this goes.
+Where protection is **forced** the note gives the reason instead, and the checkbox is
+disabled.
+
+The **preview page** shows the same box, ticked and disabled, whenever the nanopublication
+it is about to publish carries the marker: by then it is signed into the content and
+cannot be taken back there. Its consent checkbox follows the same rule and the same
+wording (`PublishForm.getConsentText()`), so it is absent for a protected preview.
+
+Two consequences of tying consent to open publication: a protected nanopublication is
+published without any box being ticked (there is only the protected box, and on a
+private-by-default deployment it starts ticked), and `isConsentGiven()` — which also
+feeds the preview page — is true whenever protection is on.
+
+The plain consent text (no "openly published" clause) stays in place on deployments where
+protection is not possible, since there is nothing there to contrast it with.
+
+The protected checkbox is shown only when the main registry reports itself as a local instance
+(`ServiceMode.isRegistryLocal()`), because a public registry cannot store a protected
+nanopublication and the option would do nothing but make publishing fail.
+
+## Defaults
+
+Both kinds of local instance exist — mostly-public ones with occasional protected
+content, and private-by-default ones — so the default is a deployment setting:
+
+```
+NANODASH_PROTECTED_BY_DEFAULT=true
+```
+
+(or `protectedByDefault: true` in `~/.nanopub/nanodash-preferences.yml`). It only sets
+where the form starts, and has no effect where protection is not offered.
+
+## When the user has no say
+
+`ProtectedNanopubs.getForcedReason` decides this; the checkbox is then shown checked and
+disabled, with the reason spelled out.
+
+- **The fill source is protected** (supersede, derive, override, improve, use). The new
+  nanopublication repeats the old one's content, so publishing it unprotected would be
+  the thing that exposes it.
+- **A template the form is built on is protected**. That template is stored on the local
+  instance only, so a public nanopublication made with it would carry a
+  `nt:wasCreatedFromTemplate` link nobody outside can follow.
+
+Not covered: a nanopublication governed by a protected space. The governing space is
+identified by a resource IRI rather than by the nanopublication that defines it, so
+answering that would take a query; in practice the templates such a space governs are
+themselves stored on the local instance, which the template rule catches.
+
+If protection is forced but the template cannot be loaded, the form refuses to publish
+rather than publishing without the marker.
+
+## Always-protected content
+
+A kind of content that is always protected needs no code and no user decision: an
+assertion template can list the pubinfo template in `nt:hasRequiredPubinfoElement`, which
+adds it to the form and makes it non-removable.
+
+## What this does not change
+
+Publishing *without* the marker on a local instance still shares the nanopublication with
+the public network, if the local registry has public peers — which is the normal setup,
+since that is how it mirrors the network. "Not protected" means public, and the consent
+checkbox says so.

--- a/docs/protected-nanopublications.md
+++ b/docs/protected-nanopublications.md
@@ -22,6 +22,22 @@ nanopublication itself as the subject, and `PublishNanopub.publish` then skips e
 registry that is not a local instance — refusing outright, without sending the content,
 when none is left.
 
+### Where it is sent
+
+`Utils.publishNanopub` addresses a protected nanopublication to `Utils.getMainRegistryUrl()`
+directly, instead of letting the library pick from its own list. That list comes from
+bootstrap plus discovered registries (or `NANOPUB_REGISTRY_INSTANCES`) and knows nothing
+about `NANODASH_MAIN_REGISTRY`, so on a deployment configured only the Nanodash way,
+publishing a protected nanopublication used to fail with "None of the available registries
+is a local instance" — while the local instance was sitting right there in the config.
+There is only one place a protected nanopublication can go, and Nanodash already checked
+that it reports itself as a local instance, so it is named directly.
+
+Everything else keeps going to the library's list, deliberately. Registries **pull** from
+their peers rather than pushing to them, so an openly published nanopublication sent only
+to a private registry would never reach the public network — the opposite of what
+publishing it unprotected means. The private registry picks it up again through peering.
+
 Two near-misses do **not** count, and both look right in a form:
 
 - `npx:hasNanopubType npx:ProtectedNanopub`, which is what the generic "Nanopublication

--- a/src/main/java/com/knowledgepixels/nanodash/NanodashPreferences.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanodashPreferences.java
@@ -61,6 +61,7 @@ public class NanodashPreferences implements Serializable {
     private boolean mcpRemoteEnabled = false;
     private String apiCacheFile;
     private String uriResolvers;
+    private boolean protectedByDefault = false;
     public static final String DEFAULT_SETTING_PATH = "/.nanopub/nanodash-preferences.yml";
 
     /**
@@ -475,6 +476,36 @@ public class NanodashPreferences implements Serializable {
 
     public void setHomeResource(String homeResource) {
         this.homeResource = homeResource;
+    }
+
+    /**
+     * Whether new nanopublications are protected by default, i.e. whether this is a
+     * private-by-default deployment. Read from the {@code NANODASH_PROTECTED_BY_DEFAULT}
+     * environment variable or the preferences file.
+     * <p>
+     * This only sets where the publish form starts; the user can still turn protection off for
+     * an individual nanopublication (unless it is protected by force, see
+     * {@link ProtectedNanopubs}). It has no effect at all on a deployment whose registry is not
+     * a local instance, since such a registry has no way to store a protected nanopublication.
+     *
+     * @return true if the publish form should offer protection pre-selected
+     */
+    public boolean isProtectedByDefault() {
+        if ("true".equals(System.getenv("NANODASH_PROTECTED_BY_DEFAULT"))) {
+            logger.debug("Found environment variable NANODASH_PROTECTED_BY_DEFAULT with value: {}", true);
+            return true;
+        }
+        logger.debug("Environment variable NANODASH_PROTECTED_BY_DEFAULT not set, using default: {}", protectedByDefault);
+        return protectedByDefault;
+    }
+
+    /**
+     * Set whether new nanopublications are protected by default.
+     *
+     * @param protectedByDefault true for a private-by-default deployment
+     */
+    public void setProtectedByDefault(boolean protectedByDefault) {
+        this.protectedByDefault = protectedByDefault;
     }
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/ProtectedNanopubs.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ProtectedNanopubs.java
@@ -1,0 +1,110 @@
+package com.knowledgepixels.nanodash;
+
+import com.knowledgepixels.nanodash.template.Template;
+import org.nanopub.Nanopub;
+import org.nanopub.extra.server.NanopubServerUtils;
+
+import java.util.Collection;
+
+/**
+ * The policy for protected nanopublications (issue #671): nanopublications typed
+ * {@code npx:ProtectedNanopub} in their publication info, which local/private Nanopub Registry
+ * instances accept, store and serve, and which the public network refuses.
+ * <p>
+ * The marker itself is added by an ordinary pubinfo template ({@link #TEMPLATE_ID}), so that the
+ * resulting statement has a template behind it like every other one and round-trips through
+ * {@code ValueFiller} when a protected nanopublication is superseded. The template is unlisted,
+ * though: it is not a description of the content but a decision about where the nanopublication
+ * may be stored, and it deserves an affordance of its own rather than a line in the "add
+ * element..." dropdown, which is behind "show more" and easy to get subtly wrong (the generic
+ * "Nanopublication type" template, for one, produces {@code npx:hasNanopubType} — <em>not</em>
+ * what makes a nanopublication protected, so a nanopublication that looks protected in the form
+ * would be published to the public network).
+ * <p>
+ * Whether protection is on by default is a deployment decision, because both kinds of local
+ * instance exist: mostly-public ones with occasional protected content, and private-by-default
+ * ones. See {@link NanodashPreferences#isProtectedByDefault()}.
+ */
+public class ProtectedNanopubs {
+
+    private ProtectedNanopubs() {
+    }  // no instances allowed
+
+    /**
+     * The pubinfo template that adds the {@code npx:ProtectedNanopub} type to the nanopublication
+     * being created. It has no placeholders: adding it adds the marker.
+     */
+    public static final String TEMPLATE_ID = "https://w3id.org/np/RAjTlfGJgWb8K7cOspGdwodPpnu859q78Rps40xDGdgZs";
+
+    /**
+     * What the protected checkbox says about a nanopublication that carries the marker. It is a
+     * statement of fact, not a consent text: nothing is openly published, so there is nothing to
+     * consent to (see {@code PublishForm.isConsentGiven}).
+     */
+    public static final String STAYS_LOCAL_NOTE =
+            "This nanopublication will stay on the local instance this Nanodash is connected to.";
+
+    /**
+     * Returns whether this deployment can store protected nanopublications at all, and should
+     * therefore offer to make them. Only a local/private registry accepts them; on a public
+     * deployment the option would do nothing but make publishing fail.
+     *
+     * @return true if the main registry is a local instance
+     */
+    public static boolean isOffered() {
+        return ServiceMode.isRegistryLocal();
+    }
+
+    /**
+     * Returns whether the publish form should start with protection turned on.
+     *
+     * @return true on a private-by-default deployment that can store protected nanopublications
+     */
+    public static boolean isOnByDefault() {
+        return isOffered() && NanodashPreferences.get().isProtectedByDefault();
+    }
+
+    /**
+     * Returns whether the given nanopublication carries the protected marker.
+     *
+     * @param np the nanopublication to check, may be null
+     * @return true if it is typed {@code npx:ProtectedNanopub} in its own publication info
+     */
+    public static boolean isProtected(Nanopub np) {
+        return np != null && NanopubServerUtils.isProtectedNanopub(np);
+    }
+
+    /**
+     * Returns why a nanopublication built on the given sources has to be protected, or null if
+     * the choice is free.
+     * <p>
+     * A new version of, or a nanopublication derived from, a protected one would otherwise expose
+     * the content it repeats; a nanopublication made with a protected template would be a public
+     * nanopublication whose {@code nt:wasCreatedFromTemplate} link nobody outside the local
+     * instance can follow. Both are decided here rather than left to the user.
+     * <p>
+     * Not covered: a nanopublication governed by a protected space. The governing space is
+     * identified by a resource IRI rather than by the nanopublication that defines it, so
+     * answering that would take a query; in practice the templates such a space governs are
+     * themselves stored on the local instance, which the template check below catches.
+     *
+     * @param fillSource the nanopublication the form is filled from (superseded, derived from,
+     *                   overridden or improved), or null
+     * @param templates  the templates the form is built on
+     * @return a phrase naming the reason, to be shown to the user, or null if not forced
+     */
+    public static String getForcedReason(Nanopub fillSource, Collection<Template> templates) {
+        if (isProtected(fillSource)) {
+            return "the nanopublication it is based on is protected";
+        }
+        if (templates != null) {
+            for (Template template : templates) {
+                if (template != null && isProtected(template.getNanopub())) {
+                    return "the template it is based on is protected";
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/knowledgepixels/nanodash/Utils.java
+++ b/src/main/java/com/knowledgepixels/nanodash/Utils.java
@@ -36,6 +36,7 @@ import org.nanopub.extra.security.NanopubSignatureElement;
 import org.nanopub.extra.security.SignatureUtils;
 import org.nanopub.extra.server.GetNanopub;
 import org.nanopub.extra.server.NanopubServerUtils;
+import org.nanopub.extra.server.PublishNanopub;
 import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.NotEnoughAPIInstancesException;
 import org.nanopub.extra.services.QueryCall;
@@ -48,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wicketstuff.select2.Select2Choice;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.net.URI;
@@ -258,6 +260,33 @@ public class Utils {
     public static void cacheNanopub(Nanopub np) {
         String artifactCode = GetNanopub.getArtifactCode(np.getUri().stringValue()).toString();
         nanopubs.put(artifactCode, np);
+    }
+
+    /**
+     * Publishes a nanopublication, choosing where it goes.
+     * <p>
+     * A protected nanopublication has exactly one possible destination: the local instance this
+     * Nanodash is configured against, which has already been checked to report itself as one (see
+     * {@link ProtectedNanopubs#isOffered()}). Naming it directly means {@code NANODASH_MAIN_REGISTRY}
+     * is enough on such a deployment, instead of also needing {@code NANOPUB_REGISTRY_INSTANCES} to
+     * steer the library's own dispatch list (#671, #680).
+     * <p>
+     * Everything else goes to that list as before, and deliberately so: registries pull from their
+     * peers rather than pushing to them, so an openly published nanopublication sent only to a
+     * private registry would never reach the public network — the opposite of what publishing it
+     * unprotected means.
+     *
+     * @param signedNp the signed nanopublication to publish
+     * @return the URL the nanopublication was published at
+     * @throws IOException if publishing fails
+     */
+    public static String publishNanopub(Nanopub signedNp) throws IOException {
+        if (ProtectedNanopubs.isProtected(signedNp) && ProtectedNanopubs.isOffered()) {
+            String registryUrl = getMainRegistryUrl();
+            logger.info("Publishing protected nanopublication to the configured local instance: {}", registryUrl);
+            return PublishNanopub.publish(signedNp, registryUrl);
+        }
+        return PublishNanopub.publish(signedNp);
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.html
@@ -132,11 +132,15 @@
 </button>
 </p>
 
+<p wicket:id="protected-section" class="protected-option">
+<input type="checkbox" wicket:id="protectedcheck" id="protectedcheck"/>
+<label for="protectedcheck"><strong>&#128274; Protected nanopublication</strong></label>
+<span wicket:id="protected-note" class="protected-note">It will be shared with the public nanopublication network.</span>
+</p>
+
 <p wicket:id="consent-section">
 <input type="checkbox" wicket:id="consentcheck" id="consentcheck"/>
-<label for="consentcheck">
-I understand that published data cannot be fully removed (only retracted or superseded by new versions), and is publicly connected to my personal identifier.
-</label>
+<label for="consentcheck"><span wicket:id="consenttext">I understand that published data cannot be fully removed (only retracted or superseded by new versions), and is publicly connected to my personal identifier.</span></label>
 </p>
 
 <p wicket:id="button-section" class="center">

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -48,9 +48,9 @@ import org.nanopub.Nanopub;
 import org.nanopub.NanopubAlreadyFinalizedException;
 import org.nanopub.NanopubCreator;
 import org.nanopub.extra.security.SignNanopub;
+import org.nanopub.extra.server.PublishNanopub;
 import org.nanopub.extra.security.SignatureAlgorithm;
 import org.nanopub.extra.security.TransformContext;
-import org.nanopub.extra.server.PublishNanopub;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
@@ -87,6 +87,15 @@ public class PublishForm extends Panel {
     private static final String[] fixedPubInfoTemplates = new String[]{CREATOR_PUB_INFO_TEMPLATE, LICENSE_PUB_INFO_TEMPLATE};
 
     private static final String INVALID_TEMPLATE_MESSAGE = "This form is based on an invalid template and cannot be published.";
+    private static final String CONSENT_TEXT =
+            "I understand that published data cannot be fully removed (only retracted or superseded " +
+            "by new versions), and is publicly connected to my personal identifier.";
+    // Where protected nanopublications are possible, the consent has to say which of the two it
+    // is about: it is the open publication that cannot be taken back (#671).
+    private static final String OPEN_CONSENT_TEXT =
+            "I understand that this will be openly published, that published data cannot be fully " +
+            "removed (only retracted or superseded by new versions), and that it will be publicly " +
+            "connected to my personal identifier.";
     // Page parameters that make the form supersede or override an existing nanopublication
     // ("fill" is the deprecated form of "supersede"):
     private static final String[] sourceParamKeys = new String[]{"supersede", "supersede-a", "override", "override-a", "fill"};
@@ -148,6 +157,19 @@ public class PublishForm extends Panel {
     private final Map<String, TemplateContext> pubInfoContextMap = new HashMap<>();
     private final List<TemplateContext> requiredPubInfoContexts = new ArrayList<>();
     private String targetNamespace;
+    // Protected nanopublications (#671). The context carrying the marker is present exactly when
+    // the nanopublication being created is to be protected; the checkbox next to the consent one
+    // adds and removes it. The reason is non-null when the user has no say (see
+    // ProtectedNanopubs.getForcedReason).
+    private TemplateContext protectedContext;
+    private String protectedForcedReason;
+    private String protectedTemplateId;
+    private boolean protectedTemplateMissing;
+    private Label protectedNoteLabel;
+    private Label consentTextLabel;
+    private CheckBox consentCheck;
+    private WebMarkupContainer consentSection;
+    private boolean publishingDisabled;
     // The space / maintained resource / user this form was reached under, which
     // space-/namespace-dependent template prefixes resolve against (see DynamicPrefix):
     private final String navigationContextId;
@@ -405,6 +427,35 @@ public class PublishForm extends Panel {
         // Propagate fill source (supersede/derive/improve) so contexts can resolve
         // the `local:nanopub`/`local:assertion` sentinels to the fill nanopub's URIs.
         Nanopub fillSource = fillNp != null ? fillNp : improveNp;
+
+        // Protected nanopublications (#671): the marker is added by an ordinary (but unlisted)
+        // pubinfo template, driven from the checkbox next to the consent one rather than from the
+        // "add element..." dropdown, which is behind "show more". A carried-over marker from a
+        // protected fill source has already put the context in the map above; that counts as on.
+        List<Template> formTemplates = new ArrayList<>();
+        formTemplates.add(assertionContext.getTemplate());
+        formTemplates.add(provenanceContext.getTemplate());
+        for (TemplateContext c : pubInfoContexts) formTemplates.add(c.getTemplate());
+        protectedForcedReason = ProtectedNanopubs.getForcedReason(fillSource, formTemplates);
+        protectedTemplateId = td.getLatestTemplateId(ProtectedNanopubs.TEMPLATE_ID);
+        protectedContext = pubInfoContextMap.get(protectedTemplateId);
+        if (protectedContext == null) {
+            protectedContext = pubInfoContextMap.get(ProtectedNanopubs.TEMPLATE_ID);
+        }
+        if (protectedContext != null && requiredPubInfoContexts.contains(protectedContext)) {
+            // The assertion template declares it in nt:hasRequiredPubinfoElement: this kind of
+            // content is always protected, whatever the deployment default says.
+            protectedForcedReason = "the template it is based on requires it";
+        }
+        if (protectedContext == null && (protectedForcedReason != null || ProtectedNanopubs.isOnByDefault())) {
+            protectedContext = newProtectedContext();
+        }
+        if (protectedContext != null && !requiredPubInfoContexts.contains(protectedContext)) {
+            // Turning protection off is what the checkbox is for; a second control for the same
+            // decision, hidden behind "show more", would only be a way to get it half-off.
+            requiredPubInfoContexts.add(protectedContext);
+        }
+
         if (fillSource != null) {
             assertionContext.setFillSource(fillSource);
             provenanceContext.setFillSource(fillSource);
@@ -586,6 +637,15 @@ public class PublishForm extends Panel {
         for (TemplateContext c : pubInfoContexts) {
             collectTemplateErrors("Publication info", c, templateErrors);
         }
+        if (protectedTemplateMissing) {
+            // The form was to start protected, and cannot. Without the marker the nanopublication
+            // would go to the public network, which is exactly what was to be prevented, and a
+            // silent downgrade to public is the one outcome that cannot be taken back.
+            templateErrors.add(new TemplateError("Publication info",
+                    "This nanopublication is to be protected, because " +
+                    (protectedForcedReason != null ? protectedForcedReason : "this deployment protects nanopublications by default") +
+                    ", but the template that marks it as such could not be loaded: " + protectedTemplateId));
+        }
         if (!templateErrors.isEmpty()) {
             add(new Label("template-error-intro", "This form is based on an invalid template and will not produce the nanopublication it describes:"));
         } else {
@@ -608,7 +668,7 @@ public class PublishForm extends Panel {
             c.finalizeStatements();
         }
 
-        final CheckBox consentCheck = new CheckBox("consentcheck", new Model<>(false));
+        consentCheck = new CheckBox("consentcheck", new Model<>(false));
         consentCheck.add(new InvalidityHighlighting());
 
         form = new Form<Void>("form") {
@@ -632,7 +692,7 @@ public class PublishForm extends Panel {
                     return;
                 }
 
-                if (!Boolean.TRUE.equals(consentCheck.getModelObject())) {
+                if (!isConsentGiven()) {
                     feedbackPanel.error("You need to check the checkbox that you understand the consequences.");
                     return;
                 }
@@ -1020,11 +1080,61 @@ public class PublishForm extends Panel {
 
         // An invalid template cannot produce the nanopublication it describes, so there is
         // nothing to consent to, publish or preview; the reasons are listed above the form.
-        boolean publishingDisabled = !templateErrors.isEmpty();
+        publishingDisabled = !templateErrors.isEmpty();
 
-        WebMarkupContainer consentSection = new WebMarkupContainer("consent-section");
+        // The protected-nanopublication option (#671), next to the consent checkbox rather than
+        // among the publication info elements: those sit behind "show more", and where a
+        // nanopublication may be stored is not something to find by unfolding an advanced section.
+        WebMarkupContainer protectedSection = new WebMarkupContainer("protected-section");
+        protectedSection.setVisible((ProtectedNanopubs.isOffered() || protectedContext != null) && !publishingDisabled);
+        final CheckBox protectedCheck = new CheckBox("protectedcheck", new Model<>(protectedContext != null));
+        protectedCheck.setOutputMarkupId(true);
+        if (protectedForcedReason != null) {
+            // Wicket skips input processing for a disabled component, so the model keeps saying
+            // "protected" even though the browser submits nothing for the checkbox.
+            protectedCheck.setEnabled(false);
+        } else {
+            protectedCheck.add(new AjaxFormComponentUpdatingBehavior("change") {
+
+                @Override
+                protected void onUpdate(AjaxRequestTarget target) {
+                    setProtected(Boolean.TRUE.equals(protectedCheck.getModelObject()), target);
+                }
+
+            });
+        }
+        protectedSection.add(protectedCheck);
+        protectedNoteLabel = new Label("protected-note", (IModel<String>) this::getProtectedNote) {
+
+            @Override
+            protected void onConfigure() {
+                super.onConfigure();
+                // Unprotected needs no note: the consent checkbox below says it will be openly
+                // published, which is the same statement.
+                setVisible(getProtectedNote() != null);
+            }
+
+        };
+        protectedNoteLabel.setOutputMarkupPlaceholderTag(true);
+        protectedSection.add(protectedNoteLabel);
+        form.add(protectedSection);
+
+        // Hidden while the protected checkbox stands in for it (#671), so that the user has one
+        // box to tick rather than two saying overlapping things.
+        consentSection = new WebMarkupContainer("consent-section");
+        consentSection.setOutputMarkupPlaceholderTag(true);
         consentSection.add(consentCheck);
-        consentSection.setVisible(!publishingDisabled);
+        consentTextLabel = new Label("consenttext", new IModel<String>() {
+
+            @Override
+            public String getObject() {
+                return getConsentText();
+            }
+
+        });
+        consentTextLabel.setOutputMarkupId(true);
+        consentSection.add(consentTextLabel);
+        consentSection.setVisible(!publishingDisabled && protectedContext == null);
         form.add(consentSection);
 
         WebMarkupContainer buttonSection = new WebMarkupContainer("button-section");
@@ -1052,7 +1162,7 @@ public class PublishForm extends Panel {
                     Nanopub signedNp = SignNanopub.signAndTransform(np, tc);
                     String previewId = signedNp.getUri().stringValue();
                     NanodashSession.get().setPreviewNanopub(previewId,
-                            new NanodashSession.PreviewNanopub(signedNp, pageParams, confirmPageClass, Boolean.TRUE.equals(consentCheck.getModelObject()), getPage().getPageReference()));
+                            new NanodashSession.PreviewNanopub(signedNp, pageParams, confirmPageClass, isConsentGiven(), getPage().getPageReference()));
                     throw new RestartResponseException(PreviewPage.class, new PageParameters().set("id", previewId));
                 } catch (RestartResponseException ex) {
                     throw ex;
@@ -1225,6 +1335,99 @@ public class PublishForm extends Panel {
         return t != null && t.isTransient();
     }
 
+    /**
+     * Turns protection of the nanopublication being created on or off (#671), by adding or
+     * removing the pubinfo context that carries the marker.
+     *
+     * @param on     whether the nanopublication is to be protected
+     * @param target the AJAX target to update the form with, may be null
+     */
+    private void setProtected(boolean on, AjaxRequestTarget target) {
+        TemplateContext created = null;
+        if (on && protectedContext == null) {
+            protectedContext = newProtectedContext();
+            if (protectedContext == null) {
+                feedbackPanel.error("The template that marks a nanopublication as protected could " +
+                        "not be loaded, so this nanopublication cannot be protected: " + protectedTemplateId);
+            } else {
+                protectedContext.initStatements();
+                requiredPubInfoContexts.add(protectedContext);
+                created = protectedContext;
+            }
+        } else if (!on && protectedContext != null) {
+            pubInfoContexts.remove(protectedContext);
+            pubInfoContextMap.remove(protectedContext.getTemplateId());
+            pubInfoContextMap.remove(protectedTemplateId);
+            requiredPubInfoContexts.remove(protectedContext);
+            protectedContext = null;
+        }
+        refreshPubInfo(target);
+        if (created != null) created.finalizeStatements();
+        consentSection.setVisible(!publishingDisabled && protectedContext == null);
+        if (target != null) {
+            target.add(protectedNoteLabel);
+            target.add(consentSection);
+        }
+    }
+
+    /**
+     * Returns the sentence below the protected-nanopublication checkbox, saying what the current
+     * setting means for where this nanopublication ends up.
+     *
+     * @return the note to show
+     */
+    private String getProtectedNote() {
+        if (protectedForcedReason != null) {
+            return "This nanopublication has to be protected, because " + protectedForcedReason + ".";
+        }
+        if (protectedContext != null) {
+            return ProtectedNanopubs.STAYS_LOCAL_NOTE;
+        }
+        // Nothing to say: the consent checkbox below states that this will be openly published.
+        return null;
+    }
+
+    /**
+     * Returns whether the user has confirmed that they understand what publishing means here.
+     * <p>
+     * The consent is about <em>open</em> publication: what cannot be taken back is putting the
+     * content on the public network under one's own identifier. A protected nanopublication does
+     * not go there, so there is nothing to consent to and no second checkbox — the protected one
+     * is then the only box on the form.
+     *
+     * @return true if publishing may go ahead
+     */
+    private boolean isConsentGiven() {
+        return protectedContext != null || Boolean.TRUE.equals(consentCheck.getModelObject());
+    }
+
+    /**
+     * Returns the text of the consent checkbox, which is only shown for a nanopublication that
+     * will be openly published. Also used by the preview page, which shows the same checkbox.
+     *
+     * @return the consent text to show
+     */
+    public static String getConsentText() {
+        return ProtectedNanopubs.isOffered() ? OPEN_CONSENT_TEXT : CONSENT_TEXT;
+    }
+
+    /**
+     * Creates the pubinfo context that marks the nanopublication as protected (#671), or returns
+     * null when its template cannot be loaded. The latter is recorded so that the form can refuse
+     * to publish when protection is not optional: publishing without the marker would put the
+     * content on the public network.
+     *
+     * @return the context, or null if the template is not available
+     */
+    private TemplateContext newProtectedContext() {
+        if (TemplateData.get().getTemplate(protectedTemplateId) == null) {
+            logger.error("Pubinfo template for protected nanopublications not available: {}", protectedTemplateId);
+            protectedTemplateMissing = true;
+            return null;
+        }
+        return createPubInfoContext(protectedTemplateId);
+    }
+
     private TemplateContext createPubInfoContext(String piTemplateId) {
         TemplateContext c;
         if (pubInfoContextMap.containsKey(piTemplateId)) {
@@ -1298,7 +1501,29 @@ public class PublishForm extends Panel {
         if (websiteUrl != null) {
             npCreator.addPubinfoStatement(NPX.WAS_CREATED_AT, vf.createIRI(websiteUrl));
         }
+        checkProtectedMarker(npCreator);
         return npCreator.finalizeNanopub();
+    }
+
+    /**
+     * Refuses to build a nanopublication that says it is protected in a way no registry acts on
+     * (#671). Registries look for {@code rdf:type npx:ProtectedNanopub} on the nanopublication
+     * itself, which only the template behind the protected checkbox produces. The generic
+     * "Nanopublication type" pubinfo element, for one, produces {@code npx:hasNanopubType
+     * npx:ProtectedNanopub} instead: it looks right in the form, and publishing it would send the
+     * content to the public network.
+     *
+     * @param npCreator the creator holding the statements about to be finalized
+     */
+    private void checkProtectedMarker(NanopubCreator npCreator) {
+        if (protectedContext != null) return;
+        for (Statement st : npCreator.getCurrentPubinfoStatements()) {
+            if (!st.getObject().equals(NPX.PROTECTED_NANOPUB)) continue;
+            throw new IllegalStateException("This nanopublication is marked as protected in a way that " +
+                    "registries do not recognize, so it would be published to the public network. Remove " +
+                    "the publication info element that states it" +
+                    (ProtectedNanopubs.isOffered() ? ", and use the protected checkbox instead." : "."));
+        }
     }
 
     private String getNanopubLabel(NanopubCreator npCreator) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -48,7 +48,6 @@ import org.nanopub.Nanopub;
 import org.nanopub.NanopubAlreadyFinalizedException;
 import org.nanopub.NanopubCreator;
 import org.nanopub.extra.security.SignNanopub;
-import org.nanopub.extra.server.PublishNanopub;
 import org.nanopub.extra.security.SignatureAlgorithm;
 import org.nanopub.extra.security.TransformContext;
 import org.nanopub.extra.services.ApiResponse;
@@ -704,7 +703,7 @@ public class PublishForm extends Panel {
                     TransformContext tc = new TransformContext(SignatureAlgorithm.RSA, NanodashSession.get().getKeyPair(), NanodashSession.get().getUserIri(), false, false, false);
                     signedNp = SignNanopub.signAndTransform(np, tc);
                     logger.info("Nanopublication signed: {}", signedNp.getUri());
-                    String npUrl = PublishNanopub.publish(signedNp);
+                    String npUrl = Utils.publishNanopub(signedNp);
                     logger.info("Nanopublication published: {}", npUrl);
                     Utils.cacheNanopub(signedNp);
                 } catch (Exception ex) {

--- a/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.html
@@ -17,12 +17,15 @@
       <div wicket:id="nanopub"></div>
 
       <form wicket:id="form">
-        <p>
+        <p wicket:id="protected-section" class="protected-option">
+          <input type="checkbox" wicket:id="protectedcheck" id="protectedcheck"/>
+          <label for="protectedcheck"><strong>&#128274; Protected nanopublication</strong></label>
+          <span wicket:id="protected-note" class="protected-note">This nanopublication will stay on the local instance this Nanodash is connected to.</span>
+        </p>
+
+        <p wicket:id="consent-section">
           <input type="checkbox" wicket:id="consentcheck" id="consentcheck"/>
-          <label for="consentcheck">
-            I understand that published data cannot be fully removed (only retracted or superseded by new versions), and
-            is publicly connected to my personal identifier.
-          </label>
+          <label for="consentcheck"><span wicket:id="consenttext">I understand that published data cannot be fully removed (only retracted or superseded by new versions), and is publicly connected to my personal identifier.</span></label>
         </p>
 
         <p class="center">

--- a/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.java
@@ -28,6 +28,7 @@ import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.NanopubElement;
 import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.PostPublishRefresh;
+import com.knowledgepixels.nanodash.ProtectedNanopubs;
 import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.WicketApplication;
 import com.knowledgepixels.nanodash.component.NanopubItem;
@@ -138,8 +139,20 @@ public class PreviewPage extends NanodashPage {
         };
         add(form);
 
+        // The protected marker is part of the signed nanopublication and so cannot be taken back
+        // here: the checkbox is shown ticked and disabled, to say what this preview is (#671).
+        boolean isProtected = ProtectedNanopubs.isProtected(signedNp);
+        WebMarkupContainer protectedSection = new WebMarkupContainer("protected-section");
+        protectedSection.add(new CheckBox("protectedcheck", new Model<>(true)).setEnabled(false));
+        protectedSection.add(new Label("protected-note", ProtectedNanopubs.STAYS_LOCAL_NOTE));
+        protectedSection.setVisible(isProtected);
+        form.add(protectedSection);
+
+        // Consent is about open publication, so a protected nanopublication has nothing to
+        // consent to and no checkbox — the same rule as in the publish form.
+        WebMarkupContainer consentSection = new WebMarkupContainer("consent-section");
         CheckBox consentCheck = new CheckBox("consentcheck", new Model<>(preview.isConsentChecked()));
-        consentCheck.setRequired(true);
+        consentCheck.setRequired(!isProtected);
         consentCheck.add(new IValidator<Boolean>() {
 
             @Override
@@ -150,7 +163,10 @@ public class PreviewPage extends NanodashPage {
             }
 
         });
-        form.add(consentCheck);
+        consentSection.add(consentCheck);
+        consentSection.add(new Label("consenttext", PublishForm.getConsentText()));
+        consentSection.setVisible(!isProtected);
+        form.add(consentSection);
 
         Button discardButton = new Button("discard-button") {
             @Override

--- a/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/PreviewPage.java
@@ -19,7 +19,6 @@ import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubUtils;
-import org.nanopub.extra.server.PublishNanopub;
 import org.nanopub.vocabulary.NTEMPLATE;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,7 +81,7 @@ public class PreviewPage extends NanodashPage {
                         return;
                     }
 
-                    String npUrl = PublishNanopub.publish(signedNp);
+                    String npUrl = Utils.publishNanopub(signedNp);
                     logger.info("Nanopublication published from preview: {}", npUrl);
                     Utils.cacheNanopub(signedNp);
                     NanodashSession.get().removePreviewNanopub(previewId);

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -1568,6 +1568,27 @@ select {
   cursor: help;
 }
 
+/* The protected-nanopublication option on the publish form, kept out of the advanced
+   publication info section because where a nanopublication may be stored is not an advanced
+   detail (#671). */
+.protected-option {
+  padding: 8px 12px;
+  background-color: #fff4d6;
+  border: 1px solid #e0b055;
+  border-radius: 3px;
+}
+
+.protected-option label {
+  color: #7a4a00;
+}
+
+.protected-note {
+  display: block;
+  margin-left: 22px;
+  font-size: 13px;
+  color: #7a4a00;
+}
+
 .protectedtag {
   color: #7a4a00;
   font-size: 12px;

--- a/src/test/java/com/knowledgepixels/nanodash/ProtectedNanopubsTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ProtectedNanopubsTest.java
@@ -1,0 +1,88 @@
+package com.knowledgepixels.nanodash;
+
+import com.knowledgepixels.nanodash.template.Template;
+import com.knowledgepixels.nanodash.template.TemplateData;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.vocabulary.NPX;
+import org.nanopub.vocabulary.NTEMPLATE;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProtectedNanopubsTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static Nanopub nanopub(String npUri, boolean isProtected) throws Exception {
+        NanopubCreator creator = new NanopubCreator(npUri);
+        creator.addAssertionStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri());
+        creator.addProvenanceStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri());
+        creator.addPubinfoStatement(RDFS.SEEALSO, creator.getNanopubUri());
+        if (isProtected) creator.addPubinfoStatement(RDF.TYPE, NPX.PROTECTED_NANOPUB);
+        return creator.finalizeNanopub();
+    }
+
+    /**
+     * Registers a minimal pubinfo template, so that its {@link Template} object can be handed to
+     * the policy without publishing anything. The nanopub carrying it is protected or not.
+     */
+    private static Template template(String npUri, boolean isProtected) throws Exception {
+        IRI st1 = vf.createIRI(npUri + "/st1");
+        NanopubCreator creator = new NanopubCreator(npUri);
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.PUBINFO_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Protected nanopubs test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st1);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, NTEMPLATE.NANOPUB_PLACEHOLDER);
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.SEEALSO);
+        creator.addAssertionStatement(st1, RDF.OBJECT, NTEMPLATE.NANOPUB_PLACEHOLDER);
+        creator.addProvenanceStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri());
+        creator.addPubinfoStatement(RDFS.SEEALSO, creator.getNanopubUri());
+        if (isProtected) creator.addPubinfoStatement(RDF.TYPE, NPX.PROTECTED_NANOPUB);
+        Template template = TemplateData.get().registerTemplate(creator.finalizeNanopub());
+        assertNotNull(template);
+        return template;
+    }
+
+    @Test
+    void protectedMarkerIsRecognized() throws Exception {
+        assertTrue(ProtectedNanopubs.isProtected(nanopub("https://w3id.org/np/RAProtectedNanopubsTest0000000000000000000001", true)));
+        assertFalse(ProtectedNanopubs.isProtected(nanopub("https://w3id.org/np/RAProtectedNanopubsTest0000000000000000000002", false)));
+        assertFalse(ProtectedNanopubs.isProtected(null));
+    }
+
+    @Test
+    void aProtectedFillSourceForcesProtection() throws Exception {
+        // A new version of, or a nanopublication derived from, a protected one repeats its
+        // content, so publishing it unprotected would expose exactly what was protected.
+        Nanopub source = nanopub("https://w3id.org/np/RAProtectedNanopubsTest0000000000000000000003", true);
+        assertEquals("the nanopublication it is based on is protected",
+                ProtectedNanopubs.getForcedReason(source, List.of()));
+    }
+
+    @Test
+    void aProtectedTemplateForcesProtection() throws Exception {
+        // The template is stored on the local instance only, so a public nanopublication made
+        // with it would carry a nt:wasCreatedFromTemplate link nobody outside can follow.
+        Template protectedTemplate = template("https://w3id.org/np/RAProtectedNanopubsTest0000000000000000000004", true);
+        assertEquals("the template it is based on is protected",
+                ProtectedNanopubs.getForcedReason(null, List.of(protectedTemplate)));
+    }
+
+    @Test
+    void ordinarySourcesLeaveTheChoiceFree() throws Exception {
+        Nanopub source = nanopub("https://w3id.org/np/RAProtectedNanopubsTest0000000000000000000005", false);
+        Template plainTemplate = template("https://w3id.org/np/RAProtectedNanopubsTest0000000000000000000006", false);
+        assertNull(ProtectedNanopubs.getForcedReason(source, List.of(plainTemplate)));
+        assertNull(ProtectedNanopubs.getForcedReason(null, null));
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/PublishRoutingTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/PublishRoutingTest.java
@@ -1,0 +1,105 @@
+package com.knowledgepixels.nanodash;
+
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.extra.server.PublishNanopub;
+import org.nanopub.vocabulary.NPX;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+
+/**
+ * Where {@link Utils#publishNanopub(Nanopub)} sends a nanopublication (#671).
+ * <p>
+ * A protected one can only go to the local instance this Nanodash is configured against, and is
+ * addressed to it directly so that {@code NANODASH_MAIN_REGISTRY} alone is enough. An unprotected
+ * one keeps going to the library's own registry list: registries pull from their peers rather than
+ * pushing to them, so sending it only to a private registry would keep it off the public network.
+ */
+class PublishRoutingTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+    private static final String LOCAL_REGISTRY = "http://localhost:19292/";
+
+    @BeforeEach
+    @AfterEach
+    void clearResolvedState() throws Exception {
+        set(ServiceMode.class, "registryIsLocal", null);
+        set(Utils.class, "resolvedMainRegistryUrl", null);
+    }
+
+    private static void set(Class<?> cls, String fieldName, Object value) throws Exception {
+        Field f = cls.getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(null, value);
+    }
+
+    private static Nanopub nanopub(String npUri, boolean isProtected) throws Exception {
+        NanopubCreator creator = new NanopubCreator(npUri);
+        creator.addAssertionStatement(vf.createIRI(npUri + "/thing"), RDFS.LABEL, vf.createLiteral("a thing"));
+        creator.addProvenanceStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri());
+        creator.addPubinfoStatement(RDFS.SEEALSO, creator.getNanopubUri());
+        if (isProtected) creator.addPubinfoStatement(RDF.TYPE, NPX.PROTECTED_NANOPUB);
+        return creator.finalizeNanopub();
+    }
+
+    @Test
+    void aProtectedNanopubGoesToTheConfiguredLocalInstance() throws Exception {
+        set(ServiceMode.class, "registryIsLocal", true);
+        set(Utils.class, "resolvedMainRegistryUrl", LOCAL_REGISTRY);
+        Nanopub np = nanopub("https://example.org/publish-routing-protected/", true);
+
+        try (MockedStatic<PublishNanopub> publish = mockStatic(PublishNanopub.class)) {
+            publish.when(() -> PublishNanopub.publish(np, LOCAL_REGISTRY)).thenReturn(LOCAL_REGISTRY + "np");
+
+            assertEquals(LOCAL_REGISTRY + "np", Utils.publishNanopub(np));
+            publish.verify(() -> PublishNanopub.publish(np, LOCAL_REGISTRY));
+            publish.verify(() -> PublishNanopub.publish(np), times(0));
+        }
+    }
+
+    @Test
+    void anUnprotectedNanopubGoesToTheLibraryList() throws Exception {
+        // Even on a deployment whose own registry is a local instance: unprotected means public,
+        // and the public network would never pull it out of a private registry.
+        set(ServiceMode.class, "registryIsLocal", true);
+        set(Utils.class, "resolvedMainRegistryUrl", LOCAL_REGISTRY);
+        Nanopub np = nanopub("https://example.org/publish-routing-open/", false);
+
+        try (MockedStatic<PublishNanopub> publish = mockStatic(PublishNanopub.class)) {
+            publish.when(() -> PublishNanopub.publish(np)).thenReturn("https://registry.example.org/np");
+
+            assertEquals("https://registry.example.org/np", Utils.publishNanopub(np));
+            publish.verify(() -> PublishNanopub.publish(np));
+        }
+    }
+
+    @Test
+    void aProtectedNanopubOnAPublicDeploymentIsLeftToTheLibrary() throws Exception {
+        // Nothing to address it to, so the library gets to refuse it with its own explicit
+        // message about no registry being a local instance, rather than this posting it to a
+        // public registry that will reject it.
+        set(ServiceMode.class, "registryIsLocal", false);
+        set(Utils.class, "resolvedMainRegistryUrl", "https://registry.knowledgepixels.com/");
+        Nanopub np = nanopub("https://example.org/publish-routing-protected-public/", true);
+
+        try (MockedStatic<PublishNanopub> publish = mockStatic(PublishNanopub.class)) {
+            publish.when(() -> PublishNanopub.publish(np)).thenReturn(null);
+
+            Utils.publishNanopub(np);
+            publish.verify(() -> PublishNanopub.publish(np));
+        }
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/component/PublishFormProtectedTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/PublishFormProtectedTest.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.NanodashSession;
 import com.knowledgepixels.nanodash.ProtectedNanopubs;
 import com.knowledgepixels.nanodash.ServiceMode;
 import com.knowledgepixels.nanodash.Utils;
@@ -71,6 +72,18 @@ class PublishFormProtectedTest {
     @BeforeEach
     void clearProbedModes() throws Exception {
         setRegistryIsLocal(null);
+    }
+
+    /**
+     * Gives the session a user, which the fixed "Creator" publication info element needs to
+     * produce a complete statement. Without it, whether the nanopublication can be built at all
+     * depends on there being an ORCID in the machine's ~/.nanopub -- true on a developer box,
+     * false on CI.
+     */
+    private static void setSessionUser() throws Exception {
+        Field f = NanodashSession.class.getDeclaredField("userIri");
+        f.setAccessible(true);
+        f.set(NanodashSession.get(), vf.createIRI("https://orcid.org/0000-0002-1267-0234"));
     }
 
     private static void setRegistryIsLocal(Boolean value) throws Exception {
@@ -202,6 +215,7 @@ class PublishFormProtectedTest {
     void theMarkerEndsUpInTheNanopublication() throws Exception {
         // The point of the whole option: what registries look at is this one triple.
         setRegistryIsLocal(true);
+        setSessionUser();
         envVars.set("NANODASH_PROTECTED_BY_DEFAULT", "true");
         PageParameters params = new PageParameters().add("template", PLAIN_TEMPLATE)
                 .add("param_thing", "https://example.org/thing")
@@ -214,6 +228,9 @@ class PublishFormProtectedTest {
         Nanopub np = (Nanopub) createNanopub.invoke(form);
 
         assertTrue(NanopubServerUtils.isProtectedNanopub(np), NanopubUtils.writeToString(np, RDFFormat.TRIG));
+        // The nanopublication really was built from the form's own elements, not an empty shell:
+        assertTrue(NanopubUtils.writeToString(np, RDFFormat.TRIG).contains("0000-0002-1267-0234"),
+                NanopubUtils.writeToString(np, RDFFormat.TRIG));
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/nanodash/component/PublishFormProtectedTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/PublishFormProtectedTest.java
@@ -1,0 +1,251 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.ProtectedNanopubs;
+import com.knowledgepixels.nanodash.ServiceMode;
+import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.page.PublishPage;
+import com.knowledgepixels.nanodash.template.TemplateData;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.NanopubImpl;
+import org.nanopub.NanopubUtils;
+import org.nanopub.extra.server.NanopubServerUtils;
+import org.nanopub.trusty.MakeTrustyNanopub;
+import org.nanopub.vocabulary.NPX;
+import org.nanopub.vocabulary.NTEMPLATE;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the protected-nanopublication option of the publish form (#671): whether it is offered,
+ * whether it starts on, and when the user has no say about it.
+ */
+@ExtendWith(SystemStubsExtension.class)
+class PublishFormProtectedTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final String PLAIN_TEMPLATE = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Prot01";
+    private static final String PROTECTED_SOURCE = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Prot02";
+    private static final String PLAIN_SOURCE = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Prot03";
+
+    @SystemStub
+    private final EnvironmentVariables envVars = new EnvironmentVariables();
+
+    private WicketTester tester;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tester = new WicketTester(new WicketApplication());
+        // The real template, so that the hard-coded ID and the template's content are tested
+        // together rather than against a stand-in built to match the code.
+        Nanopub protectedTemplate = new NanopubImpl(
+                new File("src/test/resources/np-protected-nanopub-template.trig"), RDFFormat.TRIG);
+        assertNotNull(TemplateData.get().registerTemplate(protectedTemplate));
+        registerAssertionTemplate(PLAIN_TEMPLATE);
+    }
+
+    @AfterEach
+    @BeforeEach
+    void clearProbedModes() throws Exception {
+        setRegistryIsLocal(null);
+    }
+
+    private static void setRegistryIsLocal(Boolean value) throws Exception {
+        Field f = ServiceMode.class.getDeclaredField("registryIsLocal");
+        f.setAccessible(true);
+        f.set(null, value);
+    }
+
+    private static void registerAssertionTemplate(String npUri) throws Exception {
+        registerAssertionTemplate(npUri, false);
+    }
+
+    private static void registerAssertionTemplate(String npUri, boolean requiresProtection) throws Exception {
+        IRI st1 = vf.createIRI(npUri + "/st1");
+        IRI thing = vf.createIRI(npUri + "/thing");
+        IRI name = vf.createIRI(npUri + "/name");
+        NanopubCreator creator = new NanopubCreator(npUri);
+        IRI templateNode = creator.getAssertionUri();
+        creator.addAssertionStatement(templateNode, RDF.TYPE, NTEMPLATE.ASSERTION_TEMPLATE);
+        creator.addAssertionStatement(templateNode, RDFS.LABEL, vf.createLiteral("Protected option test template"));
+        creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_STATEMENT, st1);
+        creator.addAssertionStatement(st1, RDF.SUBJECT, thing);
+        creator.addAssertionStatement(st1, RDF.PREDICATE, RDFS.LABEL);
+        creator.addAssertionStatement(st1, RDF.OBJECT, name);
+        creator.addAssertionStatement(thing, RDF.TYPE, NTEMPLATE.URI_PLACEHOLDER);
+        creator.addAssertionStatement(thing, RDFS.LABEL, vf.createLiteral("the thing"));
+        creator.addAssertionStatement(name, RDF.TYPE, NTEMPLATE.LITERAL_PLACEHOLDER);
+        creator.addAssertionStatement(name, RDFS.LABEL, vf.createLiteral("the name"));
+        if (requiresProtection) {
+            creator.addAssertionStatement(templateNode, NTEMPLATE.HAS_REQUIRED_PUBINFO_ELEMENT,
+                    vf.createIRI(ProtectedNanopubs.TEMPLATE_ID));
+        }
+        creator.addProvenanceStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri());
+        creator.addPubinfoStatement(RDFS.SEEALSO, creator.getNanopubUri());
+        assertNotNull(TemplateData.get().registerTemplate(creator.finalizeNanopub()));
+    }
+
+    /**
+     * Caches a nanopublication the form can be filled from, so that no network lookup is needed.
+     * It is made trusty because the form resolves the source by its artifact code.
+     *
+     * @return the URI of the cached nanopublication
+     */
+    private static String cacheSource(String npUri, boolean isProtected) throws Exception {
+        NanopubCreator creator = new NanopubCreator(npUri);
+        creator.addAssertionStatement(vf.createIRI(npUri + "/thing"), RDFS.LABEL, vf.createLiteral("a thing"));
+        creator.addProvenanceStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri());
+        creator.addPubinfoStatement(NTEMPLATE.WAS_CREATED_FROM_TEMPLATE, vf.createIRI(PLAIN_TEMPLATE));
+        if (isProtected) creator.addPubinfoStatement(RDF.TYPE, NPX.PROTECTED_NANOPUB);
+        Nanopub np = MakeTrustyNanopub.transform(creator.finalizeNanopub());
+        Utils.cacheNanopub(np);
+        return np.getUri().stringValue();
+    }
+
+    private String renderPublishForm(PageParameters params) {
+        tester.startComponentInPage(new PublishForm("panel", params, PublishPage.class, null));
+        return tester.getLastResponseAsString();
+    }
+
+    private String renderPublishForm() {
+        return renderPublishForm(new PageParameters().add("template", PLAIN_TEMPLATE));
+    }
+
+    @Test
+    void publicDeploymentDoesNotOfferTheOption() throws Exception {
+        // A public registry has no way to store a protected nanopublication, so the option would
+        // do nothing but make publishing fail.
+        setRegistryIsLocal(false);
+        String html = renderPublishForm();
+
+        assertFalse(html.contains("Protected nanopublication"), html);
+        // The plain consent text: nothing here needs to distinguish open from protected.
+        assertTrue(html.contains("I understand that published data cannot be fully removed"), html);
+        assertFalse(html.contains("openly published"), html);
+    }
+
+    @Test
+    void localInstanceOffersTheOptionOffByDefault() throws Exception {
+        setRegistryIsLocal(true);
+        String html = renderPublishForm();
+
+        assertTrue(html.contains("Protected nanopublication"), html);
+        // The consent checkbox is what says where this goes, so the unticked box needs no note:
+        assertTrue(html.contains("I understand that this will be openly published"), html);
+        assertFalse(html.contains("Not protected"), html);
+    }
+
+    @Test
+    void privateByDefaultDeploymentStartsProtected() throws Exception {
+        setRegistryIsLocal(true);
+        envVars.set("NANODASH_PROTECTED_BY_DEFAULT", "true");
+        String html = renderPublishForm();
+
+        assertTrue(html.contains("will stay on the local instance"), html);
+        // Nothing is openly published here, so there is nothing to consent to and only one box:
+        assertFalse(html.contains("consentcheck"), html);
+        assertFalse(html.contains("openly published"), html);
+    }
+
+    @Test
+    void anUnprotectedFormKeepsItsOwnConsentCheckbox() throws Exception {
+        setRegistryIsLocal(true);
+        String html = renderPublishForm();
+
+        assertTrue(html.contains("consentcheck"), html);
+        assertTrue(html.contains("I understand that this will be openly published"), html);
+    }
+
+    @Test
+    void supersedingAProtectedNanopubStaysProtected() throws Exception {
+        // Even on a deployment that publishes publicly by default: the new version repeats the
+        // content of the old one, so it must not be the thing that exposes it.
+        setRegistryIsLocal(true);
+        String source = cacheSource(PROTECTED_SOURCE, true);
+        String html = renderPublishForm(new PageParameters()
+                .add("template", PLAIN_TEMPLATE).add("supersede", source));
+
+        assertTrue(html.contains("has to be protected"), html);
+        assertTrue(html.contains("the nanopublication it is based on is protected"), html);
+        assertTrue(html.contains("disabled=\"disabled\""), html);
+        // Not openly published, so no consent checkbox — and none to tick, since it is disabled:
+        assertFalse(html.contains("consentcheck"), html);
+        // The marker comes back through its own template rather than through the catch-all,
+        // which is what having a real template for it is for:
+        assertFalse(html.contains("Hand-coded statements"), html);
+    }
+
+    @Test
+    void theMarkerEndsUpInTheNanopublication() throws Exception {
+        // The point of the whole option: what registries look at is this one triple.
+        setRegistryIsLocal(true);
+        envVars.set("NANODASH_PROTECTED_BY_DEFAULT", "true");
+        PageParameters params = new PageParameters().add("template", PLAIN_TEMPLATE)
+                .add("param_thing", "https://example.org/thing")
+                .add("param_name", "a name");
+        PublishForm form = new PublishForm("panel", params, PublishPage.class, null);
+        tester.startComponentInPage(form);
+
+        Method createNanopub = PublishForm.class.getDeclaredMethod("createNanopub");
+        createNanopub.setAccessible(true);
+        Nanopub np = (Nanopub) createNanopub.invoke(form);
+
+        assertTrue(NanopubServerUtils.isProtectedNanopub(np), NanopubUtils.writeToString(np, RDFFormat.TRIG));
+    }
+
+    @Test
+    void supersedingAnOrdinaryNanopubLeavesTheChoiceFree() throws Exception {
+        setRegistryIsLocal(true);
+        String source = cacheSource(PLAIN_SOURCE, false);
+        String html = renderPublishForm(new PageParameters()
+                .add("template", PLAIN_TEMPLATE).add("supersede", source));
+
+        assertTrue(html.contains("Protected nanopublication"), html);
+        assertFalse(html.contains("has to be protected"), html);
+    }
+
+    @Test
+    void aTemplateCanRequireProtection() throws Exception {
+        // No new code path for "this kind of content is always protected": the assertion template
+        // lists the pubinfo template in nt:hasRequiredPubinfoElement, and the checkbox follows.
+        setRegistryIsLocal(true);
+        String templateId = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_Prot04";
+        registerAssertionTemplate(templateId, true);
+        String html = renderPublishForm(new PageParameters().add("template", templateId));
+
+        assertTrue(html.contains("has to be protected"), html);
+        assertTrue(html.contains("the template it is based on requires it"), html);
+        assertTrue(html.contains("disabled=\"disabled\""), html);
+    }
+
+    @Test
+    void theProtectedTemplateIsTheOneTheCodeExpects() throws Exception {
+        // Guards the hard-coded ID against the template file being replaced by another one.
+        Nanopub np = new NanopubImpl(new File("src/test/resources/np-protected-nanopub-template.trig"), RDFFormat.TRIG);
+        assertTrue(np.getUri().stringValue().equals(ProtectedNanopubs.TEMPLATE_ID), np.getUri().stringValue());
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/page/PreviewPageProtectedTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/page/PreviewPageProtectedTest.java
@@ -1,0 +1,101 @@
+package com.knowledgepixels.nanodash.page;
+
+import com.knowledgepixels.nanodash.NanodashSession;
+import com.knowledgepixels.nanodash.ServiceMode;
+import com.knowledgepixels.nanodash.WicketApplication;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.extra.security.SignNanopub;
+import org.nanopub.extra.security.SignatureAlgorithm;
+import org.nanopub.extra.security.TransformContext;
+import org.nanopub.vocabulary.NPX;
+
+import java.lang.reflect.Field;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that the preview page says whether the nanopublication it is about to publish is
+ * protected (#671). The marker is part of the signed nanopublication by then, so the checkbox is
+ * there to state that, not to change it.
+ */
+class PreviewPageProtectedTest {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private WicketTester tester;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tester = new WicketTester(new WicketApplication());
+        setRegistryIsLocal(true);
+    }
+
+    @AfterEach
+    void clearProbedMode() throws Exception {
+        setRegistryIsLocal(null);
+    }
+
+    private static void setRegistryIsLocal(Boolean value) throws Exception {
+        Field f = ServiceMode.class.getDeclaredField("registryIsLocal");
+        f.setAccessible(true);
+        f.set(null, value);
+    }
+
+    private String renderPreview(String npUri, boolean isProtected) throws Exception {
+        NanopubCreator creator = new NanopubCreator(npUri);
+        creator.addAssertionStatement(vf.createIRI(npUri + "/thing"), RDFS.LABEL, vf.createLiteral("a thing"));
+        creator.addProvenanceStatement(creator.getAssertionUri(), RDFS.SEEALSO, creator.getAssertionUri());
+        creator.addPubinfoStatement(RDFS.SEEALSO, creator.getNanopubUri());
+        if (isProtected) creator.addPubinfoStatement(RDF.TYPE, NPX.PROTECTED_NANOPUB);
+        // Signed with a throwaway key, because the preview renders a NanopubItem, which reads the
+        // signature element. Nothing is published: the nanopub only lives in the session.
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(1024);
+        KeyPair keyPair = keyGen.generateKeyPair();
+        Nanopub np = SignNanopub.signAndTransform(creator.finalizeNanopub(), new TransformContext(
+                SignatureAlgorithm.RSA, keyPair, vf.createIRI("https://example.org/preview-tester"),
+                false, false, false));
+
+        String previewId = np.getUri().stringValue();
+        NanodashSession.get().setPreviewNanopub(previewId, new NanodashSession.PreviewNanopub(
+                np, new PageParameters(), null, isProtected, null));
+        tester.startPage(PreviewPage.class, new PageParameters().set("id", previewId));
+        return tester.getLastResponseAsString();
+    }
+
+    @Test
+    void aProtectedPreviewShowsTheTickedCheckbox() throws Exception {
+        String html = renderPreview("https://example.org/preview-protected/", true);
+
+        assertTrue(html.contains("Protected nanopublication"), html);
+        assertTrue(html.contains("will stay on the local instance"), html);
+        // Read-only: the marker is signed into the nanopublication and cannot be taken back here.
+        assertTrue(html.contains("disabled=\"disabled\""), html);
+        // Nothing is openly published, so the consent checkbox is gone here too.
+        assertFalse(html.contains("consentcheck"), html);
+    }
+
+    @Test
+    void anOpenPreviewKeepsTheConsentCheckbox() throws Exception {
+        String html = renderPreview("https://example.org/preview-open/", false);
+
+        assertFalse(html.contains("Protected nanopublication"), html);
+        assertTrue(html.contains("consentcheck"), html);
+        // Same wording as the publish form on a deployment where protection is possible:
+        assertTrue(html.contains("I understand that this will be openly published"), html);
+    }
+
+}

--- a/src/test/resources/np-protected-nanopub-template.trig
+++ b/src/test/resources/np-protected-nanopub-template.trig
@@ -1,0 +1,56 @@
+@prefix this: <https://w3id.org/np/RAjTlfGJgWb8K7cOspGdwodPpnu859q78Rps40xDGdgZs> .
+@prefix sub: <https://w3id.org/np/RAjTlfGJgWb8K7cOspGdwodPpnu859q78Rps40xDGdgZs/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  npx:ProtectedNanopub rdfs:label "protected nanopublication - only accepted, stored and served by local/private instances, and never by the public nanopublication network" .
+  
+  rdf:type rdfs:label "is a" .
+  
+  sub:assertion a nt:PubinfoTemplate, nt:UnlistedTemplate;
+    dct:description "Marks the nanopublication as protected, meaning that it is only accepted, stored and served by local/private Nanopub Registry and Query instances, and never by the public network. This template has no fields: adding it adds the marker. It is unlisted because it is not a description of the content but a decision about where the nanopublication may be stored, which interfaces should offer as such.";
+    rdfs:label "Protected nanopublication";
+    nt:hasStatement sub:st1 .
+  
+  sub:st1 a rdf:Statement;
+    rdf:object npx:ProtectedNanopub;
+    rdf:predicate rdf:type;
+    rdf:subject nt:NANOPUB .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+  
+  this: dct:created "2026-09-07T09:47:17.000Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:hasNanopubType nt:PubinfoTemplate;
+    npx:supersedes <https://w3id.org/np/RAv5_jG1RzfpqtvLZE6fGE2I5A5fGylyZyqBLeNR5Lx08>;
+    rdfs:label "Pubinfo template: Protected nanopublication" .
+  
+  sub:sig npx:hasAlgorithm "RSA";
+    npx:hasPublicKey "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCwUtewGCpT5vIfXYE1bmf/Uqu1ojqnWdYxv+ySO80ul8Gu7m8KoyPAwuvaPj0lvPtHrg000qMmkxzKhYknEjq8v7EerxZNYp5B3/3+5ZpuWOYAs78UnQVjbHSmDdmryr4D4VvvNIiUmd0yxci47dTFUj4DvfHnGd6hVe5+goqdcwIDAQAB";
+    npx:hasSignature "LLBK81vMHjIX28vapE/1GKddtXWTfHu7i+1qjkKMGPOdXbVfS9wzVcWkSlQT/bHJMk1g4qXmCiKG5sAeSyASlwoO4WTJLcjuVn9VeYz9ody5WqfzDd3SHnqmhVh1a5YV4O9MIYgWzeBxS9cJRlhRHnGA9nBkwH8jtRWtZ4KHHpM=";
+    npx:hasSignatureTarget this:;
+    npx:signedBy orcid:0000-0002-1267-0234 .
+}


### PR DESCRIPTION
Second half of #671: Nanodash could already *recognize* protected nanopublications (the 🔒 flag, the 🔒 restricted marker); this lets users of a deployment connected to a local/private registry **create** them.

## The marker

What registries look at is one triple, `this: a npx:ProtectedNanopub`. It is added by an ordinary pubinfo template, [`RAjTlfGJ…`](https://w3id.org/np/RAjTlfGJgWb8K7cOspGdwodPpnu859q78Rps40xDGdgZs) (published, unlisted, no placeholders), rather than emitted in code — so the statement has a `nt:wasCreatedFromPubinfoTemplate` link like every other one, and `ValueFiller` claims it when a protected nanopublication is superseded instead of sweeping it into the hand-coded catch-all.

The template is driven by a checkbox of its own rather than the "add element…" dropdown. That dropdown is behind "show more", and the generic "Nanopublication type" element produces `npx:hasNanopubType` — *not* what registries check, so a nanopublication that looks protected in the form would go to the public network. `PublishForm.checkProtectedMarker` now refuses to build one of those.

## One checkbox, not two

Consent is about *open* publication, so the consent checkbox is shown only for a nanopublication that will be openly published, and says so where protection is possible:

> I understand that this will be openly published, that published data cannot be fully removed (only retracted or superseded by new versions), and that it will be publicly connected to my personal identifier.

Ticking the protected box takes that checkbox away rather than rewording it. The user has one box, and its note is a statement of fact: *"This nanopublication will stay on the local instance this Nanodash is connected to."* The public wording would not be true there — "cannot be fully removed" holds for the public network, not for one instance whose operators can take it off again.

The preview page shows the same box, ticked and disabled: by then the marker is signed into the content.

## When it is not the user's choice

`ProtectedNanopubs.getForcedReason` — the fill source is protected (the new version repeats its content), a template the form is built on is protected (a public nanopublication would carry a link nobody outside can follow), or the assertion template lists the element in `nt:hasRequiredPubinfoElement`. The checkbox is then ticked and disabled with the reason shown. If protection is forced or defaulted on and the template cannot be loaded, publishing is refused rather than silently downgraded to public.

## Defaults

`NANODASH_PROTECTED_BY_DEFAULT` (or `protectedByDefault` in the preferences file), because both kinds of local instance exist: mostly-public ones with occasional protected content, and private-by-default ones.

## Second commit: where it is sent

`PublishNanopub.publish` picks from the library's own registry list, which knows nothing about `NANODASH_MAIN_REGISTRY`. A deployment configured only the Nanodash way read from its local instance but could not publish a protected nanopublication to it — "None of the available registries is a local instance", with the local instance sitting in the config. `Utils.publishNanopub` now addresses protected nanopublications to `getMainRegistryUrl()` directly.

Unprotected ones keep going to the library's list, deliberately: registries pull from their peers rather than pushing to them, so an openly published nanopublication sent only to a private registry would never reach the public network.

## Verification

1323 tests, 0 failures (+21). Beyond the unit tests, driven end to end against a local stack (registry 1.12.1 + query 1.28.0, both `LOCAL_INSTANCE=true`), from a deployment deliberately configured *without* `NANOPUB_REGISTRY_INSTANCES` — the case that used to fail:

- published `https://w3id.org/np/RA5-gEQNLlun_V1QVV6pbzedbRBzSXY5_4x5fJXM8nCcU`
- log: `Publishing protected nanopublication to the configured local instance: http://localhost:19292/`
- local registry **200**; registry.knowledgepixels.com, registry.petapico.org and w3id.org all **404**
- stored pubinfo carries `this: a npx:ProtectedNanopub` and the template link; Nanodash renders it back with the 🔒 flag

Design notes in [`docs/protected-nanopublications.md`](docs/protected-nanopublications.md).

## Known gaps

- A nanopublication governed by a *protected space* does not force protection: the governing space is a resource IRI, not the nanopublication defining it, so answering that needs a query. In practice the templates such a space governs are local-only, which the template rule catches.
- On a private-by-default deployment the protected box starts ticked, so nothing is left for the user to tick before publishing — consent becomes implicit there. That follows from tying consent to open publication.

Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwZT7hRpsCLCaJw7GCkHWy
