### PR TITLE
feat(spaces): show member names instead of bare ORCIDs in space user listings

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -243,8 +243,13 @@ public class QueryApiAccess {
     // materialized RoleInstantiation carries npa:trustStatus npa:seen, produced by the
     // PendingAccountState self-arm for observer-tier self-signups of introduced-but-unapproved
     // users — shows ⏳ in the headerless flag column (empty = approved-validated, ⏳ =
-    // pending-validated, ⚠️ = not validated at all).
-    public static final String LIST_SPACE_OBSERVERS_REF = "RAt8PKQ21Ppsf3EZTH-Th749ZF8bjaniYc0jDqLt6ixXg/list-space-observers";
+    // pending-validated, ⚠️ = not validated at all). Latest (RANXPEIi, supersedes RAt8PKQ2) adds a
+    // member_label column so each agent shows by name: the canonical foaf:name mirrored into the
+    // current space state, falling back to the foaf:name asserted for that agent in the grant
+    // nanopub's pubinfo. Most role holders have no key introduction of their own, so without the
+    // fallback they rendered as bare ORCIDs; purely self-declared claims that carry no name
+    // anywhere still show their IRI.
+    public static final String LIST_SPACE_OBSERVERS_REF = "RANXPEIihP6m2ozdLr6KTw4Jw9fKk6BxbI3sGVOuyYUzQ/list-space-observers";
 
     // Ref-scoped non-approved role claims (root_np): agents holding a higher-tier role
     // instantiation (admin/maintainer/member) that is NOT in the validated state — a
@@ -275,8 +280,9 @@ public class QueryApiAccess {
     // Space itself (a competing root definition) is not offered for derivation; admin-tier
     // claims from such definitions pair with the built-in admin-assignment template instead
     // (the hasAdmin triple unifies), keeping the space-ref-conflict remedy.
-    // Source at docs/queries/list-space-non-approved-ref-v7.trig.
-    public static final String LIST_SPACE_NON_APPROVED_REF = "RAVsaIwAWFk9NekiVx-pGN6c1p-CK9ozishyvXcjUtTLc/list-space-non-approved";
+    // Source at docs/queries/list-space-non-approved-ref-v7.trig. v8 (RAoX3Htu, supersedes
+    // RAVsaIwA) adds a member_label column, sourced like the observers query above.
+    public static final String LIST_SPACE_NON_APPROVED_REF = "RAoX3HtuHttjxGWkdPc9tzF11hNrTiD2fm3OcQgR7Wbxw/list-space-non-approved";
 
     // Ref-scoped variants of the four About-tab *view* display queries (distinct from the
     // GET_SPACE_*_REF client-authority queries above). Each takes the ref's root nanopub
@@ -292,9 +298,11 @@ public class QueryApiAccess {
     // (npa:hasRoleType) and its role (gen:hasRole) in the current space state, now that nanopub-query
     // persists tier on the instantiation (nanopub-query#125 + #127). Simplifies away the earlier
     // RoleAssignment-scoping workaround and the global RoleDeclaration matching that leaked observer-tier
-    // members into the Approved listing. See nanodash#498. Latest (RAJ15No3, supersedes RA7E54m5, adding the hidden revokeAgent action-mapping column; RA7E54m5 superseded RApyKS9D)
-    // drops the role-label coalesce to read schema:name only.
-    public static final String LIST_SPACE_MEMBERS_REF = "RAJ15No3ghODCXHgk71ix3ZHOWlrL_u6FhuIPffgkjA_Y/list-space-members";
+    // members into the Approved listing. See nanodash#498. RAJ15No3 (supersedes RA7E54m5, adding the hidden revokeAgent action-mapping column; RA7E54m5 superseded RApyKS9D)
+    // drops the role-label coalesce to read schema:name only. Latest (RA-90ZiE, supersedes RAJ15No3)
+    // adds a member_label column, sourced like the observers query above, and orders rows by tier and
+    // then by that display name.
+    public static final String LIST_SPACE_MEMBERS_REF = "RA-90ZiEE8OomcMz4np_IoQtsodQjyycUKfRPMDI67ju4/list-space-members";
     public static final String LIST_SPACE_ROLES_REF = "RAYy3dC-N0ps7va0vZ8vQiD9cbU5XNOxmbfvhrImx7UMU/list-space-roles";
     public static final String LIST_SUB_SPACES_REF = "RA-j0DFqkNUHxF_WIds8wWJix6DkDFBmUBWmKXfG24XYQ/list-sub-spaces";
     public static final String LIST_MAINTAINED_RESOURCES_REF = "RAPthUMRDXiJeD2BrOsZigTsbA0LktBc-HC4alDSfVNKM/list-maintained-resources";


### PR DESCRIPTION
## Problem

The **Approved Admins/Maintainers/Members**, **Self-Assigned/Observers** and **Pending Admins/Maintainers/Members** tables on a space's About tab rendered most agents as bare ORCID digits.

Nanodash resolves an agent name client-side in `NanodashLink`, but only via `UserData` → `get-all-user-intros`, which covers just the agents who published a **key introduction** of their own. Most role holders of a space never did. For `https://w3id.org/spaces/semantics/2026-eu` that was **4 named out of 97 members**.

## Fix

The names are already in the data, so the listing queries now return them as a `member_label` companion column, resolved in two steps:

1. `foaf:name` on the agent in the current space-state graph — canonical, from the agent's own introduction;
2. otherwise the `foaf:name` asserted for that agent in the **pubinfo of the grant nanopublication** (Nanodash writes this whenever an agent placeholder is filled).

`QueryResultTable` hides a `_label` companion and renders it as the link text, and `FilteredQueryResultDataProvider` already sorts a column on its `_label`, so no rendering code changes. Default row order now follows the display name (tier first for members).

Full label coverage on every space sampled, at no measurable cost (330 rows in ~0.9 s). Agents whose grant carries no name either — purely self-declared claims — still show their IRI; that name was never asserted anywhere.

## Why a code change is needed

Views resolve to their latest version automatically, but **queries are pinned by exact IRI**. And `AboutSpacePanel` drives these three tables from the hard-coded **ref-scoped** queries (`root_np`-keyed), not from the views' own `gen:hasViewQuery`, whenever the ref root is known — the view query is only the fallback. So the constants have to be bumped here for the change to reach a real space page.

| Constant | New query | Supersedes |
|---|---|---|
| `LIST_SPACE_MEMBERS_REF` | `RA-90ZiEE8OomcMz4np_IoQtsodQjyycUKfRPMDI67ju4` | `RAJ15No3…` |
| `LIST_SPACE_OBSERVERS_REF` | `RANXPEIihP6m2ozdLr6KTw4Jw9fKk6BxbI3sGVOuyYUzQ` | `RAt8PKQ2…` |
| `LIST_SPACE_NON_APPROVED_REF` | `RAoX3HtuHttjxGWkdPc9tzF11hNrTiD2fm3OcQgR7Wbxw` | `RAVsaIwA…` |

The corresponding IRI-keyed queries (the no-refRoot fallback) and the three view nanopubs were superseded alongside them, so both paths agree. All are published live and their supersede chains resolve.

## Verification

Ran a local instance on the patched constants:

- `zonmw/antibiotica-resistentie-abr/541003005` — members render as Margreet Bloemers, Tobias Kuhn, Anita C. Schürch, Ad Fluit, Herman Wunderink, JPM Coolen, Lieke B. van Alphen, Monika Anna Fliss, Rob Willems, Suzan Bongers (previously all but two were bare ORCIDs).
- `fdo-conference-2026` — members 3/3 named, observers 10/10 named on the first page, pending 10/10 named.

Headers stay `member | tier | role assignments`; `member_label` is hidden as a companion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Npfb25jWo6cLNjKbHZPtim