### PR TITLE
feat(views): pre-fill a result action's form from a fill query (#690)

### DIFF
--- a/docs/magic-query-params.md
+++ b/docs/magic-query-params.md
@@ -236,6 +236,16 @@ Today an action carries a single `queryVar:templateParam` mapping that only sets
 `"derive_target:@derive-a local_pubkey:public-key__.1"` — the first drives
 visibility (conditional target), the second supplies the key.
 
+A **result** action (the view-level "add…" button) passes the same literal whole to
+the publish form as `values-from-query-mapping`, and the form applies every mapping
+in it against every row of the view's query (`PublishForm.applyQueryValues`). Until
+issue #690 the result-action path passed only the raw first literal and the form
+split it on its *first* colon, so `"a:b c:d"` became a target of `"b c"` and filled
+nothing — every multi-mapping in `docs/queries/` was on an entry action, which is why
+nobody noticed. A raw `@key` target has no meaning on this path: those keys (the
+fill mode, the template) are read before any query runs, so only a link can carry
+them, as an entry action does.
+
 A third form was added later (issue #678): a `!` in front of the field name
 (`local_pubkey:!public-key__.1`) also **locks** the field, so the form shows the
 value the action filled in but does not let the user change it — for values an
@@ -249,6 +259,74 @@ only, as a raw `@` key is not a form field.
 A query may `SELECT` a magic variable back out
 (`(sample(?__LOCALPUBKEY_multi) AS ?local_pubkey)`) and feed it to an action via
 an ordinary mapping (e.g. derive's key parameter).
+
+### Pre-filling from the target: the action's fill query (issue #690)
+
+The listing-driven mapping above reads the view's **rows**. That is the wrong source
+for a *default*: a value the new entry should inherit from the resource whose page the
+button is on — the event's start date for a presentation, a location, a series, an
+organiser. With zero rows there is nothing to read from (and adding the first entry is
+exactly where a default helps most); with *n* rows the same value lands *n* times, as
+`startDate`, `startDate__1`, … on a field that is not repeatable.
+
+So a result action can carry its **own query, bound to the target**:
+
+```turtle
+sub:addAction a gen:ViewResultAction ;
+    rdfs:label "🎤 add presentation" ;
+    gen:hasActionTemplate <…/presentation-template> ;
+    gen:hasActionTemplateTargetField "event" ;
+    gen:hasActionFillQuery <…/get-event-defaults> ;
+    gen:hasActionFillQueryTargetField "event" ;          # optional, default "resource"
+    gen:hasActionFillQueryMapping "startDate:startDate location:location" .
+```
+
+- **`gen:hasActionFillQuery`** — a published query. When the button is rendered, the
+  target resource's IRI is bound to the query placeholder named by
+  **`gen:hasActionFillQueryTargetField`** (`resource` if absent) and the bound
+  reference travels to the publish page as `fill-query`.
+- **`gen:hasActionFillQueryMapping`** — the same whitespace-separated `col:field`
+  literal as the query mapping (`View.parseMappingLiteral`), travelling as
+  `fill-query-mapping`. `col:!field` fills *and locks* the field, exactly as for entry
+  actions (docs/locked-prefilled-values.md); `@key` targets are ignored here for the
+  reason given above.
+
+**When it runs.** On the publish page, in `PublishForm`, before the fields are built —
+not while the listing renders. The listing bakes only a URL, so per-row rendering
+stays free of queries and a cold cache cannot silently produce a button with no
+default. The query goes through `ApiCache.retrieveResponseSync(ref, false)`: a cold
+cache blocks inline once, a warm one serves at once with a background refresh, and
+the same target opened twice is one query. A query that fails costs the user the
+pre-fill, not the form.
+
+**Which row.** The **first** row only, with no `__i` suffixes
+(`PublishForm.applyFillQueryValues`): the query describes the target, and the fields
+being defaulted are single-valued. Zero rows is a natural no-op; a blank value is no
+default (the field is left as it was, and stays unlocked).
+
+**Precedence.** Fill query, then listing values, then explicit `param_` URL
+parameters — the most specific source wins. An action can carry both a fill query
+and a listing mapping.
+
+**Magic parameters** are bound at consumption, on the publishing user's own request
+(`MagicQueryParams.augment` in `PublishForm`), so a fill query may use `_LOCALPUBKEY`
+or `_CURRENTUSER` and get the person opening the form, not the person who rendered
+the listing that linked there.
+
+**Own map, own columns.** The fill mappings are kept apart from the query mappings in
+`View`: their `col` names belong to the fill query, so they never count as
+`getActionMappingSourceColumns` and are never hidden from the view's own table.
+
+**Provenance is the query's business.** A generic `<target> <p> ?v` over the whole
+store would let anyone's assertion become the default. The point of a *published*
+fill query is that its author scopes it — to the target's governing space, to a
+signing key, to whatever the case warrants — and that scope is reviewable and
+governable like any other query nanopub. Bear that in mind before reaching for `!`:
+a locked field is precisely the one the user cannot correct.
+
+The `ActionMapping` record in `View` is the one parser for `col:target` in all three
+places it is read (entry-action links, the listing fill, the fill query). It splits on
+the first colon; neither a result column nor a field name may contain one.
 
 ## Phase 3 design: the introductions view (concrete)
 

--- a/src/main/java/com/knowledgepixels/nanodash/View.java
+++ b/src/main/java/com/knowledgepixels/nanodash/View.java
@@ -452,6 +452,12 @@ public class View implements Serializable {
     private Map<IRI, IRI> actionTemplateTypeMap = new HashMap<>();
     private Map<IRI, String> actionTemplatePartFieldMap = new HashMap<>();
     private Map<IRI, List<String>> actionTemplateQueryMappingsMap = new HashMap<>();
+    // The action's fill query (issue #690): run against the target when the form opens,
+    // kept apart from the listing-driven query mappings above, whose source columns the
+    // result builders hide — these columns belong to a different query altogether.
+    private Map<IRI, GrlcQuery> actionFillQueryMap = new HashMap<>();
+    private Map<IRI, List<String>> actionFillQueryMappingsMap = new HashMap<>();
+    private Map<IRI, String> actionFillQueryTargetFieldMap = new HashMap<>();
     private Map<IRI, String> labelMap = new HashMap<>();
     private IRI viewType;
     private boolean queryForm = false;
@@ -522,6 +528,20 @@ public class View implements Serializable {
                 if (!"void".equals(mapping)) {
                     actionTemplateQueryMappingsMap.computeIfAbsent((IRI) st.getSubject(), k -> new ArrayList<>()).add(mapping);
                 }
+            } else if (st.getPredicate().equals(KPXL_TERMS.HAS_ACTION_FILL_QUERY) && st.getObject() instanceof IRI objIri) {
+                GrlcQuery fillQuery = GrlcQuery.get(objIri.stringValue());
+                if (fillQuery == null) {
+                    logger.error("Fill query of action {} could not be loaded: {}", st.getSubject(), objIri);
+                } else {
+                    actionFillQueryMap.put((IRI) st.getSubject(), fillQuery);
+                }
+            } else if (st.getPredicate().equals(KPXL_TERMS.HAS_ACTION_FILL_QUERY_MAPPING)) {
+                String mapping = st.getObject().stringValue();
+                if (!"void".equals(mapping)) {
+                    actionFillQueryMappingsMap.computeIfAbsent((IRI) st.getSubject(), k -> new ArrayList<>()).add(mapping);
+                }
+            } else if (st.getPredicate().equals(KPXL_TERMS.HAS_ACTION_FILL_QUERY_TARGET_FIELD)) {
+                putUnlessVoid(actionFillQueryTargetFieldMap, (IRI) st.getSubject(), st.getObject().stringValue());
             } else if (st.getPredicate().equals(KPXL_TERMS.IS_VISIBLE_TO) && st.getObject() instanceof IRI objIri) {
                 // Per-action visibility: gen:isVisibleTo on an action node restricts
                 // that action button to viewers holding the given role tier or
@@ -713,7 +733,8 @@ public class View implements Serializable {
      * — or, when {@code target} begins with {@code @}, to the raw URL parameter
      * {@code target} (without the {@code param_} prefix), used for fill-mode keys
      * such as {@code @derive-a} / {@code @supersede}. An entry action applies all
-     * of these per row; see docs/magic-query-params.md.
+     * of these per row; a result action passes them whole to the publish form, which
+     * applies them against every row of the view's query. See docs/magic-query-params.md.
      *
      * @param actionIri the action IRI
      * @return the list of mappings (never null; empty if none)
@@ -768,15 +789,81 @@ public class View implements Serializable {
     }
 
     /**
-     * Gets the first query mapping for an action, or null. Kept for result-action
-     * callers that pass a single {@code values-from-query-mapping}.
+     * Gets the fill query of an action (issue #690): a query run against the action's
+     * target resource when the form opens, whose first result row pre-fills form fields
+     * per {@link #getFillQueryMappings}. The target's IRI is bound to the placeholder
+     * named by {@link #getFillQueryTargetFieldForAction}.
      *
      * @param actionIri the action IRI
-     * @return the first mapping, or null
+     * @return the fill query, or null if the action declares none (or it failed to load)
      */
-    public String getTemplateQueryMapping(IRI actionIri) {
-        List<String> mappings = actionTemplateQueryMappingsMap.get(actionIri);
-        return (mappings == null || mappings.isEmpty()) ? null : mappings.get(0);
+    public GrlcQuery getFillQueryForAction(IRI actionIri) {
+        return actionFillQueryMap.get(actionIri);
+    }
+
+    /**
+     * Gets the fill-query mappings of an action, each {@code "col:field"} — result column
+     * {@code col} of the fill query to template field {@code field}, or {@code !field} to
+     * also lock the field. Same literal syntax as the query mappings
+     * ({@link #parseMappingLiteral}), but the columns are the <em>fill</em> query's, so
+     * these never count as {@link #getActionMappingSourceColumns}.
+     *
+     * @param actionIri the action IRI
+     * @return the mappings (never null; empty if none)
+     */
+    public List<String> getFillQueryMappings(IRI actionIri) {
+        List<String> result = new ArrayList<>();
+        for (String literal : actionFillQueryMappingsMap.getOrDefault(actionIri, Collections.emptyList())) {
+            result.addAll(parseMappingLiteral(literal));
+        }
+        return result;
+    }
+
+    /**
+     * Gets the fill-query placeholder the action's target IRI is bound to, or null for
+     * the default ({@code resource}).
+     *
+     * @param actionIri the action IRI
+     * @return the placeholder name, or null
+     */
+    public String getFillQueryTargetFieldForAction(IRI actionIri) {
+        return actionFillQueryTargetFieldMap.get(actionIri);
+    }
+
+    /**
+     * One parsed {@code "col:target"} action mapping: the value of result column
+     * {@code column} goes to {@code key} — a template field (written to
+     * {@code param_<key>}) unless {@code rawKey}, in which case {@code key} is a raw
+     * publish-URL key (the target began with {@code @}). {@code locked} says the target
+     * began with {@code !}: the field is filled and then locked
+     * (docs/locked-prefilled-values.md). Only meaningful for a field, so never set
+     * together with {@code rawKey}.
+     *
+     * @param column the result column the value is read from
+     * @param key    the template field or raw URL key, with its {@code @}/{@code !} marker stripped
+     * @param rawKey whether {@code key} is a raw URL key rather than a template field
+     * @param locked whether the field is to be locked after filling
+     */
+    public record ActionMapping(String column, String key, boolean rawKey, boolean locked) {
+
+        /**
+         * Parses one mapping. The split is on the <em>first</em> colon: neither a result
+         * column nor a field name may contain one.
+         *
+         * @param mapping the {@code "col:target"} mapping
+         * @return the parsed mapping, or null if it has no colon
+         */
+        public static ActionMapping parse(String mapping) {
+            int sep = mapping.indexOf(':');
+            if (sep < 0) return null;
+            String column = mapping.substring(0, sep);
+            String target = mapping.substring(sep + 1);
+            boolean rawKey = target.startsWith("@");
+            String key = rawKey ? target.substring(1) : target;
+            boolean locked = !rawKey && key.startsWith("!");
+            if (locked) key = key.substring(1);
+            return new ActionMapping(column, key, rawKey, locked);
+        }
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -373,28 +373,19 @@ public class PublishForm extends Panel {
                 }
             }
         }
+        // Query-driven pre-fills, least specific first, so that a later source overrides an
+        // earlier one: the target-driven fill query (issue #690), then the listing-driven
+        // values, then the explicit param_ parameters below.
+        if (!pageParams.get("fill-query").isEmpty() && !pageParams.get("fill-query-mapping").isEmpty()) {
+            // Bound here, on the publishing user's own request, so a fill query may use the
+            // magic parameters (local key, current user) of whoever opens the form rather
+            // than of whoever rendered the listing that linked here.
+            QueryRef fillRef = MagicQueryParams.augment(QueryRef.parseString(pageParams.get("fill-query").toString()));
+            applyFillQueryValues(pageParams.get("fill-query-mapping").toString(), retrieveForPrefill(fillRef), assertionContext);
+        }
         if (!pageParams.get("values-from-query").isEmpty() && !pageParams.get("values-from-query-mapping").isEmpty()) {
-            String querySpec = pageParams.get("values-from-query").toString();
-
-            String mapping = pageParams.get("values-from-query-mapping").toString();
-            String mapsFrom, mapsTo;
-            if (mapping.contains(":")) {
-                mapsFrom = mapping.split(":")[0];
-                mapsTo = mapping.split(":")[1];
-            } else {
-                mapsFrom = mapping;
-                mapsTo = mapping;
-            }
-            ApiResponse resp = ApiCache.retrieveResponseSync(QueryRef.parseString(querySpec), false);
-            int i = 0;
-            for (ApiResponseEntry e : resp.getData()) {
-                String mapsToSuffix = "";
-                if (i > 0) {
-                    mapsToSuffix = "__" + i;
-                }
-                assertionContext.setParam(mapsTo + mapsToSuffix, e.get(mapsFrom));
-                i++;
-            }
+            QueryRef valuesRef = QueryRef.parseString(pageParams.get("values-from-query").toString());
+            applyQueryValues(pageParams.get("values-from-query-mapping").toString(), retrieveForPrefill(valuesRef), assertionContext);
         }
         for (String k : pageParams.getNamedKeys()) {
             if (k.startsWith("param_")) {
@@ -1285,6 +1276,92 @@ public class PublishForm extends Panel {
      * ({@code st2}) or by a placeholder that occurs in that statement and no other
      * ({@code public-key}).
      */
+    /**
+     * Runs a query whose result is to pre-fill the form. A pre-fill is a convenience, so a
+     * query that cannot be run (the API is down, or has failed on it repeatedly) costs the
+     * user the pre-fill and not the form.
+     *
+     * @param queryRef the query to run
+     * @return the response, or null if it could not be obtained
+     */
+    private static ApiResponse retrieveForPrefill(QueryRef queryRef) {
+        try {
+            return ApiCache.retrieveResponseSync(queryRef, false);
+        } catch (RuntimeException ex) {
+            logger.warn("Could not run {} to pre-fill the form: {}", queryRef.getAsUrlString(), ex.toString());
+            return null;
+        }
+    }
+
+    /**
+     * Parses one mapping as a form-side pre-fill understands it: {@code "col:field"} or
+     * {@code "col:!field"} (docs/magic-query-params.md). A bare {@code "name"} maps the column
+     * to the field of the same name, as the listing-driven fill has always allowed in a
+     * hand-written URL. A raw-key target ({@code "col:@key"}) has no meaning here: such keys
+     * (the fill mode, the template) are read before any query runs, so they can only come
+     * from the link itself, as an entry action passes them.
+     *
+     * @param mapping the mapping
+     * @return the parsed mapping, or null if it cannot apply at this point
+     */
+    private static View.ActionMapping parseFormMapping(String mapping) {
+        View.ActionMapping m = View.ActionMapping.parse(mapping);
+        if (m == null) return new View.ActionMapping(mapping, mapping, false, false);
+        if (m.rawKey()) {
+            logger.warn("Ignoring mapping {}: a raw key cannot be set from a query result at form time", mapping);
+            return null;
+        }
+        return m;
+    }
+
+    /**
+     * Listing-driven pre-fill: the mapped columns of <em>every</em> row go into the template,
+     * the rows after the first under the repetition suffixes {@code __1}, {@code __2}, ...
+     * This is what a result action's {@code gen:hasActionTemplateQueryMapping} does with the
+     * view's own query — it fills a repeatable field from the listing (one row per entry).
+     *
+     * @param mappingLiteral the whitespace-separated mappings
+     * @param response       the query response, or null for none
+     * @param context        the assertion context to fill
+     */
+    static void applyQueryValues(String mappingLiteral, ApiResponse response, TemplateContext context) {
+        if (response == null) return;
+        for (String mapping : View.parseMappingLiteral(mappingLiteral)) {
+            View.ActionMapping m = parseFormMapping(mapping);
+            if (m == null) continue;
+            int i = 0;
+            for (ApiResponseEntry row : response.getData()) {
+                String name = m.key() + (i > 0 ? "__" + i : "");
+                context.setParam(name, row.get(m.column()));
+                if (m.locked()) context.setLocked(name);
+                i++;
+            }
+        }
+    }
+
+    /**
+     * Target-driven pre-fill (issue #690): the mapped columns of the <em>first</em> row go
+     * into the template, and only the first, as these are defaults for single-valued fields
+     * — the fill query is bound to the target resource, and the row describes it. An empty
+     * or missing value is no default at all: the field is left as it was, and unlocked.
+     *
+     * @param mappingLiteral the whitespace-separated mappings
+     * @param response       the query response, or null for none
+     * @param context        the assertion context to fill
+     */
+    static void applyFillQueryValues(String mappingLiteral, ApiResponse response, TemplateContext context) {
+        if (response == null || response.getData().isEmpty()) return;
+        ApiResponseEntry row = response.getData().get(0);
+        for (String mapping : View.parseMappingLiteral(mappingLiteral)) {
+            View.ActionMapping m = parseFormMapping(mapping);
+            if (m == null) continue;
+            String value = row.get(m.column());
+            if (value == null || value.isBlank()) continue;
+            context.setParam(m.key(), value);
+            if (m.locked()) context.setLocked(m.key());
+        }
+    }
+
     static void applyLocks(PageParameters pageParams, TemplateContext assertionContext,
             TemplateContext provenanceContext, Map<Integer, TemplateContext> piParamIdMap) {
         forEachLockedName(pageParams, "locked", assertionContext, provenanceContext, piParamIdMap,

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultListBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultListBuilder.java
@@ -2,15 +2,8 @@ package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.*;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
-import com.knowledgepixels.nanodash.domain.MaintainedResource;
-import com.knowledgepixels.nanodash.domain.Space;
-import com.knowledgepixels.nanodash.page.PublishPage;
-import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
-import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.Component;
 import org.apache.wicket.behavior.AttributeAppender;
-import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.QueryRef;
 
@@ -116,68 +109,14 @@ public class QueryResultListBuilder implements Serializable {
     }
 
     private QueryResultList buildList(String markupId, ApiResponse response) {
-        if (resourceWithProfile == null) {
-            QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
-            resultList.setPageResource(pageResource);
-            resultList.setContextId(contextId);
-            ViewActionMappings.addResultActions(resultList, viewDisplay, queryRef, id, contextId, null, refRoot);
-            return resultList;
-        }
         QueryResultList resultList = new QueryResultList(markupId, queryRef, response, viewDisplay);
         resultList.setResourceWithProfile(resourceWithProfile);
         resultList.setPageResource(pageResource);
         resultList.setContextId(contextId);
         resultList.setPostPublishTab(postPublishTab);
         resultList.setRefRoot(refRoot);
-        View view = viewDisplay.getView();
-        if (view != null) {
-            for (IRI actionIri : view.getViewResultActionList()) {
-                if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), resourceWithProfile, refRoot)) continue;
-                Template t = view.getTemplateForAction(actionIri);
-                if (t == null) continue;
-                String targetField = view.getTemplateTargetFieldForAction(actionIri);
-                if (targetField == null) targetField = "resource";
-                String label = view.getLabelForAction(actionIri);
-                if (label == null) label = "action...";
-                if (!label.endsWith("...")) label += "...";
-                PageParameters params = new PageParameters().set("template", t.getId())
-                        .set("param_" + targetField, id)
-                        .set("context", contextId)
-                        .set("template-version", "latest");
-                if (id != null && contextId != null && !id.equals(contextId)) {
-                    params.set("part", id);
-                }
-                String partField = view.getTemplatePartFieldForAction(actionIri);
-                if (partField != null && contextId != null) {
-                    // The part field pre-fills a namespaced child IRI (the user fills the suffix).
-                    // TODO Find a better way to pass the MaintainedResource object to this method:
-                    MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
-                    String namespace = null;
-                    if (r != null) {
-                        namespace = r.getNamespace();
-                    } else if (resourceWithProfile instanceof Space) {
-                        // The Space-creation templates' `space` placeholder has a fixed
-                        // `https://w3id.org/spaces/` prefix, so the pre-fill is relative to it.
-                        // Nesting the new space's IRI under this space's path makes it a
-                        // sub-space via the prefix match.
-                        namespace = contextId.replaceFirst("https://w3id.org/spaces/", "") + "/";
-                    }
-                    if (namespace != null) {
-                        params.set("param_" + partField, namespace + "<SET-SUFFIX>");
-                    }
-                }
-                String queryMapping = view.getTemplateQueryMapping(actionIri);
-                if (queryMapping != null && queryMapping.contains(":")) {
-                    params.set("values-from-query", queryRef.getAsUrlString());
-                    params.set("values-from-query-mapping", queryMapping);
-                }
-                params.set("refresh-upon-publish", queryRef.getAsUrlString());
-                if (postPublishTab != null) params.set("postpub-tab", postPublishTab);
-                resultList.addButton(label, PublishPage.class, params);
-            }
-        }
+        ViewActionMappings.addResultActions(resultList, viewDisplay, queryRef, id, contextId, resourceWithProfile, refRoot);
         return resultList;
     }
-
 
 }

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraphBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraphBuilder.java
@@ -1,19 +1,10 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.ApiCache;
-import com.knowledgepixels.nanodash.SpaceMemberRole;
-import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
-import com.knowledgepixels.nanodash.domain.MaintainedResource;
-import com.knowledgepixels.nanodash.domain.Space;
-import com.knowledgepixels.nanodash.page.PublishPage;
-import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
-import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.Component;
 import org.apache.wicket.behavior.AttributeAppender;
-import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.QueryRef;
 
@@ -28,51 +19,9 @@ public class QueryResultPlainParagraphBuilder implements Serializable {
     private ViewDisplay viewDisplay;
     private String contextId = null;
     private QueryRef queryRef;
-    private Space space = null;
     private String id = null;
     private AbstractResourceWithProfile pageResource = null;
     private String refRoot = null;
-
-    // This method is the result of refactoring and copying code from other classes done
-    // by Cursor. This should in general be aligned and refactored more with the other classes.
-    private void addResultButtons(QueryResultPlainParagraph resultPlainParagraph) {
-        View view = viewDisplay.getView();
-        if (view == null) return;
-        for (IRI actionIri : view.getViewResultActionList()) {
-            // Per-action role gating (docs/role-specific-views.md): skip an action
-            // whose gen:isVisibleTo the viewer does not satisfy.
-            if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), pageResource, refRoot)) continue;
-            Template t = view.getTemplateForAction(actionIri);
-            if (t == null) continue;
-            String targetField = view.getTemplateTargetFieldForAction(actionIri);
-            if (targetField == null) targetField = "resource";
-            String label = view.getLabelForAction(actionIri);
-            if (label == null) label = "action...";
-            if (!label.endsWith("...")) label += "...";
-            PageParameters params = new PageParameters().set("template", t.getId())
-                    .set("param_" + targetField, id)
-                    .set("context", contextId)
-                    .set("template-version", "latest");
-            if (id != null && contextId != null && !id.equals(contextId)) {
-                params.set("part", id);
-            }
-            String partField = view.getTemplatePartFieldForAction(actionIri);
-            if (partField != null) {
-                // TODO Find a better way to pass the MaintainedResource object to this method:
-                MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
-                if (r != null && r.getNamespace() != null) {
-                    params.set("param_" + partField, r.getNamespace() + "<SET-SUFFIX>");
-                }
-            }
-            String queryMapping = view.getTemplateQueryMapping(actionIri);
-            if (queryMapping != null && queryMapping.contains(":")) {
-                params.set("values-from-query", queryRef.getAsUrlString());
-                params.set("values-from-query-mapping", queryMapping);
-            }
-            params.set("refresh-upon-publish", queryRef.getAsUrlString());
-            resultPlainParagraph.addButton(label, PublishPage.class, params);
-        }
-    }
 
     private QueryResultPlainParagraphBuilder(String markupId, QueryRef queryRef, ViewDisplay viewDisplay) {
         this.markupId = markupId;
@@ -142,10 +91,9 @@ public class QueryResultPlainParagraphBuilder implements Serializable {
 
     private QueryResultPlainParagraph buildPlainParagraph(String markupId, ApiResponse response) {
         QueryResultPlainParagraph resultPlainParagraph = new QueryResultPlainParagraph(markupId, queryRef, response, viewDisplay);
-        if (space != null) resultPlainParagraph.setResourceWithProfile(space);
         resultPlainParagraph.setPageResource(pageResource);
         resultPlainParagraph.setContextId(contextId);
-        addResultButtons(resultPlainParagraph);
+        ViewActionMappings.addResultActions(resultPlainParagraph, viewDisplay, queryRef, id, contextId, pageResource, refRoot);
         return resultPlainParagraph;
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvgBuilder.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvgBuilder.java
@@ -1,18 +1,10 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.ApiCache;
-import com.knowledgepixels.nanodash.SpaceMemberRole;
-import com.knowledgepixels.nanodash.View;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
-import com.knowledgepixels.nanodash.domain.MaintainedResource;
-import com.knowledgepixels.nanodash.page.PublishPage;
-import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
-import com.knowledgepixels.nanodash.template.Template;
 import org.apache.wicket.Component;
 import org.apache.wicket.behavior.AttributeAppender;
-import org.apache.wicket.request.mapper.parameter.PageParameters;
-import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.QueryRef;
 
@@ -30,44 +22,6 @@ public class QueryResultSvgBuilder implements Serializable {
     private String id = null;
     private AbstractResourceWithProfile pageResource = null;
     private String refRoot = null;
-
-    private void addResultButtons(QueryResultSvg resultSvg) {
-        View view = viewDisplay.getView();
-        if (view == null) return;
-        for (IRI actionIri : view.getViewResultActionList()) {
-            // Per-action role gating (docs/role-specific-views.md): skip an action
-            // whose gen:isVisibleTo the viewer does not satisfy.
-            if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), pageResource, refRoot)) continue;
-            Template t = view.getTemplateForAction(actionIri);
-            if (t == null) continue;
-            String targetField = view.getTemplateTargetFieldForAction(actionIri);
-            if (targetField == null) targetField = "resource";
-            String label = view.getLabelForAction(actionIri);
-            if (label == null) label = "action...";
-            if (!label.endsWith("...")) label += "...";
-            PageParameters params = new PageParameters().set("template", t.getId())
-                    .set("param_" + targetField, id)
-                    .set("context", contextId)
-                    .set("template-version", "latest");
-            if (id != null && contextId != null && !id.equals(contextId)) {
-                params.set("part", id);
-            }
-            String partField = view.getTemplatePartFieldForAction(actionIri);
-            if (partField != null) {
-                MaintainedResource r = MaintainedResourceRepository.get().findById(contextId);
-                if (r != null && r.getNamespace() != null) {
-                    params.set("param_" + partField, r.getNamespace() + "<SET-SUFFIX>");
-                }
-            }
-            String queryMapping = view.getTemplateQueryMapping(actionIri);
-            if (queryMapping != null && queryMapping.contains(":")) {
-                params.set("values-from-query", queryRef.getAsUrlString());
-                params.set("values-from-query-mapping", queryMapping);
-            }
-            params.set("refresh-upon-publish", queryRef.getAsUrlString());
-            resultSvg.addButton(label, PublishPage.class, params);
-        }
-    }
 
     private QueryResultSvgBuilder(String markupId, QueryRef queryRef, ViewDisplay viewDisplay) {
         this.markupId = markupId;
@@ -139,7 +93,7 @@ public class QueryResultSvgBuilder implements Serializable {
         QueryResultSvg resultSvg = new QueryResultSvg(markupId, queryRef, response, viewDisplay);
         resultSvg.setPageResource(pageResource);
         resultSvg.setContextId(contextId);
-        addResultButtons(resultSvg);
+        ViewActionMappings.addResultActions(resultSvg, viewDisplay, queryRef, id, contextId, pageResource, refRoot);
         return resultSvg;
     }
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewActionMappings.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewActionMappings.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash.component;
 
+import com.knowledgepixels.nanodash.GrlcQuery;
 import com.knowledgepixels.nanodash.QueryResult;
 import com.knowledgepixels.nanodash.SpaceMemberRole;
 import com.knowledgepixels.nanodash.Utils;
@@ -114,10 +115,25 @@ class ViewActionMappings {
                     params.set("param_" + partField, namespace + "<SET-SUFFIX>");
                 }
             }
-            String queryMapping = view.getTemplateQueryMapping(actionIri);
-            if (queryMapping != null && queryMapping.contains(":")) {
+            // Listing-driven mappings: the form re-runs this view's query and copies the
+            // mapped columns of every row into the template (see PublishForm.applyQueryValues).
+            List<String> queryMappings = view.getTemplateQueryMappings(actionIri);
+            if (!queryMappings.isEmpty()) {
                 params.set("values-from-query", queryRef.getAsUrlString());
-                params.set("values-from-query-mapping", queryMapping);
+                params.set("values-from-query-mapping", String.join(" ", queryMappings));
+            }
+            // Target-driven fill (issue #690): the form runs the action's own query against
+            // the target resource and copies its first row into the template, so a field
+            // can default to something known about the target — the event's start date for
+            // a presentation, say — with an empty listing being no obstacle. Bound to the
+            // page resource, so there is nothing to fill on a resource-less page.
+            GrlcQuery fillQuery = view.getFillQueryForAction(actionIri);
+            List<String> fillMappings = view.getFillQueryMappings(actionIri);
+            if (id != null && fillQuery != null && !fillMappings.isEmpty()) {
+                String fillTargetField = view.getFillQueryTargetFieldForAction(actionIri);
+                if (fillTargetField == null) fillTargetField = "resource";
+                params.set("fill-query", new QueryRef(fillQuery.getQueryId(), fillTargetField, id).getAsUrlString());
+                params.set("fill-query-mapping", String.join(" ", fillMappings));
             }
             params.set("refresh-upon-publish", queryRef.getAsUrlString());
             if (result.getPostPublishTab() != null) params.set("postpub-tab", result.getPostPublishTab());
@@ -195,25 +211,18 @@ class ViewActionMappings {
     static boolean applyEntryMappings(View view, IRI actionIri, ApiResponseEntry row, PageParameters params) {
         Template template = view.getTemplateForAction(actionIri);
         for (String mapping : view.getTemplateQueryMappings(actionIri)) {
-            int sep = mapping.indexOf(':');
-            if (sep < 0) continue;
-            String col = mapping.substring(0, sep);
-            String target = mapping.substring(sep + 1);
-            boolean rawKey = target.startsWith("@");
-            String key = rawKey ? target.substring(1) : target;
-            // A "!" in front of the field name says that what the action fills in is not the
-            // user's to change (issue #678): the field is shown with the value but locked. Only
-            // meaningful for a template field, as a raw key is not a form field.
-            boolean locked = !rawKey && key.startsWith("!");
-            if (locked) key = key.substring(1);
-            String value = row.get(col);
+            View.ActionMapping m = View.ActionMapping.parse(mapping);
+            if (m == null) continue;
+            String value = row.get(m.column());
             if (value == null || value.isBlank()) {
                 // Empty: hide the action only if the target is required.
-                if (rawKey || template == null || template.isRequiredField(key)) return false;
+                if (m.rawKey() || template == null || template.isRequiredField(m.key())) return false;
                 continue;
             }
-            params.set(rawKey ? key : "param_" + key, value);
-            if (locked) params.add("locked", "param_" + key);
+            params.set(m.rawKey() ? m.key() : "param_" + m.key(), value);
+            // A "!" in front of the field name says that what the action fills in is not the
+            // user's to change (issue #678): the field is shown with the value but locked.
+            if (m.locked()) params.add("locked", "param_" + m.key());
         }
         return true;
     }

--- a/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
+++ b/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
@@ -101,6 +101,16 @@ public class KPXL_TERMS {
     public static final IRI HAS_ACTION_TEMPLATE_TARGET_FIELD = VocabUtils.createIRI(NAMESPACE, "hasActionTemplateTargetField");
     public static final IRI HAS_ACTION_TEMPLATE_PART_FIELD = VocabUtils.createIRI(NAMESPACE, "hasActionTemplatePartField");
     public static final IRI HAS_ACTION_TEMPLATE_QUERY_MAPPING = VocabUtils.createIRI(NAMESPACE, "hasActionTemplateQueryMapping");
+    /**
+     * A query a view action runs against its target resource when its form opens, to pre-fill
+     * fields from what is known about that resource (issue #690). The target's IRI is bound
+     * to the query placeholder named by {@link #HAS_ACTION_FILL_QUERY_TARGET_FIELD}
+     * ({@code resource} by default); the first result row is mapped into form fields by
+     * {@link #HAS_ACTION_FILL_QUERY_MAPPING}. See docs/magic-query-params.md.
+     */
+    public static final IRI HAS_ACTION_FILL_QUERY = VocabUtils.createIRI(NAMESPACE, "hasActionFillQuery");
+    public static final IRI HAS_ACTION_FILL_QUERY_MAPPING = VocabUtils.createIRI(NAMESPACE, "hasActionFillQueryMapping");
+    public static final IRI HAS_ACTION_FILL_QUERY_TARGET_FIELD = VocabUtils.createIRI(NAMESPACE, "hasActionFillQueryTargetField");
     public static final IRI HAS_PAGE_SIZE = VocabUtils.createIRI(NAMESPACE, "hasPageSize");
     public static final IRI HAS_STRUCTURAL_POSITION = VocabUtils.createIRI(NAMESPACE, "hasStructuralPosition");
     public static final IRI IS_DISPLAY_OF_VIEW = VocabUtils.createIRI(NAMESPACE, "isDisplayOfView");

--- a/src/test/java/com/knowledgepixels/nanodash/ViewFillQueryTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ViewFillQueryTest.java
@@ -1,0 +1,110 @@
+package com.knowledgepixels.nanodash;
+
+import com.knowledgepixels.nanodash.template.Template;
+import com.knowledgepixels.nanodash.template.TemplateData;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubImpl;
+
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Parsing of an action's fill query (issue #690): the query run against the target
+ * resource when the form opens, its target placeholder, and its mappings.
+ */
+public class ViewFillQueryTest {
+
+    static final String NP = "https://w3id.org/np/RAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQ1";
+    static final String VIEW = NP + "/view";
+    static final IRI ADD = SimpleValueFactory.getInstance().createIRI(NP + "/addAction");
+    static final IRI PLAIN = SimpleValueFactory.getInstance().createIRI(NP + "/plainAction");
+    static final String VIEW_QUERY = "https://w3id.org/np/RAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq/list-presentations";
+    static final String FILL_QUERY = "https://w3id.org/np/RAfffffffffffffffffffffffffffffffffffffffffff/get-event-defaults";
+    public static final String FILL_QUERY_ID = "RAfffffffffffffffffffffffffffffffffffffffffff/get-event-defaults";
+
+    /**
+     * Loads the fixture view with its two queries and the action template stubbed out, so
+     * that nothing is fetched. Callers close the returned mocks.
+     */
+    public static View loadFixture(MockedStatic<Utils> utils, MockedStatic<GrlcQuery> grlc, MockedStatic<TemplateData> td) throws Exception {
+        Nanopub np = new NanopubImpl(new File("src/test/resources/np-fill-query-view.trig"), RDFFormat.TRIG);
+        utils.when(() -> Utils.getAsNanopub(NP)).thenReturn(np);
+        GrlcQuery viewQuery = mock(GrlcQuery.class);
+        when(viewQuery.getQueryId()).thenReturn("RAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq/list-presentations");
+        GrlcQuery fillQuery = mock(GrlcQuery.class);
+        when(fillQuery.getQueryId()).thenReturn(FILL_QUERY_ID);
+        grlc.when(() -> GrlcQuery.get(VIEW_QUERY)).thenReturn(viewQuery);
+        grlc.when(() -> GrlcQuery.get(FILL_QUERY)).thenReturn(fillQuery);
+        Template template = mock(Template.class);
+        when(template.getId()).thenReturn("https://w3id.org/np/RAttttttttttttttttttttttttttttttttttttttttttt");
+        TemplateData templateData = mock(TemplateData.class);
+        when(templateData.getTemplate(anyString())).thenReturn(template);
+        td.when(TemplateData::get).thenReturn(templateData);
+        return View.get(VIEW, false);
+    }
+
+    @Test
+    void fillQueryIsParsedPerAction() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            View view = loadFixture(utils, grlc, td);
+
+            assertNotNull(view.getFillQueryForAction(ADD));
+            assertEquals(FILL_QUERY_ID, view.getFillQueryForAction(ADD).getQueryId());
+            assertEquals("event", view.getFillQueryTargetFieldForAction(ADD));
+            assertEquals(List.of("startDate:startDate", "location:!location"), view.getFillQueryMappings(ADD));
+
+            assertNull(view.getFillQueryForAction(PLAIN));
+            assertNull(view.getFillQueryTargetFieldForAction(PLAIN));
+            assertEquals(List.of(), view.getFillQueryMappings(PLAIN));
+        }
+    }
+
+    /**
+     * The fill query's columns belong to a different query than the view's, so they must
+     * not be hidden from the view's own result table the way mapping-source columns are.
+     */
+    @Test
+    void fillQueryColumnsAreNotMappingSourceColumns() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            View view = loadFixture(utils, grlc, td);
+            assertEquals(Set.of("series", "organiser"), view.getActionMappingSourceColumns());
+        }
+    }
+
+    @Test
+    void actionMappingParsesTheThreeTargetForms() {
+        View.ActionMapping plain = View.ActionMapping.parse("col:field");
+        assertEquals("col", plain.column());
+        assertEquals("field", plain.key());
+        assertFalse(plain.rawKey());
+        assertFalse(plain.locked());
+
+        View.ActionMapping locked = View.ActionMapping.parse("local_pubkey:!public-key__.1");
+        assertEquals("local_pubkey", locked.column());
+        assertEquals("public-key__.1", locked.key());
+        assertFalse(locked.rawKey());
+        assertTrue(locked.locked());
+
+        View.ActionMapping raw = View.ActionMapping.parse("derive_target:@derive-a");
+        assertEquals("derive_target", raw.column());
+        assertEquals("derive-a", raw.key());
+        assertTrue(raw.rawKey());
+        assertFalse(raw.locked(), "a raw key is not a form field, so it cannot be locked");
+
+        assertNull(View.ActionMapping.parse("nocolon"));
+    }
+}

--- a/src/test/java/com/knowledgepixels/nanodash/component/PublishFormQueryFillTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/PublishFormQueryFillTest.java
@@ -1,0 +1,172 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.template.ContextType;
+import com.knowledgepixels.nanodash.template.Template;
+import com.knowledgepixels.nanodash.template.TemplateContext;
+import com.knowledgepixels.nanodash.template.TemplateData;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.ApiResponseEntry;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * The two query-driven pre-fills of the publish form: the target-driven fill query (issue
+ * #690), which takes the first row only, and the listing-driven values, which take every row.
+ */
+class PublishFormQueryFillTest {
+
+    private static final String NP_URI = "https://w3id.org/np/RAAbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE";
+
+    private MockedStatic<TemplateData> templateDataMockedStatic;
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+        templateDataMockedStatic = mockStatic(TemplateData.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        templateDataMockedStatic.close();
+    }
+
+    private TemplateContext context() {
+        Template template = mock(Template.class);
+        TemplateData templateDataMock = mock(TemplateData.class);
+        templateDataMockedStatic.when(TemplateData::get).thenReturn(templateDataMock);
+        when(templateDataMock.getTemplate(NP_URI)).thenReturn(template);
+        return new TemplateContext(ContextType.ASSERTION, NP_URI, "statement", (String) null);
+    }
+
+    /** A response with the given columns and one row per value array. */
+    private static ApiResponse response(String[] columns, String[]... rows) {
+        ApiResponse response = new ApiResponse();
+        response.setHeader(columns);
+        for (String[] row : rows) {
+            ApiResponseEntry entry = new ApiResponseEntry();
+            for (int i = 0; i < columns.length; i++) entry.add(columns[i], row[i]);
+            response.add(entry);
+        }
+        return response;
+    }
+
+    // ---- fill query: first row only ----
+
+    @Test
+    void fillQueryFillsFromTheFirstRow() {
+        TemplateContext ctx = context();
+        PublishForm.applyFillQueryValues("startDate:startDate location:location",
+                response(new String[]{"startDate", "location"}, new String[]{"2026-10-01", "Vienna"}), ctx);
+        assertEquals("2026-10-01", ctx.getParam("startDate"));
+        assertEquals("Vienna", ctx.getParam("location"));
+        assertFalse(ctx.isLocked("startDate"));
+    }
+
+    @Test
+    void fillQueryIgnoresRowsAfterTheFirst() {
+        TemplateContext ctx = context();
+        PublishForm.applyFillQueryValues("startDate:startDate",
+                response(new String[]{"startDate"}, new String[]{"2026-10-01"}, new String[]{"2026-10-02"}), ctx);
+        assertEquals("2026-10-01", ctx.getParam("startDate"));
+        assertNull(ctx.getParam("startDate__1"), "a default for a single-valued field must not spill into a repetition");
+    }
+
+    @Test
+    void fillQueryWithNoRowsFillsNothing() {
+        TemplateContext ctx = context();
+        PublishForm.applyFillQueryValues("startDate:startDate", response(new String[]{"startDate"}), ctx);
+        assertNull(ctx.getParam("startDate"));
+        PublishForm.applyFillQueryValues("startDate:startDate", null, ctx);
+        assertNull(ctx.getParam("startDate"));
+    }
+
+    @Test
+    void fillQuerySkipsEmptyValuesAndLeavesThemUnlocked() {
+        TemplateContext ctx = context();
+        PublishForm.applyFillQueryValues("startDate:!startDate location:!location",
+                response(new String[]{"startDate", "location"}, new String[]{"", "Vienna"}), ctx);
+        assertNull(ctx.getParam("startDate"));
+        assertFalse(ctx.isLocked("startDate"), "no value, nothing to lock the user out of");
+        assertEquals("Vienna", ctx.getParam("location"));
+        assertTrue(ctx.isLocked("location"));
+    }
+
+    @Test
+    void fillQueryHonoursTheLockMarker() {
+        TemplateContext ctx = context();
+        PublishForm.applyFillQueryValues("event:!event",
+                response(new String[]{"event"}, new String[]{"https://example.org/e"}), ctx);
+        assertEquals("https://example.org/e", ctx.getParam("event"));
+        assertTrue(ctx.isLocked("event"));
+    }
+
+    @Test
+    void fillQueryIgnoresRawKeyTargets() {
+        TemplateContext ctx = context();
+        PublishForm.applyFillQueryValues("np:@derive-a startDate:startDate",
+                response(new String[]{"np", "startDate"}, new String[]{"https://example.org/np", "2026-10-01"}), ctx);
+        assertNull(ctx.getParam("derive-a"));
+        assertNull(ctx.getParam("@derive-a"));
+        assertEquals("2026-10-01", ctx.getParam("startDate"), "the other mappings still apply");
+    }
+
+    // ---- listing values: every row ----
+
+    @Test
+    void listingValuesFillEveryRowUnderRepetitionSuffixes() {
+        TemplateContext ctx = context();
+        PublishForm.applyQueryValues("np:nanopub",
+                response(new String[]{"np"}, new String[]{"a"}, new String[]{"b"}, new String[]{"c"}), ctx);
+        assertEquals("a", ctx.getParam("nanopub"));
+        assertEquals("b", ctx.getParam("nanopub__1"));
+        assertEquals("c", ctx.getParam("nanopub__2"));
+    }
+
+    /**
+     * Regression: a result action with two mappings in one literal used to be split on
+     * the first colon, giving a target of {@code "series organiser"} and filling nothing.
+     */
+    @Test
+    void listingValuesApplyEveryMappingInTheLiteral() {
+        TemplateContext ctx = context();
+        PublishForm.applyQueryValues("series:series organiser:organiser",
+                response(new String[]{"series", "organiser"}, new String[]{"S1", "O1"}, new String[]{"S2", "O2"}), ctx);
+        assertEquals("S1", ctx.getParam("series"));
+        assertEquals("S2", ctx.getParam("series__1"));
+        assertEquals("O1", ctx.getParam("organiser"));
+        assertEquals("O2", ctx.getParam("organiser__1"));
+        assertNull(ctx.getParam("series organiser"));
+    }
+
+    @Test
+    void listingValuesKeepTheBareNameShorthand() {
+        TemplateContext ctx = context();
+        PublishForm.applyQueryValues("thing", response(new String[]{"thing"}, new String[]{"x"}), ctx);
+        assertEquals("x", ctx.getParam("thing"));
+    }
+
+    @Test
+    void listingValuesLockEveryRepetitionOfALockedField() {
+        TemplateContext ctx = context();
+        PublishForm.applyQueryValues("np:!nanopub",
+                response(new String[]{"np"}, new String[]{"a"}, new String[]{"b"}), ctx);
+        assertTrue(ctx.isLocked("nanopub"));
+        assertTrue(ctx.isLocked("nanopub__1"));
+    }
+
+    @Test
+    void listingValuesWithNoResponseFillNothing() {
+        TemplateContext ctx = context();
+        PublishForm.applyQueryValues("np:nanopub", null, ctx);
+        assertNull(ctx.getParam("nanopub"));
+    }
+}

--- a/src/test/java/com/knowledgepixels/nanodash/component/ViewActionMappingsFillQueryTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/ViewActionMappingsFillQueryTest.java
@@ -1,0 +1,113 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.*;
+import com.knowledgepixels.nanodash.ViewFillQueryTest;
+import com.knowledgepixels.nanodash.template.TemplateData;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.QueryRef;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * The link a result action's button carries (issue #690): the fill-query parameters bound
+ * to the target, and — fixed on the way — the listing-driven mappings passed whole.
+ */
+class ViewActionMappingsFillQueryTest {
+
+    private static final String EVENT = "https://example.org/events/conf-2026";
+    private static final QueryRef LISTING = new QueryRef("RAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq/list-presentations", "resource", EVENT);
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+    }
+
+    /** The smallest concrete result component: buttons are all this test reads. */
+    private static QueryResult resultFor(View view) {
+        return new QueryResult("r", LISTING, new ApiResponse(), new ViewDisplay(view)) {
+            @Override
+            protected void populateComponent() {
+            }
+        };
+    }
+
+    private static PageParameters paramsOf(QueryResult result, String label) {
+        for (QueryResult.MenuAction a : result.getMenuActions()) {
+            if (a.label().equals(label)) return a.params();
+        }
+        return fail("no button labelled " + label + " among " + result.getMenuActions());
+    }
+
+    @Test
+    void fillQueryIsBoundToTheTargetAndPassedWithItsMappings() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            View view = ViewFillQueryTest.loadFixture(utils, grlc, td);
+            QueryResult result = resultFor(view);
+
+            ViewActionMappings.addResultActions(result, new ViewDisplay(view), LISTING, EVENT, EVENT, null, null);
+
+            PageParameters add = paramsOf(result, "add presentation...");
+            assertEquals(new QueryRef(ViewFillQueryTest.FILL_QUERY_ID, "event", EVENT).getAsUrlString(),
+                    add.get("fill-query").toString(), "the fill query is bound to the target through its target field");
+            assertEquals("startDate:startDate location:!location", add.get("fill-query-mapping").toString());
+            assertEquals(EVENT, add.get("param_event").toString(), "the ordinary target pre-fill is unaffected");
+
+            PageParameters plain = paramsOf(result, "add note...");
+            assertTrue(plain.get("fill-query").isNull(), "an action without a fill query passes none");
+            assertTrue(plain.get("fill-query-mapping").isNull());
+        }
+    }
+
+    /**
+     * No target, nothing to bind the fill query to: a resource-less page (the general
+     * Spaces page, the standalone view-results page) gets the button without the fill.
+     */
+    @Test
+    void noTargetMeansNoFillQuery() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            View view = ViewFillQueryTest.loadFixture(utils, grlc, td);
+            QueryResult result = resultFor(view);
+
+            ViewActionMappings.addResultActions(result, new ViewDisplay(view), LISTING, null, null, null, null);
+
+            PageParameters add = paramsOf(result, "add presentation...");
+            assertTrue(add.get("fill-query").isNull());
+            assertTrue(add.get("param_event").isNull());
+        }
+    }
+
+    /**
+     * A result action with several listing-driven mappings used to pass only the raw first
+     * literal, which the form then split on its first colon into nonsense. All mappings
+     * travel now, in the one literal the form knows how to split.
+     */
+    @Test
+    void allListingMappingsArePassed() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            View view = ViewFillQueryTest.loadFixture(utils, grlc, td);
+            QueryResult result = resultFor(view);
+
+            ViewActionMappings.addResultActions(result, new ViewDisplay(view), LISTING, EVENT, EVENT, null, null);
+
+            PageParameters add = paramsOf(result, "add presentation...");
+            assertEquals(LISTING.getAsUrlString(), add.get("values-from-query").toString());
+            assertEquals("series:series organiser:organiser", add.get("values-from-query-mapping").toString());
+            assertEquals(List.of("series:series", "organiser:organiser"),
+                    View.parseMappingLiteral(add.get("values-from-query-mapping").toString()));
+        }
+    }
+}

