### PR TITLE
fix: never fail the start page over a query answer that came back short

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -96,21 +96,24 @@ public class HomePage extends NanodashPage {
         setOutputMarkupId(true);
 
         final String homeResourceId = NanodashPreferences.get().getHomeResource();
-        final MaintainedResource homeResource = MaintainedResourceRepository.get().findById(homeResourceId);
+        // The last resource this id ever resolved to, not merely the one the newest
+        // answer carries: the home page is the one page that must survive a query answer
+        // coming back short of it (issue #623).
+        final MaintainedResource homeResource = MaintainedResourceRepository.get().findLastKnownById(homeResourceId);
 
         // Added before the branching below, which returns early on several paths.
         add(PageTitleMenu.forResource("titlemenu", homeResource));
 
         // Rendered only for a genuine misconfiguration (see below): the resource
-        // repository is warm but the configured id is not a known maintained resource.
+        // repository knows maintained resources, and the configured id is none of them.
         final String notFoundHtml = "<div class=\"row-section\"><div class=\"col-12\"><p class=\"negative\">" +
                 "Configured home resource <code>" + Strings.escapeMarkup(homeResourceId) + "</code> could not be found. " +
                 "Set the <code>NANODASH_HOME_RESOURCE</code> environment variable to a valid maintained-resource IRI." +
                 "</p></div></div>";
 
-        if (homeResource == null && MaintainedResourceRepository.get().isReady()) {
-            // The repository has a full snapshot, yet the configured id isn't in it:
-            // a real misconfiguration, not a cold-cache race.
+        if (homeResource == null && MaintainedResourceRepository.get().isAbsent(homeResourceId)) {
+            // The repository holds resources and this id is none of them, nor was it ever:
+            // a real misconfiguration, not a cold cache or an answer that came back short.
             add(new Label("views", notFoundHtml).setEscapeModelStrings(false));
             return;
         }
@@ -128,18 +131,18 @@ public class HomePage extends NanodashPage {
         }
 
         // Either the resource exists but its data isn't initialized yet, or the
-        // repository itself is still cold so findById is transiently null (cache
-        // refresh in flight / racing spaces load). Lazy-load and poll until the data
-        // resolves, rather than declaring a hard "not found" on a transient null. If
-        // the repository warms up without the configured id, the misconfig notice is
-        // shown then.
+        // repository has nothing for the id yet (cache refresh in flight / racing spaces
+        // load / an answer carrying no resources at all). Lazy-load and poll until the
+        // data resolves, rather than declaring a hard "not found" on a transient null. If
+        // the repository ends up holding resources without the configured id among them,
+        // the misconfig notice is shown then.
         // Resolve the repository singleton inside the anonymous classes rather than
         // capturing it: MaintainedResourceRepository is not Serializable, and a
         // captured reference makes the whole page fail to serialize to the page store.
         final IModel<MaintainedResource> homeResourceModel = new LoadableDetachableModel<MaintainedResource>() {
             @Override
             protected MaintainedResource load() {
-                return MaintainedResourceRepository.get().findById(homeResourceId);
+                return MaintainedResourceRepository.get().findLastKnownById(homeResourceId);
             }
         };
 
@@ -158,9 +161,10 @@ public class HomePage extends NanodashPage {
                 MaintainedResource r = homeResourceModel.getObject();
                 // isDataInitialized() also kicks off the (idempotent) data load.
                 if (r != null) return r.isDataInitialized();
-                // Resource still unresolved: keep polling while the repository is cold,
-                // and stop (to show the misconfig notice) only once it is warm.
-                return MaintainedResourceRepository.get().isReady();
+                // Resource still unresolved: keep polling, and stop (to show the
+                // misconfig notice) only once the id is known to be no resource of this
+                // instance rather than one the answers keep leaving out.
+                return MaintainedResourceRepository.get().isAbsent(homeResourceId);
             }
 
             @Override

--- a/src/main/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepository.java
+++ b/src/main/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepository.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class MaintainedResourceRepository {
 
@@ -56,6 +57,14 @@ public class MaintainedResourceRepository {
     private volatile ApiResponse cachedFor;
     private volatile Snapshot snapshot = Snapshot.EMPTY;
 
+    // Every resource a snapshot ever held, by id. The query API is a set of instances
+    // with independently built indexes, so an answer that is short of a resource -- or
+    // of all of them -- is a normal kind of failure rather than news that the resource
+    // is gone. Letting such an answer make a resource disappear is what had the home
+    // page reporting its own configuration as broken (issue #623), so callers that must
+    // not fail over a momentarily missing resource ask findLastKnownById() instead.
+    private final Map<String, MaintainedResource> lastKnownById = new ConcurrentHashMap<>();
+
     private Snapshot current() {
         ApiResponse resp = ApiCache.retrieveResponseIfAvailable(new QueryRef(QueryApiAccess.GET_MAINTAINED_RESOURCES));
         if (resp == null) {
@@ -78,6 +87,7 @@ public class MaintainedResourceRepository {
             }
             snapshot = built;
             cachedFor = resp;
+            lastKnownById.putAll(built.resourcesById);
             return built;
         }
     }
@@ -129,6 +139,13 @@ public class MaintainedResourceRepository {
             // ready" so current() doesn't memoise this empty result.
             return null;
         }
+        if (byId.isEmpty() && !snapshot.resourcesById.isEmpty()) {
+            // An instance that has been shown maintained resources does not suddenly
+            // have none: an answer carrying nothing at all is the query API failing to
+            // answer, not the resources being gone. Keep what we have — latching this
+            // would also let removeStale() below wipe every resource instance.
+            return null;
+        }
         MaintainedResourceFactory.removeStale(byId.keySet());
         return new Snapshot(byId, byNamespace, bySpace);
     }
@@ -174,19 +191,43 @@ public class MaintainedResourceRepository {
     }
 
     /**
-     * Whether a complete resource snapshot has been built at least once, i.e. the
-     * spaces-repo response was fetched and at least one row's space resolved (so
-     * {@link #build} latched a real snapshot rather than bailing out). Until this is
-     * true, {@link #findById} can return null simply because the data is still cold
-     * (cache refresh in flight, or a racing {@link SpaceRepository} load), not
-     * because the id is genuinely unknown. Callers can use this to distinguish a
-     * transient "not loaded yet" from a real "not found".
+     * Like {@link #findById(String)}, but falls back to the resource as it was last
+     * known when the current snapshot has no entry for the id. For the callers that must
+     * keep working across an answer that came back short (issue #623) — above all the
+     * home page, which would otherwise declare its configured resource missing — rather
+     * than for the many callers that ask merely whether an IRI <em>is</em> a maintained
+     * resource; those want {@link #findById(String)} and its strict answer.
      *
-     * @return true once a full snapshot has been built and latched
+     * @param id The id of the resource.
+     * @return The resource, from the current snapshot or from before it, or null if no
+     *         answer ever carried this id.
      */
-    public boolean isReady() {
-        current();
-        return cachedFor != null;
+    public MaintainedResource findLastKnownById(String id) {
+        MaintainedResource resource = findById(id);
+        if (resource != null) return resource;
+        return lastKnownById.get(id);
+    }
+
+    /**
+     * Whether the given id can be taken to be genuinely unknown, i.e. a null from
+     * {@link #findLastKnownById(String)} is final rather than a matter of waiting. Three
+     * things have to hold: a snapshot has been latched at all (the response was fetched
+     * and {@link #build} kept it), that snapshot holds resources, and neither it nor any
+     * earlier answer carried this id. Short of that, an unresolved id means the data is
+     * missing — a cold cache, a racing {@link SpaceRepository}, or an answer short of
+     * every resource — and not that the id is wrong. What lets the home page tell a
+     * misconfigured home resource from an instance that has not been told about its
+     * resources yet (issue #623).
+     *
+     * @param id The id to ask about.
+     * @return true if the id is known not to be a maintained resource
+     */
+    public boolean isAbsent(String id) {
+        Snapshot current = current();
+        return cachedFor != null
+                && !current.resourcesById.isEmpty()
+                && !current.resourcesById.containsKey(id)
+                && !lastKnownById.containsKey(id);
     }
 
     /**

--- a/src/test/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepositoryTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/repository/MaintainedResourceRepositoryTest.java
@@ -1,0 +1,171 @@
+package com.knowledgepixels.nanodash.repository;
+
+import com.knowledgepixels.nanodash.ApiCache;
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import com.knowledgepixels.nanodash.domain.MaintainedResource;
+import com.knowledgepixels.nanodash.domain.Space;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.ApiResponseEntry;
+import org.nanopub.extra.services.QueryRef;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * What the repository does with an answer that comes back short of the resources it
+ * carried before. The query API is a set of instances with independently built indexes,
+ * so a partial or empty result set is a normal kind of failure — and taking it at face
+ * value is what made the home page report its own configuration as broken (issue #623).
+ */
+class MaintainedResourceRepositoryTest {
+
+    private static final String RESOURCE_A = "https://w3id.org/spaces/test/a/r/home";
+    private static final String RESOURCE_B = "https://w3id.org/spaces/test/b/r/other";
+    private static final String SPACE = "https://w3id.org/spaces/test";
+
+    private MockedStatic<SpaceRepository> spaceRepository;
+    private MockedStatic<ApiCache> apiCache;
+    // What the query API is currently answering with; null until the first answer, i.e.
+    // a cold cache. Read by the stubbed ApiCache, so no test goes near the network.
+    private ApiResponse answer;
+
+    private final MaintainedResourceRepository repo = MaintainedResourceRepository.get();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        answer = null;
+        resetRepository();
+        clearResourceInstances();
+
+        // Whichever retrieval the repository reaches for, it gets the current answer and
+        // never the network. Stubbing only the one it happens to call today would leave
+        // the other returning the static mock's null, i.e. a repository that knows
+        // nothing — which is how this test last went wrong.
+        apiCache = mockStatic(ApiCache.class);
+        apiCache.when(() -> ApiCache.retrieveResponseIfAvailable(any(QueryRef.class)))
+                .thenAnswer(invocation -> answer);
+        apiCache.when(() -> ApiCache.retrieveResponseSync(any(QueryRef.class), anyBoolean()))
+                .thenAnswer(invocation -> answer);
+
+        // The spaces are beside the point here: every row's space resolves, so what the
+        // repository does is decided by the maintained-resource answer alone.
+        SpaceRepository spaces = mock(SpaceRepository.class);
+        when(spaces.findById(SPACE)).thenReturn(mock(Space.class));
+        spaceRepository = mockStatic(SpaceRepository.class);
+        spaceRepository.when(SpaceRepository::get).thenReturn(spaces);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        spaceRepository.close();
+        apiCache.close();
+        resetRepository();
+        clearResourceInstances();
+    }
+
+    @Test
+    void anAnswerWithoutResourcesDoesNotUnseatTheOnesAlreadyKnown() {
+        answer(RESOURCE_A, RESOURCE_B);
+        MaintainedResource a = repo.findById(RESOURCE_A);
+        assertNotNull(a);
+
+        answer(); // the query API answers, with nothing in it
+
+        assertSame(a, repo.findById(RESOURCE_A), "the known resources stay");
+        assertNotNull(AbstractResourceWithProfile.get(RESOURCE_A),
+                "and are not wiped from the instance registry either");
+        assertFalse(repo.isAbsent(RESOURCE_A), "nothing about them is absent");
+    }
+
+    @Test
+    void aResourceMissingFromTheNewestAnswerIsStillFoundAsLastKnown() {
+        answer(RESOURCE_A, RESOURCE_B);
+        MaintainedResource a = repo.findById(RESOURCE_A);
+
+        answer(RESOURCE_B); // an answer short of one resource, not of all of them
+
+        assertNull(repo.findById(RESOURCE_A), "the newest answer does not carry it");
+        assertSame(a, repo.findLastKnownById(RESOURCE_A), "but it is not forgotten");
+        assertFalse(repo.isAbsent(RESOURCE_A), "and it is not reported as unknown");
+    }
+
+    @Test
+    void anIdNoAnswerEverCarriedIsReportedAbsent() {
+        answer(RESOURCE_B);
+
+        assertNull(repo.findLastKnownById(RESOURCE_A));
+        assertTrue(repo.isAbsent(RESOURCE_A),
+                "a warm repository holding resources knows this one is none of them");
+    }
+
+    @Test
+    void nothingIsAbsentWhileNothingIsKnown() {
+        assertFalse(repo.isAbsent(RESOURCE_A), "cold cache: no answer at all yet");
+
+        answer(); // the first answer ever carries no resources
+
+        assertFalse(repo.isAbsent(RESOURCE_A),
+                "an instance that has been told of no resources cannot tell this one apart");
+    }
+
+    /** Makes the query API answer with the given resources, and nothing else. */
+    private void answer(String... resourceIds) {
+        ApiResponse response = new ApiResponse();
+        response.setHeader(new String[]{"resource", "space", "np", "label"});
+        for (String resourceId : resourceIds) {
+            ApiResponseEntry entry = new ApiResponseEntry();
+            entry.add("resource", resourceId);
+            entry.add("space", SPACE);
+            // Deliberately not a trusty URI: Utils.getAsNanopub then answers null
+            // without going to the registry.
+            entry.add("np", "http://example.org/np/" + resourceId.hashCode());
+            entry.add("label", resourceId);
+            response.add(entry);
+        }
+        answer = response;
+    }
+
+    /** Puts the singleton back to how it starts, since the tests share it. */
+    private void resetRepository() throws Exception {
+        Field cachedFor = MaintainedResourceRepository.class.getDeclaredField("cachedFor");
+        cachedFor.setAccessible(true);
+        cachedFor.set(repo, null);
+        Class<?> snapshotClass = Class.forName(
+                "com.knowledgepixels.nanodash.repository.MaintainedResourceRepository$Snapshot");
+        Field empty = snapshotClass.getDeclaredField("EMPTY");
+        empty.setAccessible(true);
+        Field snapshot = MaintainedResourceRepository.class.getDeclaredField("snapshot");
+        snapshot.setAccessible(true);
+        snapshot.set(repo, empty.get(null));
+        Field lastKnown = MaintainedResourceRepository.class.getDeclaredField("lastKnownById");
+        lastKnown.setAccessible(true);
+        ((Map<?, ?>) lastKnown.get(repo)).clear();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void clearResourceInstances() throws Exception {
+        ((Map<Object, Map<?, ?>>) field(AbstractResourceWithProfile.class, "instances")).clear();
+    }
+
+    private static Object field(Class<?> owner, String name) throws Exception {
+        Field f = owner.getDeclaredField(name);
+        f.setAccessible(true);
+        return f.get(null);
+    }
+
+}


### PR DESCRIPTION
Closes #623.

The home page reported `Configured home resource ... could not be found` whenever the resource repository had latched a snapshot and that snapshot had no entry for the configured id. Latching, though, took any answer at face value — an answer with no rows at all included.

That is the wrong reading of an empty answer. The query API is a set of instances with independently built indexes, so a short or empty result set is a routine kind of failure and not news that the resources are gone. One such answer latched an empty snapshot, ran `removeStale()` over it (wiping every `MaintainedResource` instance), and turned a passing API hiccup into the page declaring its own configuration broken — with the persisted cache that could have covered it overwritten along the way.

## What now stands between such an answer and the page

| | |
|---|---|
| **An emptied answer is not latched** | `build()` keeps the current snapshot when a new answer carries no resources at all and the current one has some, so what was fetched before — or restored from the persistent cache after a restart — goes on being served, instances and all. |
| **A resource is not forgotten** | Every resource a snapshot ever held is kept by id, and `findLastKnownById()` falls back to it. `findById()` keeps its strict answer for the many callers that use it to ask whether an IRI *is* a maintained resource. |
| **"Not found" has to be earned** | `isAbsent()` replaces `isReady()` as what the home page asks: a snapshot is latched, it holds resources, and neither it nor any earlier answer carried this id. |

So the notice is reserved for a genuine misconfiguration — the configured IRI is none of the resources this instance knows, and never was. Anything else keeps the last known resource on screen, or goes on waiting for one.

## The trade-off

An instance whose query API reports no maintained resources at all now waits on the loading state instead of showing the notice, because that case cannot be told apart from an answer that failed to carry them. That is the trade the issue asks for: the start page should not fail.

## Tests

Four new, driving the repository through the answers it has to survive — an answer with nothing in it, an answer short of one resource, an id no answer ever carried, and a repository that knows nothing yet. All stubbed, so none of them goes near the network.

Suite: 1263 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtcVArNfYKiiTVowsdkF44
