### PR TITLE
feat(presets): key preset assignments on the preset kind and offer an update action (#607)

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -92,10 +92,18 @@ sub:assignment a gen:PresetAssignment ;
 ```
 
 The crucial design point — copied directly from view displays — is that **the
-assignment is identified by the `(preset, resource)` pair, not by the
+assignment is identified by the `(preset kind, resource)` pair, not by the
 nanopublication's URI.** The `sub:assignment` node is a fresh local resource
 minted in each nanopub; what ties two nanopubs together is that they describe an
 assignment of the *same* preset for the *same* resource.
+
+The key is the preset's stable **kind** (`dct:isVersionOf`), not the pinned
+version the assignment references — exactly as a view display's identity is
+`(view kind, resource)` and not the view version it points at. So assigning
+another version of the same preset *replaces* the earlier assignment rather than
+adding a second, competing one (see [Updating to a newer preset
+version](#updating-to-a-newer-preset-version)). A preset version that declares no
+kind keys on itself.
 
 ### Activation and cross-user deactivation
 
@@ -182,7 +190,7 @@ implementation can largely follow the existing code paths:
 | `gen:DeactivatedViewDisplay`           | `gen:DeactivatedPresetAssignment`        |
 | `gen:isDisplayOfView`                  | `gen:isAssignmentOfPreset`               |
 | `gen:isDisplayFor`                     | `gen:isAssignmentFor`                    |
-| identity by `(view, resource)`         | identity by `(preset, resource)`         |
+| identity by `(view kind, resource)`    | identity by `(preset kind, resource)`    |
 | "Displaying a view for a resource"     | "Assigning a preset to a resource"       |
 | "Deactivating a view display ..."      | (covered by the deactivated type toggle) |
 
@@ -211,16 +219,94 @@ These were open during design; the implementation has since settled them.
   `appliesToInstancesOf` / `appliesToNamespace`. See `Preset` (`topLevelViews`
   vs `views`) and `ViewDisplay.forPresetView(…, topLevel, …)`.
 - **Deactivation:** an assignment is deactivated by publishing a
-  `gen:DeactivatedPresetAssignment` for the same `(preset, resource)` pair
+  `gen:DeactivatedPresetAssignment` for the same `(preset kind, resource)` pair
   (latest-wins among authorized agents), so a different agent can deactivate one
   they did not create — mirroring view-display deactivation. The preset-assignments
   view exposes a per-row deactivate action; `PresetAssignment.isActive()` reads the
   type. (No separate "deactivating" template was needed.)
-- **Assignment target granularity:** assignments reference a preset (version)
-  node, and resolution follows the supersedes chain to the latest version —
-  exactly as views do (`PresetAssignment.getPreset()` → `Preset.get()` →
-  `getLatestVersionId`). The version-independent `presetKind` (`dct:isVersionOf`)
-  is captured too (`Preset.getPresetKindIri()`).
+- **Assignment target granularity:** an assignment *references* a concrete preset
+  version and that pin is what takes effect — a preset never auto-updates, which
+  matters because presets carry roles. Assignment *identity*, though, is by preset
+  kind (see above), so a newer version is adopted by assigning it, and the older
+  assignment then loses on publication time.
+
+## Updating to a newer preset version
+
+Presets deliberately do not follow their kind forward on their own: the views and
+especially the **roles** a resource picks up stay exactly the ones its admins
+signed off on. Adopting a newer version is therefore an explicit act, and the
+"🪟 Assigned presets" table on the About page makes it a one-click one
+([issue #607](https://github.com/knowledgepixels/nanodash/issues/607)):
+
+- The listing queries (`list-preset-assignments` and its ref-scoped twin) look up
+  the newest non-invalidated version of the assigned preset's kind and report the
+  verdict in a **`version` column**: `version_label` holds what the cell displays
+  ("latest" or "⬆️ update available") and `version` the dates behind it. That way
+  round because `QueryResultTable` displays a literal column's `_label` companion and
+  puts the principal value in the hover tooltip — not the other way round. The newer
+  version itself goes in `updatePreset`, which the action mapping hides from the table.
+- Candidate versions are restricted to those published by the **same agent** as
+  the assigned version, so an unrelated agent cannot advertise a version of
+  someone else's preset in a space's About page.
+- The views carry an "⬆️ update to latest version" entry action, gated to
+  maintainers and above, that opens the page's own assignment template pre-filled
+  with the newer version (`updatePreset:preset`). Publishing it makes the newer
+  assignment the latest for that `(preset kind, resource)` pair; nothing needs to
+  be deactivated first. Rows with no newer version carry an empty `updatePreset`,
+  which hides the button for them.
+
+### Who may assign, update and deactivate
+
+The tiers differ by resource type, because the query service does:
+
+- **Spaces: admins only.** `AuthorityResolver`'s ref-scoped assignment mirror and its
+  preset-role attachment both require the publisher to hold `gen:hasAdmin` on the
+  target ref, so a maintainer's assignment is never stamped into the space state and
+  never reaches the space's "Assigned presets" table. The space view's three actions
+  are therefore gated `gen:isVisibleTo gen:AdminRole`, matching what the server will
+  honour — offering them to maintainers produced a publish whose views took effect
+  while the listing and the roles ignored it.
+- **Maintained resources and their parts: maintainers and above.** Those pages run the
+  IRI-keyed listing, which accepts admins and maintainers alike, and preset-derived
+  roles are not materialized for non-space targets at all
+  (`presetAttachmentValidationUpdate` resolves no `?targetRef` and inserts nothing), so
+  views are the only effect and they accept maintainers too.
+- **User pages: the user themselves.** The owner counts as the sole admin of their own
+  page and no one else holds a tier there, so the distinction does not arise.
+
+Widening spaces to maintainers would mean a maintainer can attach role definitions to a
+space by assigning a preset — the escalation surface presets are deliberately careful
+about — so the narrower gate is the default, and changing it is a server-side decision
+before it is a view-side one.
+
+### What the query service already does — and where it still differs
+
+Worth knowing, because it is not symmetric: **roles are already resolved by kind
+server-side.** `AuthorityResolver.presetAttachmentValidationUpdate` maps an
+assignment's preset reference to its `npa:presetKind` and then draws the roles from
+the *latest live declaration of that kind* (steps 5–5c; see
+`doc/design-preset-role-materialization.md`, "a superseded preset version's roles
+never leak"). So the roles a resource picks up follow the newest preset version on
+their own, whichever version an assignment pins — it is the **views** that stay
+pinned, which is what makes the update action necessary in the first place.
+
+What is still keyed on the pinned `(preset version, resource)` pair server-side is
+**which assignment counts** — the latest-wins/anti-hijack filter in that same update
+(step 7) and `presetDeactivationCheckWhere`. That is consistent with the update
+action (assigning a newer version leaves the roles resolving to that version anyway),
+but it diverges on **deactivation** while two versions of one kind are assigned:
+Nanodash treats the newest row for the kind as decisive and drops the preset
+entirely, whereas the materializer only sees that one *version's* assignment
+switched off and keeps the role attachments alive through the older version's
+assignment. Aligning it means keying those two filters on the kind as well — a
+contained nanopub-query change; both blocks already have `?kind` in scope or one
+join away.
+
+Note also that "deactivate the old version and activate the new one in a single
+nanopublication" is not an option: `SpacesExtractor.extractPresetAssignment` reads
+only the first `gen:isAssignmentOfPreset` triple and emits one row keyed by the
+nanopub's artifact code, so a second assignment node in the same nanopub is
+silently ignored.
 
 ## Example nanopubs
 

--- a/docs/queries/get-view-displays-unresolved.trig
+++ b/docs/queries/get-view-displays-unresolved.trig
@@ -19,10 +19,10 @@ sub:Head {
 }
 
 sub:assertion {
-  sub:get-view-displays a grlc:grlc-query;
-    dct:description "Returns the views to display for a given resource: both standalone view displays and the views contributed by assigned presets (issue #302), unioned and ordered by date so latest-wins override resolution holds across both. Filtered server-side to declarations signed by an admin or maintainer of the owning space, or by the affected user themselves (for an agent's own page). Each referenced view is resolved to its latest version by following the npx:supersedes chain: among the version tree's current heads (nanopubs that are themselves neither superseded nor validly retracted via npx:invalidates), the most recent is chosen, so ?view is the latest non-retracted view definition (no separate latest-version lookup needed by the client). Choosing a current head rather than the max-timestamp node makes resolution robust to backdated supersedes and to retracted versions. Preset-derived rows have an unbound ?display and carry the resolved ?view plus the assignment's activation mode. The view-version resolution is wrapped in a run-once sub-SELECT so it is evaluated once for the whole view set rather than once per referenced view. Space-governed versions (gen:governedBy, nanodash docs/views-and-presets-as-maintained-resources.md): a referenced version declaring gen:governedBy resolves to the newest version of its (kind, space) pair signed by a current member+ (admin/maintainer/member) of that space -- with the kind validated as a maintained resource of the space -- taking precedence over the supersedes-based head; without a valid governed candidate the pinned version stands. Federation footprint (2026-08-20): the query now runs on the repo/full endpoint, so the former SERVICE hops to repo/full (preset branch) and to the ResourceView type repo (view lookups, governed candidates) are plain local patterns; only the two lookups of materialized space state (authority gate, governed-signer validation) remain federated, to repo/spaces. The previous 5-SERVICE layout was the main amplifier of a connection-pool deadlock in the query service's loopback federation (an outer query holds a pooled connection while each SERVICE hop -- one per binding under a nested-loop join -- requests another from the same pool): a thread dump during a production wedge showed all 60 route connections held by result streamers of exactly these hops. Validated byte-for-byte identical to the previous version across resources covering standalone displays, preset assignments, governed views, an agent's own page, and rival space refs. Pending accounts (nanopub-query#195, nanodash#625): the self-signed arm additionally accepts npa:PendingAccountState rows -- mirrored by the query service from authoritative introductions of users who are not trust-approved yet -- so such a user's own page shows the view displays they signed themselves. The pending class is distinct from npa:AccountState, so no authority-granting join is widened: the admin/maintainer arm and the governed-version resolution keep requiring approved accounts. Preset-assignment identity (nanodash issue #607): rows contributed by a preset assignment now also carry ?presetKind, the assigned preset's stable kind (dct:isVersionOf, falling back to the version IRI), so the client can keep only the newest assignment per (preset kind, resource) -- the same identity view displays already have via view kind -- and views that a newer preset version no longer carries drop out with the older assignment. Purely additive: every pre-existing column is unchanged.";
+  sub:get-view-displays-unresolved a grlc:grlc-query;
+    dct:description "Variant of get-view-displays (ref-scoped) that returns view references UNRESOLVED: the ?view column carries the version IRI the display/preset actually references (or, for space-governed pins, the governed resolution), and resolving a referenced version to the current supersedes-head is the CALLER's job (Nanodash: per-view latest-version lookups through ApiCache, forced refresh on own publishes). This removes the former run-once repo-wide resolution sub-select -- the query's dominant and fragility-prone cost, linear in the total view count -- leaving only bound point lookups; see nanopub-query doc/design-view-head-materialization.md for the measurements. Same inputs as get-view-displays-ref-scoped (resource = space IRI, root_np = the ref's root nanopub; authority gate scoped to that ref) and the same columns, plus ?governedBySpace: when bound, the row's ?view is the space-governed resolution (newest member+-signed version of its (kind, space) pair, kind validated as maintained resource; nanodash docs/views-and-presets-as-maintained-resources.md) and the caller must NOT apply supersedes-head resolution on top of it; when unbound, the caller resolves ?view to its latest version. ?viewKind is taken from the referenced version's own dct:isVersionOf (version-stable, hence equal to the head's kind), falling back to ?view itself for kind-less legacy views. Federation footprint (2026-08-20): the query now runs on the repo/full endpoint, so the former SERVICE hops to repo/full (preset branch) and to the ResourceView type repo (view lookups, governed candidates) are plain local patterns; only the two lookups of materialized space state (authority gate, governed-signer validation) remain federated, to repo/spaces. The previous 5-SERVICE layout was the main amplifier of a connection-pool deadlock in the query service's loopback federation (an outer query holds a pooled connection while each SERVICE hop -- one per binding under a nested-loop join -- requests another from the same pool): a thread dump during a production wedge showed all 60 route connections held by result streamers of exactly these hops. Validated byte-for-byte identical to the previous version across resources covering standalone displays, preset assignments, governed views, an agent's own page, and rival space refs. Preset-assignment identity (nanodash issue #607): rows contributed by a preset assignment now also carry ?presetKind, the assigned preset's stable kind (dct:isVersionOf, falling back to the version IRI), so the client can keep only the newest assignment per (preset kind, resource) -- the same identity view displays already have via view kind -- and views that a newer preset version no longer carries drop out with the older assignment. Purely additive: every pre-existing column is unchanged.";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
-    rdfs:label "Get view displays";
+    rdfs:label "Get view displays (unresolved versions)";
     grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/full>;
     grlc:sparql """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix dct:  <http://purl.org/dc/terms/>
@@ -31,33 +31,29 @@ prefix npa:  <http://purl.org/nanopub/admin/>
 prefix npx:  <http://purl.org/nanopub/x/>
 prefix gen:  <https://w3id.org/kpxl/gen/terms/>
 
-select distinct ?display ?view (coalesce(?viewKindOptional, ?view) as ?viewKind) ?presetKind
+select distinct ?display ?view (coalesce(?pinKind, ?view) as ?viewKind) ?governedBySpace ?presetKind
                 ?label ?displayType ?displayMode ?np ?pubkey ?date where {
   values ?_resource_multi_iri {}
+  values ?_root_np_multi_iri {}
   service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
     graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
+    graph npa:spacesGraph { ?passedRef npa:rootNanopub ?_root_np_multi_iri . }
     {
       # Authority gate (issue #130 / nanodash#510): a single mandatory hop through the
       # governing space ref, which covers both a maintained resource and a space itself
       # (the reflexive self-edge), keyed on the role tier materialized on the
       # RoleInstantiation since #125. Replaces the old bare-IRI isMaintainedBy? hop and the
-      # dead RoleDeclaration maintainer join. Non-ref variant: any ref claiming the IRI, so
-      # authority merges across refs (the ref variant pins a single ?passedRef instead).
+      # dead RoleDeclaration maintainer join. Ref variant: the governing ref is pinned to
+      # ?passedRef (resolved from root_np), so authority cannot bleed across rival refs
+      # claiming the same space IRI.
       graph ?stateG {
-        ?_resource_multi_iri npa:hasGoverningSpaceRef ?spaceRef .
-        ?ri a gen:RoleInstantiation ; npa:forSpaceRef ?spaceRef ; npa:hasRoleType ?roleType ; npa:forAgent ?authAgent .
+        ?_resource_multi_iri npa:hasGoverningSpaceRef ?passedRef .
+        ?ri a gen:RoleInstantiation ; npa:forSpaceRef ?passedRef ; npa:hasRoleType ?roleType ; npa:forAgent ?authAgent .
         filter(?roleType = gen:AdminRole || ?roleType = gen:MaintainerRole)
         ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
       }
     } union {
       graph ?stateG { ?selfAcct a npa:AccountState ; npa:agent ?_resource_multi_iri ; npa:pubkey ?pubkey . }
-    } union {
-      # Own page of an agent who is introduced but not trust-approved yet
-      # (nanopub-query#195, nanodash#625): npa:PendingAccountState rows are mirrored
-      # from authoritative introductions and carry a distinct class so that no
-      # authority join can resolve through them; this arm is display-only and scoped
-      # to the page's own agent, exactly like the AccountState self-arm above.
-      graph ?stateG { ?pendAcct a npa:PendingAccountState ; npa:agent ?_resource_multi_iri ; npa:pubkey ?pubkey . }
     }
   }
   {
@@ -116,39 +112,31 @@ select distinct ?display ?view (coalesce(?viewKindOptional, ?view) as ?viewKind)
       }
     }
   }
-  # Resolve each referenced view to its latest version: the current head of its
-  # supersedes version tree (a nanopub itself neither superseded nor validly
-  # retracted via npx:invalidates), most recent among heads on a fork. Now a
-  # LOCAL lookup (endpoint = repo/full; the ?ra type gate keeps it scoped to
-  # ResourceView nanopubs exactly as the former type-shard service did). Still
-  # wrapped in a run-once sub-SELECT so it is evaluated once for the whole view
-  # set rather than once per referenced view.
+  # Pin metadata of the referenced version (kind + optional governing space).
+  # ?refView is bound by branch (a)/(b) at this point, so these are bound point
+  # lookups for the handful of referenced views — now LOCAL joins (endpoint =
+  # repo/full), where previously each was its own SERVICE round-trip: evaluated
+  # under a nested-loop join, that fired one loopback HTTP request per
+  # referenced view while the outer query held its own pooled connection — the
+  # per-binding amplification at the heart of the federation deadlock. NOT
+  # wrapped in a sub-select, deliberately: a run-once sub-select could not see
+  # outer bindings and would have to enumerate every view in the repository
+  # (the measured dominant cost of the former resolution variant;
+  # supersedes-head resolution itself happens caller-side, per view, cached).
   optional {
     {  # was: service repo/type/ec6722… (ResourceView shard) — now local on the repo/full endpoint
-      select distinct ?refView ?latestView ?viewKindOptional ?pinKind ?pinSpace where {
-        graph npa:graph { ?rnp npx:embeds ?refView ; np:hasAssertion ?ra . }
-        graph ?ra { ?refView a gen:ResourceView . }
-        optional { graph ?ra { ?refView dct:isVersionOf ?pinKind ; gen:governedBy ?pinSpace . } }
-        optional {
-          ?vnp npx:embeds ?refView .
-          ?latestNp (npx:supersedes|^npx:supersedes)* ?vnp ; dct:created ?ldate ; npx:embeds ?latestView ; np:hasAssertion ?va ; npa:hasValidSignatureForPublicKeyHash ?invPk .
-          filter not exists { ?supNp npx:supersedes ?latestNp . }
-          filter not exists { ?invNp npx:invalidates ?latestNp ; npa:hasValidSignatureForPublicKeyHash ?invPk . }
-          filter not exists {
-            ?other (npx:supersedes|^npx:supersedes)* ?vnp ; dct:created ?odate ; npa:hasValidSignatureForPublicKeyHash ?invPk2 .
-            filter not exists { ?supNp2 npx:supersedes ?other . }
-            filter not exists { ?invNp2 npx:invalidates ?other ; npa:hasValidSignatureForPublicKeyHash ?invPk2 . }
-            filter(?odate > ?ldate)
-          }
-          graph ?va { ?latestView a gen:ResourceView . optional { ?latestView dct:isVersionOf ?viewKindOptional . } }
-        }
-      }
+      graph npa:graph { ?rnp npx:embeds ?refView ; np:hasAssertion ?ra . }
+      graph ?ra { ?refView a gen:ResourceView . }
+      optional { graph ?ra { ?refView dct:isVersionOf ?pinKind . } }
+      optional { graph ?ra { ?refView gen:governedBy ?pinSpace . } }
     }
   }
-    # Space-governed resolution (gen:governedBy; nanodash docs/views-and-presets-as-
+  # Space-governed resolution (gen:governedBy; nanodash docs/views-and-presets-as-
   # maintained-resources.md): a pinned version declaring a governing space resolves to
   # the newest member+-signed version of its (kind, space) pair instead of the
-  # supersedes head; no valid candidate -> the pin stands.
+  # supersedes head; no valid candidate -> the pin stands. Joins on (?pinKind,
+  # ?pinSpace) from the bound lookup above; rows without a governing space are
+  # unaffected.
   optional {
         { select ?pinKind ?pinSpace (iri(strafter(max(concat(str(?cDate), \">\", str(?cver))), \">\")) as ?governedLatest) where {
             # Candidate versions — was a service on the ResourceView type shard, now
@@ -178,7 +166,8 @@ select distinct ?display ?view (coalesce(?viewKindOptional, ?view) as ?viewKind)
             }
           } group by ?pinKind ?pinSpace }
   }
-  bind(if(bound(?pinSpace), coalesce(?governedLatest, ?refView), coalesce(?latestView, ?refView)) as ?view)
+  bind(if(bound(?pinSpace), coalesce(?governedLatest, ?refView), ?refView) as ?view)
+  bind(if(bound(?pinSpace), ?pinSpace, ?undef_) as ?governedBySpace)
 }
 order by desc(?date)""" .
 }
@@ -193,9 +182,9 @@ sub:pubinfo {
   this: dct:created "2026-09-09T06:25:41Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    npx:embeds sub:get-view-displays;
-    npx:supersedes <https://w3id.org/np/RA3ekD-2utY7P0ZgAHSr4HRwugzNnYhxJbkeI-3EfYfww>;
-    rdfs:label "Get view displays";
+    npx:embeds sub:get-view-displays-unresolved;
+    npx:supersedes <https://w3id.org/np/RAkIkmSiwDT-bgYZhGtknPhpkHsJcx0Q3nP0u8OyO_fZ4>;
+    rdfs:label "Get view displays (unresolved versions)";
     nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
     nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,
       <https://w3id.org/np/RAoTD7udB2KtUuOuAe74tJi1t3VzK0DyWS7rYVAq1GRvw>, <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI>;

--- a/docs/queries/list-preset-assignments-ref.trig
+++ b/docs/queries/list-preset-assignments-ref.trig
@@ -1,8 +1,9 @@
 @prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
-@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub:  <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix np: <http://www.nanopub.org/nschema#> .
 @prefix grlc: <https://w3id.org/kpxl/grlc/> .
 @prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
 @prefix npx: <http://purl.org/nanopub/x/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -19,7 +20,7 @@ sub:Head {
 
 sub:assertion {
   sub:list-preset-assignments a grlc:grlc-query;
-    dct:description "Lists the presets assigned in a given space ref (space IRI + root definition). Pass the ref's root nanopub (root_np); the query resolves the ref via npa:rootNanopub and reads the server-materialised npa:PresetAssignment rows scoped by npa:forSpaceRef from the trust-validated current space-state graph (only admin-authored assignments are materialised, so this is authorisation-scoped). Per (preset, resource) only the latest assignment by dct:created counts, and the preset is listed only when that latest row is still activated (npa:isActivated true) — a deactivation is a newer admin-authored row with npa:isActivated false. Columns match the IRI-keyed list-preset-assignments (preset, preset_label, deactivatePreset, added_by, date_added, np, np_label) so it drives the existing Preset assignments view unchanged. Ref-scoped variant: shows only that one ref's assignments rather than merging all refs claiming the IRI.";
+    dct:description "Lists the presets assigned in a given space ref (space IRI + root definition). Pass the ref's root nanopub (root_np); the query resolves the ref via npa:rootNanopub and reads the server-materialised npa:PresetAssignment rows scoped by npa:forSpaceRef from the trust-validated current space-state graph (only admin-authored assignments are materialised, so this is authorisation-scoped). An assignment is identified by the assigned preset's stable KIND (dct:isVersionOf) and the resource, mirroring view displays, which the client dedups by view kind (nanodash issue #607): among the assignments of one preset kind for one resource only the latest by dct:created counts, so assigning another version of the same preset replaces the earlier assignment instead of adding a second, competing row; a version declaring no kind keys on itself, and the preset listed is the version that assignment pinned. The preset is listed only when that latest row is still activated (npa:isActivated true) -- a deactivation is a newer admin-authored row with npa:isActivated false. The version column reports whether the assigned version is still current: version_label is what the cell shows (latest, or an up-arrow plus update available) and version carries the dates behind it as the hover tooltip -- that way round because the renderer displays a literal column's _label companion and puts the principal value in the tooltip. updatePreset holds the version the update action pre-fills. All three are derived from the newest non-invalidated version of the same kind, restricted to versions published by the same agent as the assigned version, so an unrelated agent cannot advertise a version of someone else's preset here. Presets never auto-update -- adopting the newer version stays an explicit, admin-signed act. Columns match the IRI-keyed list-preset-assignments (preset, preset_label, deactivatePreset, added_by, date_added, update_noheader, update_label, updatePreset, np, np_label) so it drives the existing Preset assignments view unchanged. Ref-scoped variant: shows only that one ref's assignments rather than merging all refs claiming the IRI.";
     dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
     rdfs:label "List preset assignments (ref-scoped)";
     grlc:endpoint <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces>;
@@ -30,8 +31,12 @@ prefix npa: <http://purl.org/nanopub/admin/>
 prefix npx: <http://purl.org/nanopub/x/>
 prefix gen: <https://w3id.org/kpxl/gen/terms/>
 
-select ?preset (sample(?lbl) as ?preset_label) (str(?preset) as ?deactivatePreset)
-       (sample(?user) as ?added_by) (?date as ?date_added) ?np (\"^\" as ?np_label)
+select ?preset (sample(?lbl) as ?preset_label)
+       (sample(?detail) as ?version) (sample(?verdict) as ?version_label)
+       (str(?preset) as ?deactivatePreset)
+       (sample(?user) as ?added_by) (?date as ?date_added)
+       (sample(?updateTarget) as ?updatePreset)
+       ?np (\"^\" as ?np_label)
 where {
   values ?_root_np_multi_iri {}
   graph npa:spacesGraph { ?ref npa:rootNanopub ?_root_np_multi_iri . }
@@ -40,16 +45,69 @@ where {
     ?paRef a npa:PresetAssignment ; npa:forSpaceRef ?ref ; npa:ofPreset ?preset ; npa:forResource ?resource ;
            npa:isActivated ?activated ; npa:viaNanopub ?np ; dct:created ?date .
   }
+  # The assigned preset version: its label, its stable kind, its author and its date.
+  optional {
+    ?pnp npx:embeds ?preset ; np:hasAssertion ?pa .
+    optional { graph npa:graph { ?pnp npx:signedBy ?presetSigner } }
+    optional { graph npa:graph { ?pnp dct:created ?presetDate } }
+    graph ?pa {
+      optional { ?preset rdfs:label ?lbl }
+      optional { ?preset dct:isVersionOf ?presetKindOptional }
+    }
+  }
+  # Assignment identity is (preset KIND, resource) -- as for view displays, where the
+  # client dedups by view kind -- so assigning another version of the same preset
+  # replaces the earlier assignment instead of adding a second, competing one. A
+  # version that declares no kind keys on itself.
+  bind(coalesce(?presetKindOptional, ?preset) as ?presetKey)
   filter(?activated = true)
   filter not exists {
-    graph ?g { ?pa2 a npa:PresetAssignment ; npa:forSpaceRef ?ref ; npa:ofPreset ?preset ; npa:forResource ?resource ; dct:created ?date2 . }
-    filter(?date2 > ?date)
+    graph ?g { ?pa2 a npa:PresetAssignment ; npa:forSpaceRef ?ref ; npa:ofPreset ?preset2 ;
+                    npa:forResource ?resource ; npa:viaNanopub ?np2 ; dct:created ?date2 . }
+    optional {
+      ?pnp2 npx:embeds ?preset2 ; np:hasAssertion ?pa2Assertion .
+      graph ?pa2Assertion { ?preset2 dct:isVersionOf ?presetKind2 }
+    }
+    filter(coalesce(?presetKind2, ?preset2) = ?presetKey)
+    filter(?date2 > ?date || (?date2 = ?date && str(?np2) > str(?np)))
   }
+  # Newest version of the assigned preset's kind, restricted to versions published by
+  # the same agent as the assigned version, so an unrelated agent cannot advertise a
+  # version of someone else's preset here (issue #607). Presets never auto-update:
+  # this only surfaces the newer version and pre-fills the update action with it.
+  optional {
+    { select (?versionKind as ?presetKey) (?versionSigner as ?presetSigner)
+             (iri(strafter(max(concat(str(?vDate), \">\", str(?vPreset))), \">\")) as ?latestVersion)
+             (max(?vDate) as ?latestDate) where {
+        graph npa:graph {
+          ?vNp npx:hasNanopubType gen:Preset ;
+               npa:hasValidSignatureForPublicKeyHash ?vPubkey ;
+               dct:created ?vDate ;
+               npx:signedBy ?versionSigner ;
+               npx:embeds ?vPreset ;
+               np:hasAssertion ?vA .
+          filter not exists { ?vInv npx:invalidates ?vNp ; npa:hasValidSignatureForPublicKeyHash ?vPubkey . }
+        }
+        graph ?vA { ?vPreset a gen:Preset ; dct:isVersionOf ?versionKind . }
+      } group by ?versionKind ?versionSigner }
+  }
+  bind(bound(?latestVersion) && ?latestVersion != ?preset && ?latestDate > ?presetDate as ?hasUpdate)
+  # See the IRI-keyed twin: for a literal column with an \"x_label\" companion the LABEL
+  # is displayed and the principal value becomes the hover tooltip, so the short verdict
+  # is the label and the dates are the principal.
+  bind(if(?hasUpdate, \"⬆️ update available\", \"latest\") as ?rawVerdict)
+  bind(if(?hasUpdate,
+          concat(\"Assigned version of \", substr(str(?presetDate), 1, 10),
+                 \"; version of \", substr(str(?latestDate), 1, 10), \" is newer\"),
+          concat(\"Assigned version of \", substr(str(?presetDate), 1, 10))) as ?rawDetail)
+  bind(if(bound(?presetDate), ?rawVerdict, \"\") as ?verdict)
+  bind(if(bound(?presetDate), ?rawDetail, \"\") as ?detail)
+  bind(if(?hasUpdate, str(?latestVersion), \"\") as ?updateTarget)
   optional { graph npa:graph { ?np npx:signedBy ?user } }
-  optional { ?pnp npx:embeds ?preset ; np:hasAssertion ?pa . graph ?pa { ?preset rdfs:label ?lbl } }
 }
 group by ?preset ?date ?np
-order by desc(?date)""" .
+order by desc(?date)
+""" .
 }
 
 sub:provenance {
@@ -58,9 +116,14 @@ sub:provenance {
 
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-
-  this: dct:created "2026-06-19T08:01:45Z"^^xsd:dateTime;
+  
+  this: dct:created "2026-09-09T08:02:41Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    npx:embeds sub:list-preset-assignments .
+    npx:embeds sub:list-preset-assignments;
+    npx:supersedes <https://w3id.org/np/RArC6iR-Bwm8e1RP9PPClwJuzVEKJYX0agMZaQIc9Ln0s>;
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RAEFAt-QcFK0ZhqfvlsmS10BnzGJA0xwOICZXkO-ai87k> .
 }
+

--- a/docs/queries/list-preset-assignments.trig
+++ b/docs/queries/list-preset-assignments.trig
@@ -1,0 +1,173 @@
+@prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub:  <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+sub:assertion {
+  sub:list-preset-assignments a <https://w3id.org/kpxl/grlc/grlc-query>;
+    dct:description "Lists the currently active presets assigned to a resource, for the About page, filtered to assignments signed by an admin or maintainer of the owning space, or by the affected user themselves. An assignment is identified by the assigned preset's stable KIND (dct:isVersionOf) and the resource, mirroring view displays, which the client dedups by view kind (nanodash issue #607): among the assignments of one preset kind for one resource only the latest by dct:created counts, so assigning another version of the same preset replaces the earlier assignment instead of adding a second, competing row; a version declaring no kind keys on itself, and the preset listed is the version that assignment pinned. Deactivated assignments (and assignments with a newer one for the same pair) are excluded. Shows each assigned preset, who added it, the date, and the source nanopub. The deactivatePreset column feeds the per-row deactivate action. The version column reports whether the assigned version is still current: version_label is what the cell shows (latest, or an up-arrow plus update available) and version carries the dates behind it as the hover tooltip -- that way round because the renderer displays a literal column's _label companion and puts the principal value in the tooltip. updatePreset holds the version the update action pre-fills. All three are derived from the newest non-invalidated version of the same kind, restricted to versions published by the same agent as the assigned version, so an unrelated agent cannot advertise a version of someone else's preset here. Presets never auto-update -- adopting the newer version stays an explicit, admin-signed act.";
+    dct:license <http://www.apache.org/licenses/LICENSE-2.0>;
+    rdfs:label "List preset assignments";
+    <https://w3id.org/kpxl/grlc/endpoint> <https://w3id.org/np/l/nanopub-query-1.1/repo/full>;
+    <https://w3id.org/kpxl/grlc/sparql> """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix np: <http://www.nanopub.org/nschema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix npx: <http://purl.org/nanopub/x/>
+prefix gen: <https://w3id.org/kpxl/gen/terms/>
+
+select distinct ?preset ?preset_label ?version ?version_label
+       (str(?preset) as ?deactivatePreset)
+       (?user as ?added_by) (?date as ?date_added)
+       ?updatePreset
+       ?np (\"^\" as ?np_label) where {
+  values ?_resource_multi_iri {}
+  service <https://w3id.org/np/l/nanopub-query-1.1/repo/spaces> {
+    graph npa:graph { npa:thisRepo npa:hasCurrentSpaceState ?stateG . }
+    {
+      graph ?stateG {
+        ?_resource_multi_iri npa:isMaintainedBy? ?space .
+        ?ri a gen:RoleInstantiation ; npa:forSpace ?space ; npa:forAgent ?authAgent ;
+            (npa:inverseProperty|npa:regularProperty) ?roleProp .
+        ?authAcct a npa:AccountState ; npa:agent ?authAgent ; npa:pubkey ?pubkey .
+      }
+      optional {
+        graph npa:spacesGraph {
+          ?rd a npa:RoleDeclaration ; npa:forSpace ?space ;
+              npa:hasRoleType gen:MaintainerRole ;
+              (npa:inverseProperty|npa:regularProperty) ?roleProp .
+          bind(true as ?isMaintainer)
+        }
+      }
+      filter(?roleProp = gen:hasAdmin || bound(?isMaintainer))
+    } union {
+      graph ?stateG { ?selfAcct a npa:AccountState ; npa:agent ?_resource_multi_iri ; npa:pubkey ?pubkey . }
+    }
+  }
+  graph npa:graph {
+    ?np npx:hasNanopubType gen:PresetAssignment ;
+        npa:hasValidSignatureForPublicKeyHash ?pubkey ;
+        dct:created ?date ;
+        npx:embeds ?assignment ;
+        np:hasAssertion ?a .
+    filter not exists { ?npx npx:invalidates ?np ; npa:hasValidSignatureForPublicKeyHash ?pubkey . }
+    optional { ?np npx:signedBy ?user }
+  }
+  graph ?a {
+    ?assignment gen:isAssignmentFor ?_resource_multi_iri ;
+                gen:isAssignmentOfPreset ?preset .
+    optional {
+      values ?mode { gen:ActivatedPresetAssignment gen:DeactivatedPresetAssignment }
+      ?assignment a ?mode .
+    }
+  }
+  # The assigned preset version: its label, its stable kind, its author and its date.
+  optional {
+    graph npa:graph {
+      ?presetNp npx:embeds ?preset ; np:hasAssertion ?pa .
+      optional { ?presetNp npx:signedBy ?presetSigner }
+      optional { ?presetNp dct:created ?presetDate }
+    }
+    graph ?pa {
+      optional { ?preset rdfs:label ?preset_label . }
+      optional { ?preset dct:isVersionOf ?presetKindOptional . }
+    }
+  }
+  # Assignment identity is (preset KIND, resource) -- as for view displays, where the
+  # client dedups by view kind -- so assigning another version of the same preset
+  # replaces the earlier assignment instead of adding a second, competing one. A
+  # version that declares no kind keys on itself.
+  bind(coalesce(?presetKindOptional, ?preset) as ?presetKey)
+  filter(!bound(?mode) || !contains(str(?mode), \"Deactivated\"))
+  filter not exists {
+    graph npa:graph {
+      ?np2 npx:hasNanopubType gen:PresetAssignment ;
+          npa:hasValidSignatureForPublicKeyHash ?pubkey2 ;
+          dct:created ?date2 ;
+          npx:embeds ?assignment2 ;
+          np:hasAssertion ?a2 .
+      filter not exists { ?npx2 npx:invalidates ?np2 ; npa:hasValidSignatureForPublicKeyHash ?pubkey2 . }
+    }
+    graph ?a2 {
+      ?assignment2 gen:isAssignmentFor ?_resource_multi_iri ;
+                  gen:isAssignmentOfPreset ?preset2 .
+    }
+    optional {
+      graph npa:graph { ?presetNp2 npx:embeds ?preset2 ; np:hasAssertion ?pa2 . }
+      graph ?pa2 { ?preset2 dct:isVersionOf ?presetKind2 . }
+    }
+    filter(coalesce(?presetKind2, ?preset2) = ?presetKey)
+    filter(?date2 > ?date || (?date2 = ?date && str(?np2) > str(?np)))
+  }
+  # Newest version of the assigned preset's kind, restricted to versions published by
+  # the same agent as the assigned version, so an unrelated agent cannot advertise a
+  # version of someone else's preset here (issue #607). Presets never auto-update:
+  # this only surfaces the newer version and pre-fills the update action with it.
+  optional {
+    { select (?versionKind as ?presetKey) (?versionSigner as ?presetSigner)
+             (iri(strafter(max(concat(str(?vDate), \">\", str(?vPreset))), \">\")) as ?latestVersion)
+             (max(?vDate) as ?latestDate) where {
+        graph npa:graph {
+          ?vNp npx:hasNanopubType gen:Preset ;
+               npa:hasValidSignatureForPublicKeyHash ?vPubkey ;
+               dct:created ?vDate ;
+               npx:signedBy ?versionSigner ;
+               npx:embeds ?vPreset ;
+               np:hasAssertion ?vA .
+          filter not exists { ?vInv npx:invalidates ?vNp ; npa:hasValidSignatureForPublicKeyHash ?vPubkey . }
+        }
+        graph ?vA { ?vPreset a gen:Preset ; dct:isVersionOf ?versionKind . }
+      } group by ?versionKind ?versionSigner }
+  }
+  bind(bound(?latestVersion) && ?latestVersion != ?preset && ?latestDate > ?presetDate as ?hasUpdate)
+  # The version column. NOTE the renderer's convention for a literal column with an
+  # \"x_label\" companion: the LABEL is what the cell displays and the principal value
+  # becomes its hover tooltip -- so the short verdict goes in ?version_label and the
+  # dates behind it in ?version. Both are blank when the assigned version's own
+  # nanopub could not be read, rather than claiming \"latest\" without having checked.
+  bind(if(?hasUpdate, \"⬆️ update available\", \"latest\") as ?verdict)
+  bind(if(?hasUpdate,
+          concat(\"Assigned version of \", substr(str(?presetDate), 1, 10),
+                 \"; version of \", substr(str(?latestDate), 1, 10), \" is newer\"),
+          concat(\"Assigned version of \", substr(str(?presetDate), 1, 10))) as ?detail)
+  bind(if(bound(?presetDate), ?verdict, \"\") as ?version_label)
+  bind(if(bound(?presetDate), ?detail, \"\") as ?version)
+  bind(if(?hasUpdate, str(?latestVersion), \"\") as ?updatePreset)
+}
+order by desc(?date)
+""" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
+  
+  this: dct:created "2026-09-09T08:02:41Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    npx:embeds sub:list-preset-assignments;
+    npx:supersedes <https://w3id.org/np/RA6yOUA1c8dDWgBdI-Cl8wnXIiXjwpUnr_lbAUPXleixI>;
+    rdfs:label "List preset assignments";
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RA0J4vUn_dekg-U1kK3AOEt02p9mT2WO03uGxLDec1jLw>,
+      <https://w3id.org/np/RAoTD7udB2KtUuOuAe74tJi1t3VzK0DyWS7rYVAq1GRvw>, <https://w3id.org/np/RAukAcWHRDlkqxk7H2XNSegc1WnHI569INvNr-xdptDGI>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RAEFAt-QcFK0ZhqfvlsmS10BnzGJA0xwOICZXkO-ai87k> .
+}
+

--- a/docs/queries/maintained-resource-preset-assignments-view.trig
+++ b/docs/queries/maintained-resource-preset-assignments-view.trig
@@ -1,8 +1,9 @@
 @prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
-@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub:  <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix gen: <https://w3id.org/kpxl/gen/terms/> .
 @prefix np: <http://www.nanopub.org/nschema#> .
 @prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
 @prefix npx: <http://purl.org/nanopub/x/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -25,15 +26,15 @@ sub:assertion {
     gen:hasActionTemplateQueryMapping "void";
     gen:hasActionTemplateTargetField "resource";
     gen:isVisibleTo gen:MaintainerRole .
-
+  
   sub:deactivate-action a gen:ViewEntryAction;
-    rdfs:label "❌ deactivate";
+    rdfs:label "🚫 deactivate";
     gen:hasActionTemplate <https://w3id.org/np/RAFzdaAgvIUvpzMz98mlyO__xETbCxdMY_Dj4G9aZYO_Q>;
     gen:hasActionTemplatePartField "void";
     gen:hasActionTemplateQueryMapping "deactivatePreset:preset";
     gen:hasActionTemplateTargetField "resource";
     gen:isVisibleTo gen:MaintainerRole .
-
+  
   sub:preset-assignments-view a gen:ResourceView, gen:TabularView;
     dct:isVersionOf sub:maintained-resource-preset-assignments-view-kind;
     dct:title "🪟 Assigned presets";
@@ -41,9 +42,17 @@ sub:assertion {
     gen:appliesToInstancesOf gen:MaintainedResource;
     gen:hasDisplayWidth gen:ColumnWidth06of12;
     gen:hasStructuralPosition "5.4.presets";
-    gen:hasViewAction sub:add-preset-action, sub:deactivate-action;
-    gen:hasViewQuery <https://w3id.org/np/RAZYHKDeAsHTPN5IsXNKa0rZwmhiWklXcnxOU7IBS4vtk/list-preset-assignments>;
+    gen:hasViewAction sub:add-preset-action, sub:deactivate-action, sub:update-action;
+    gen:hasViewQuery <https://w3id.org/np/RAPiZTlc_E24Lx6lXYI6yZTNNvE34E83dyFO6Rqyxm82E/list-preset-assignments>;
     gen:hasViewQueryTargetField "resource" .
+  
+  sub:update-action a gen:ViewEntryAction;
+    rdfs:label "⬆️ update to latest version";
+    gen:hasActionTemplate <https://w3id.org/np/RAwpNZMM1Bgppqam84yXsIYvt8aLCPP2KNB8J8KSGU4Qo>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "updatePreset:preset";
+    gen:hasActionTemplateTargetField "resource";
+    gen:isVisibleTo gen:MaintainerRole .
 }
 
 sub:provenance {
@@ -52,11 +61,16 @@ sub:provenance {
 
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-
-  this: dct:created "2026-06-19T13:18:21Z"^^xsd:dateTime;
+  
+  this: dct:created "2026-09-09T08:03:32Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:preset-assignments-view;
     npx:introduces sub:maintained-resource-preset-assignments-view-kind;
-    rdfs:label "Assigned presets view (maintained resource)" .
+    npx:supersedes <https://w3id.org/np/RAHdIUwDZeX0PsNKVtP_MaZv5HyJNqKr74PIvgTKeZOrs>;
+    rdfs:label "Assigned presets view (maintained resource)";
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RACJ58Gvyn91LqCKIO9zu1eijDQIeEff28iyDrJgjSJF8>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RA8_hijwsfGCryMYtjtEpec21ZSNY68-qmL0bHRWR0sWM> .
 }
+

--- a/docs/queries/space-preset-assignments-view.trig
+++ b/docs/queries/space-preset-assignments-view.trig
@@ -1,8 +1,9 @@
 @prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
-@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub:  <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix gen: <https://w3id.org/kpxl/gen/terms/> .
 @prefix np: <http://www.nanopub.org/nschema#> .
 @prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
 @prefix npx: <http://purl.org/nanopub/x/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -24,16 +25,16 @@ sub:assertion {
     gen:hasActionTemplatePartField "void";
     gen:hasActionTemplateQueryMapping "void";
     gen:hasActionTemplateTargetField "resource";
-    gen:isVisibleTo gen:MaintainerRole .
-
+    gen:isVisibleTo gen:AdminRole .
+  
   sub:deactivate-action a gen:ViewEntryAction;
-    rdfs:label "❌ deactivate";
+    rdfs:label "🚫 deactivate";
     gen:hasActionTemplate <https://w3id.org/np/RAFzdaAgvIUvpzMz98mlyO__xETbCxdMY_Dj4G9aZYO_Q>;
     gen:hasActionTemplatePartField "void";
     gen:hasActionTemplateQueryMapping "deactivatePreset:preset";
     gen:hasActionTemplateTargetField "resource";
-    gen:isVisibleTo gen:MaintainerRole .
-
+    gen:isVisibleTo gen:AdminRole .
+  
   sub:preset-assignments-view a gen:ResourceView, gen:TabularView;
     dct:isVersionOf sub:space-preset-assignments-view-kind;
     dct:title "🪟 Assigned presets";
@@ -41,9 +42,17 @@ sub:assertion {
     gen:appliesToInstancesOf gen:Space;
     gen:hasDisplayWidth gen:ColumnWidth06of12;
     gen:hasStructuralPosition "5.4.presets";
-    gen:hasViewAction sub:add-preset-action, sub:deactivate-action;
-    gen:hasViewQuery <https://w3id.org/np/RAZYHKDeAsHTPN5IsXNKa0rZwmhiWklXcnxOU7IBS4vtk/list-preset-assignments>;
+    gen:hasViewAction sub:add-preset-action, sub:deactivate-action, sub:update-action;
+    gen:hasViewQuery <https://w3id.org/np/RAPiZTlc_E24Lx6lXYI6yZTNNvE34E83dyFO6Rqyxm82E/list-preset-assignments>;
     gen:hasViewQueryTargetField "resource" .
+  
+  sub:update-action a gen:ViewEntryAction;
+    rdfs:label "⬆️ update to latest version";
+    gen:hasActionTemplate <https://w3id.org/np/RAI5NAXRmn5qdjgNnwVO_iLn4Um2mOGluILtRfRPz-rAM>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "updatePreset:preset";
+    gen:hasActionTemplateTargetField "resource";
+    gen:isVisibleTo gen:AdminRole .
 }
 
 sub:provenance {
@@ -52,11 +61,16 @@ sub:provenance {
 
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-
-  this: dct:created "2026-06-19T13:18:21Z"^^xsd:dateTime;
+  
+  this: dct:created "2026-09-09T08:03:32Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:preset-assignments-view;
     npx:introduces sub:space-preset-assignments-view-kind;
-    rdfs:label "Assigned presets view (space)" .
+    npx:supersedes <https://w3id.org/np/RAd9qQWORQ8lZgMCru0DpCv85BYP1RgG0IXzV9zd8dyh8>;
+    rdfs:label "Assigned presets view (space)";
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RACJ58Gvyn91LqCKIO9zu1eijDQIeEff28iyDrJgjSJF8>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RA8_hijwsfGCryMYtjtEpec21ZSNY68-qmL0bHRWR0sWM> .
 }
+

--- a/docs/queries/user-preset-assignments-view.trig
+++ b/docs/queries/user-preset-assignments-view.trig
@@ -1,8 +1,9 @@
 @prefix this: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
-@prefix sub: <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
+@prefix sub:  <https://w3id.org/np/ARTIFACTCODE-PLACEHOLDER> .
 @prefix gen: <https://w3id.org/kpxl/gen/terms/> .
 @prefix np: <http://www.nanopub.org/nschema#> .
 @prefix dct: <http://purl.org/dc/terms/> .
+@prefix nt: <https://w3id.org/np/o/ntemplate/> .
 @prefix npx: <http://purl.org/nanopub/x/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -25,15 +26,15 @@ sub:assertion {
     gen:hasActionTemplateQueryMapping "void";
     gen:hasActionTemplateTargetField "resource";
     gen:isVisibleTo gen:MaintainerRole .
-
+  
   sub:deactivate-action a gen:ViewEntryAction;
-    rdfs:label "❌ deactivate";
+    rdfs:label "🚫 deactivate";
     gen:hasActionTemplate <https://w3id.org/np/RAFzdaAgvIUvpzMz98mlyO__xETbCxdMY_Dj4G9aZYO_Q>;
     gen:hasActionTemplatePartField "void";
     gen:hasActionTemplateQueryMapping "deactivatePreset:preset";
     gen:hasActionTemplateTargetField "resource";
     gen:isVisibleTo gen:MaintainerRole .
-
+  
   sub:preset-assignments-view a gen:ResourceView, gen:TabularView;
     dct:isVersionOf sub:user-preset-assignments-view-kind;
     dct:title "🪟 Assigned presets";
@@ -41,9 +42,17 @@ sub:assertion {
     gen:appliesToInstancesOf gen:IndividualAgent;
     gen:hasDisplayWidth gen:ColumnWidth06of12;
     gen:hasStructuralPosition "5.4.presets";
-    gen:hasViewAction sub:add-preset-action, sub:deactivate-action;
-    gen:hasViewQuery <https://w3id.org/np/RAZYHKDeAsHTPN5IsXNKa0rZwmhiWklXcnxOU7IBS4vtk/list-preset-assignments>;
+    gen:hasViewAction sub:add-preset-action, sub:deactivate-action, sub:update-action;
+    gen:hasViewQuery <https://w3id.org/np/RAPiZTlc_E24Lx6lXYI6yZTNNvE34E83dyFO6Rqyxm82E/list-preset-assignments>;
     gen:hasViewQueryTargetField "resource" .
+  
+  sub:update-action a gen:ViewEntryAction;
+    rdfs:label "⬆️ update to latest version";
+    gen:hasActionTemplate <https://w3id.org/np/RAEKxVpk1FHItIKnTCAwfAqwmuM9FUCw7HKlIyzUB2oSc>;
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "updatePreset:preset";
+    gen:hasActionTemplateTargetField "resource";
+    gen:isVisibleTo gen:MaintainerRole .
 }
 
 sub:provenance {
@@ -52,11 +61,16 @@ sub:provenance {
 
 sub:pubinfo {
   orcid:0000-0002-1267-0234 foaf:name "Tobias Kuhn" .
-
-  this: dct:created "2026-06-19T13:18:21Z"^^xsd:dateTime;
+  
+  this: dct:created "2026-09-09T08:03:32Z"^^xsd:dateTime;
     dct:creator orcid:0000-0002-1267-0234;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     npx:embeds sub:preset-assignments-view;
     npx:introduces sub:user-preset-assignments-view-kind;
-    rdfs:label "Assigned presets view (user)" .
+    npx:supersedes <https://w3id.org/np/RAICFnc_r3qYAcsqGJdVuqtblEHcVeRoIhycuyXR-_qAQ>;
+    rdfs:label "Assigned presets view (user)";
+    nt:wasCreatedFromProvenanceTemplate <https://w3id.org/np/RA7lSq6MuK_TIC6JMSHvLtee3lpLoZDOqLJCLXevnrPoU>;
+    nt:wasCreatedFromPubinfoTemplate <https://w3id.org/np/RACJ58Gvyn91LqCKIO9zu1eijDQIeEff28iyDrJgjSJF8>;
+    nt:wasCreatedFromTemplate <https://w3id.org/np/RA8_hijwsfGCryMYtjtEpec21ZSNY68-qmL0bHRWR0sWM> .
 }
+

--- a/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryApiAccess.java
@@ -119,7 +119,13 @@ public class QueryApiAccess {
     // themselves. Display-only: the pending class is distinct from npa:AccountState, so the
     // admin/maintainer arm and the governed-version resolution keep requiring approved
     // accounts. Validated byte-identical to RAWlJqJ5 across approved resources.
-    public static final String GET_VIEW_DISPLAYS = "RA3ekD-2utY7P0ZgAHSr4HRwugzNnYhxJbkeI-3EfYfww/get-view-displays";
+    // RAwkiytr (supersedes RA3ekD-2) adds ?presetKind to the preset branch (issue #607): the
+    // assigned preset's stable kind (dct:isVersionOf, falling back to the version IRI), so the
+    // client keeps only the newest assignment per (preset kind, resource) -- the identity view
+    // displays already have via view kind. Purely additive; every other column is unchanged
+    // (validated identical across standalone, preset, governed, self-page and maintained-resource
+    // cases).
+    public static final String GET_VIEW_DISPLAYS = "RAwkiytrR_PaBVqUjfUtoTEBAVwNWq7QxHJbAshQ1dD9g/get-view-displays";
     // Ref-scoped get-view-displays (the Content-tab renderer query): takes the space IRI (resource)
     // AND the ref's root nanopub (root_np) as two concrete params, gating the authorised signers on
     // that ref's admins/maintainers (npa:forSpaceRef) instead of the IRI merged across refs, so the
@@ -147,7 +153,9 @@ public class QueryApiAccess {
     // RAkIkmSi (supersedes RAXdRFNL): endpoint rebased onto repo/full (5 SERVICE -> 2, see
     // GET_VIEW_DISPLAYS above); in particular the per-referenced-view pin lookups are now
     // local joins instead of one federated round-trip per view under a nested-loop join.
-    public static final String GET_VIEW_DISPLAYS_UNRESOLVED = "RAkIkmSiwDT-bgYZhGtknPhpkHsJcx0Q3nP0u8OyO_fZ4/get-view-displays-unresolved";
+    // RAt7dfZO (supersedes RAkIkmSi) adds the same ?presetKind column as GET_VIEW_DISPLAYS
+    // (issue #607); no other change.
+    public static final String GET_VIEW_DISPLAYS_UNRESOLVED = "RAt7dfZOYAqtuR_7o0Q1ogzLtnvuvmzMRfnzOT_nq8r6I/get-view-displays-unresolved";
 
     // Spaces-repo queries (endpoint: nanopub-query .../repo/spaces)
     // v2: IRI-keyed get-spaces. Prior client head, retained for reference; deployments up
@@ -323,7 +331,15 @@ public class QueryApiAccess {
     // admin-authored row). Column-identical to the IRI-keyed list-preset-assignments, so it drives
     // the existing Preset assignments view unchanged. Used by AboutSpacePanel with an IRI-keyed
     // fallback when the ref root is unknown. Source at docs/queries/list-preset-assignments-ref.trig.
-    public static final String LIST_PRESET_ASSIGNMENTS_REF = "RAeLNbudAq68NdqfIL3mtT2YeLnIHZ5T52Qwl_rJzMJJk/list-preset-assignments";
+    // RArC6iR- (supersedes RA3zdn0g, itself the head this constant had been left behind by)
+    // keys an assignment on the preset's stable kind rather than the pinned version, and adds the
+    // version columns behind the view's "update to latest version" action (issue #607).
+    // RArXnUQf (supersedes RArC6iR-) replaces the earlier blank-header notice with a proper
+    // "version" column: version_label is the displayed verdict ("latest" / "⬆️ update available")
+    // and version the dates behind it, since the renderer shows a literal column's _label
+    // companion and puts the principal value in the tooltip. Column-compatible with the IRI-keyed
+    // variant, which the view supplies for non-space pages.
+    public static final String LIST_PRESET_ASSIGNMENTS_REF = "RArXnUQf2dQguqlteWMwKVWxIpnk5xzF4ppAokGkpuOn8/list-preset-assignments";
 
     private static final Logger logger = LoggerFactory.getLogger(QueryApiAccess.class);
 

--- a/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/AbstractResourceWithProfile.java
@@ -567,6 +567,13 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
         // it also covers space-governed pins); the older resolved heads return ?view
         // already latest-resolved server-side, so it is passed through as-is.
         boolean viewsPreResolved = !QueryApiAccess.GET_VIEW_DISPLAYS_UNRESOLVED.equals(ref.getQueryId());
+        // A preset assignment is identified by the preset's stable kind and the resource
+        // (issue #607), just as a view display is by view kind and resource. The rows come
+        // newest first, so the first assignment nanopub seen for a preset kind is the one
+        // that counts; rows from any older assignment of the same kind are dropped, and a
+        // view that a newer preset version no longer carries goes away with them. Queries
+        // that don't return the column (an older head) leave every row in place.
+        Map<String, String> winningPresetNp = new HashMap<>();
         for (ApiResponseEntry r : response.getData()) {
             try {
                 String view = r.get("view");
@@ -575,6 +582,12 @@ public abstract class AbstractResourceWithProfile implements Serializable, Resou
                     list.add(ViewDisplay.get(display, viewsPreResolved ? view : null));
                 } else {
                     if (view == null || view.isEmpty()) continue;
+                    String presetKind = r.get("presetKind");
+                    if (presetKind != null && !presetKind.isEmpty()) {
+                        String np = r.get("np");
+                        String winner = winningPresetNp.computeIfAbsent(presetKind, k -> np);
+                        if (winner != null && !winner.equals(np)) continue;
+                    }
                     boolean topLevel = KPXL_TERMS.TOP_LEVEL_VIEW_DISPLAY.stringValue().equals(r.get("displayType"));
                     boolean deactivated = KPXL_TERMS.DEACTIVATED_PRESET_ASSIGNMENT.stringValue().equals(r.get("displayMode"));
                     ViewDisplay vd = ViewDisplay.forPresetView(id, view, topLevel, deactivated, !viewsPreResolved);


### PR DESCRIPTION
Closes #607.

## What

A preset assignment is now identified by the assigned preset's stable **kind** (`dct:isVersionOf`) and the resource, mirroring view displays — whose identity `filterViewDisplays` already resolves by *view kind*, not by the pinned view version. Assigning another version of the same preset therefore replaces the earlier assignment instead of adding a second, competing one.

That was the missing piece for #607: without it, "update to a newer version" would leave the old assignment active. Four spaces (`example/foo`, `example/bar`, `GRADE-Edit-a-thon-2026`, `semantics/2026-eu/nanopub-tutorial`) carried two versions of the same preset at once, showing two identically-labelled rows, and `semantics/2026-eu` carried three corrective nanopubs from 2026-08-25 undoing exactly that by hand.

Presets still **never auto-update**: the assignment pins a version, and adopting a newer one stays an explicit, admin-signed act — which matters because presets carry roles. The listing queries surface *that* a newer version exists, and the views offer a one-click way to take it.

## How it renders

| preset | version | added by | date added |
|---|---|---|---|
| Scientific conference preset | ⬆️ update available | Tobias Kuhn | Aug 31, 2026 |
| Scientific conference preset | latest | Tobias Kuhn | Aug 19, 2026 |

Hovering the version cell gives the dates behind the verdict. The row menu offers "⬆️ update to latest version…", which opens that page's own assignment template pre-filled with the newer version; rows with nothing to update carry an empty `updatePreset` and get no button.

Candidate versions are restricted to those published by the **same agent** as the assigned version, so an unrelated agent cannot advertise a version of someone else's preset on a space's About page.

## Published nanopubs

| | new head |
|---|---|
| list-preset-assignments | `RAPiZTlc_E24Lx6lXYI6yZTNNvE34E83dyFO6Rqyxm82E/list-preset-assignments` |
| list-preset-assignments (ref-scoped) | `RArXnUQf2dQguqlteWMwKVWxIpnk5xzF4ppAokGkpuOn8/list-preset-assignments` |
| get-view-displays | `RAwkiytrR_PaBVqUjfUtoTEBAVwNWq7QxHJbAshQ1dD9g/get-view-displays` |
| get-view-displays-unresolved | `RAt7dfZOYAqtuR_7o0Q1ogzLtnvuvmzMRfnzOT_nq8r6I/get-view-displays-unresolved` |
| 🪟 Assigned presets (maintained resource) | `RARFwPBDeODmWkgkdK_OmCgEO67Rru8VzZWLblXRpVzy4` |
| 🪟 Assigned presets (space) | `RALeYg8FepF17V6jWDf-_M6uaP2kJtGPCscqJWuCKzBmo` |
| 🪟 Assigned presets (user) | `RAjMK5Z_eILwQ1HQWueT2BYRlaacmGn2_v1lf0mY4QV-4` |

All are live and their chains resolve from the anchors the code holds.

## Code

- **`QueryApiAccess`** — three constants bumped. `LIST_PRESET_ASSIGNMENTS_REF` had also drifted a version behind its chain head, so the space About page was running an older query than its view declared (the same class of drift as #667).
- **`AbstractResourceWithProfile`** — preset-contributed rows now carry `?presetKind`, so only the newest assignment per `(preset kind, resource)` contributes views, and a view a newer preset version no longer carries goes away with the older assignment. Queries that don't return the column leave every row in place, so this is safe against an older query head.
- **`docs/presets.md`** — kind-based identity, the update flow, which tiers may assign on which resource type, and the renderer's label/tooltip convention for literal columns.

## Tier gating

The space view's actions are gated to `gen:AdminRole`, the others stay at maintainer-and-above. That is not cosmetic: `AuthorityResolver`'s ref-scoped assignment mirror and its preset-role attachment both require `gen:hasAdmin`, so a maintainer's assignment on a *space* is never stamped into the space state — the buttons now match what the server honours. Maintained resources have no such gate (no preset roles are materialized for non-space targets), so maintainers keep the actions there.

## Verification

- Old-vs-new listing output compared across every resource with a preset assignment: the only changes are the five intended collapses.
- `get-view-displays` output byte-identical on every pre-existing column across standalone displays, preset rows, governed views, a user page and a maintained resource.
- Rendered end-to-end against a local instance with a clean cache: `example/bar` shows "⬆️ update available", `example/foo` and `test-ontology` show "latest", `updatePreset` is hidden, and the update action appears in the row menu.
- Full test suite passes (1367 tests).

## Deployment note

The nanopubs are already live, so user, maintained-resource and part pages — which take the listing query from the view — already use the new query. **Space** pages take it from the constant in this PR, so they keep showing both preset versions until this is deployed. A long-running instance may briefly show an unhidden `updatePreset` column, which is a stale memoized view paired with the new query; a restart or the page's "refresh now" clears it.

## Follow-up

`AuthorityResolver` still keys *which assignment counts* on `(preset version, resource)` — filed as a nanopub-query issue. Roles themselves already resolve by kind, so the update action is consistent today; the divergence appears only when deactivating while two versions of one kind are assigned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpQe4aJzdBr1epP8XSGYiY