--- a/src/test/resources/np-fill-query-view.trig
+++ b/src/test/resources/np-fill-query-view.trig
@@ -1,0 +1,52 @@
+@prefix this: <https://w3id.org/np/RAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQ1> .
+@prefix sub: <https://w3id.org/np/RAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFQ1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+# A tabular view with two result actions (issue #690): one that pre-fills its form from a
+# fill query bound to the target resource, and one that does not. The first also carries a
+# two-mapping listing-driven query mapping, which result actions used to mishandle.
+sub:assertion {
+  sub:view a gen:ResourceView, gen:TabularView;
+    rdfs:label "presentations-view";
+    dct:title "Presentations";
+    gen:hasViewQuery <https://w3id.org/np/RAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq/list-presentations>;
+    gen:hasViewQueryTargetField "resource";
+    gen:hasViewAction sub:addAction, sub:plainAction .
+
+  sub:addAction a gen:ViewResultAction;
+    rdfs:label "add presentation";
+    gen:hasActionTemplate <https://w3id.org/np/RAttttttttttttttttttttttttttttttttttttttttttt>;
+    gen:hasActionTemplateTargetField "event";
+    gen:hasActionTemplateQueryMapping "series:series organiser:organiser";
+    gen:hasActionFillQuery <https://w3id.org/np/RAfffffffffffffffffffffffffffffffffffffffffff/get-event-defaults>;
+    gen:hasActionFillQueryTargetField "event";
+    gen:hasActionFillQueryMapping "startDate:startDate location:!location" .
+
+  sub:plainAction a gen:ViewResultAction;
+    rdfs:label "add note";
+    gen:hasActionTemplate <https://w3id.org/np/RAttttttttttttttttttttttttttttttttttttttttttt> .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  this: dct:created "2026-09-08T09:00:00.000Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    npx:embeds sub:view .
+}


### PR DESCRIPTION
Closes #690.

## What

A view's result action (the "add…" button) could pre-fill only the target field. It can now carry its **own query, bound to the target resource**, whose first result row pre-fills the form:

```turtle
sub:addAction a gen:ViewResultAction ;
    gen:hasActionTemplate <…/presentation-template> ;
    gen:hasActionTemplateTargetField "event" ;
    gen:hasActionFillQuery <…/get-event-defaults> ;
    gen:hasActionFillQueryTargetField "event" ;          # optional, default "resource"
    gen:hasActionFillQueryMapping "startDate:startDate location:!location" .
```

- The button carries the bound reference as `fill-query` / `fill-query-mapping`; `PublishForm` runs it when the form opens (cold cache blocks once, warm serves at once) and applies the **first row only** — these are defaults for single-valued fields, so no `__i` suffixes.
- `col:!field` fills **and locks** the field, as entry actions already can (#678). Blank values are skipped and left unlocked.
- Precedence: fill query → listing values → explicit `param_`. An action can carry both a fill query and a listing mapping.
- Magic parameters are bound at consumption, on the publishing user's request.
- The fill mappings are kept apart from the listing mappings in `View`, so their columns are never hidden from the view's own table.

Doc: new section in `docs/magic-query-params.md`.

## Also in here

- **Refactor (own commit):** the result-action button block existed in four copies; the list, SVG and plain-paragraph builders now call `ViewActionMappings.addResultActions`. Two divergences resolved toward the shared version (null-guarded `param_<target>`/`context`; Space-namespace fallback for the part field); the paragraph builder's dead `space` field removed.
- **Fix:** a result action with several listing mappings in one literal was passed raw and split on the first colon by the form (`"a:b c:d"` → target `"b c"`, nothing filled). Not a regression — the result-action path never got the phase-2 multi-mapping support, and every multi-mapping in `docs/queries/` is on an entry action. `View.ActionMapping` is now the one `col:target` parser for all three consumers.
- A query the API fails on now costs the pre-fill rather than 500-ing the form.

## Compatibility

- Existing views render identically: no fill triples → no fill params; single listing mappings produce the same URL as before; `"void"` is dropped as before.
- Old Nanodash ignores the new predicates (button without fill) — deploy before publishing views that use them.
- `View` is persisted in the API cache snapshot with no `serialVersionUID`, so the first restart after deploy discards the snapshot and starts cold, by design (`ApiCachePersistence.load`); the per-entry store still serves query responses.

## Verified

- Full suite: 1340 tests, 0 failures. New: `ViewFillQueryTest`, `ViewActionMappingsFillQueryTest` (incl. the multi-mapping regression), `PublishFormQueryFillTest` (11 cases), fixture `np-fill-query-view.trig`.
- Live demo on `https://w3id.org/spaces/test/group`: view `RAqsB5Zk7p…/qa-fill-demo-view`, fill query `RA1MUappxs…/get-question-defaults`, display `RAcRiqiS1n…`. On a local build, "❓ ask a question…" opens with the question text pre-filled from the space's label (editable) and the evidence pre-filled with the space's definition nanopub and locked (`readonly` + `locked-value`).

## Follow-up (not in this PR)

The view-creation template needs three optional members for the new predicates so the form can express them; the target-field placeholder must carry **no** default. Tracked on #690.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpQe4aJzdBr1epP8XSGYiY