### PR TITLE
fix(navigation): carry the resource part across links out of a part page

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/NavigationContext.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NavigationContext.java
@@ -32,6 +32,10 @@ import java.util.Set;
  * under, carried across pages as the {@code context} URL parameter. It determines where
  * the user is forwarded to after publishing a nanopub and where the title bar's
  * back-link points on pages that are not themselves a context resource's page.
+ * <p>
+ * A resource part is not a context resource of its own but can still be where the user
+ * came from, so it travels next to the context as the {@code part} parameter, and the
+ * back-link prefers it over the maintaining resource the context names (issue #697).
  */
 public class NavigationContext {
 
@@ -44,6 +48,20 @@ public class NavigationContext {
     public static final String CONTEXT_PARAM = "context";
 
     /**
+     * Name of the page parameter holding the resource part a page was reached under
+     * (issue #697). A part is not a context resource of its own — the {@code context}
+     * parameter next to it names the maintaining resource the part belongs to — so it
+     * travels as a second parameter, and only ever together with that context.
+     */
+    public static final String PART_PARAM = "part";
+
+    /**
+     * Name of the page parameter holding the label of {@link #PART_PARAM}, so the
+     * back-link can name the part without resolving it over the network.
+     */
+    public static final String PART_LABEL_PARAM = "part-label";
+
+    /**
      * Reads the navigation context id from the given page parameters.
      *
      * @param params the page parameters
@@ -53,6 +71,30 @@ public class NavigationContext {
         if (params == null) return null;
         String contextId = params.get(CONTEXT_PARAM).toString("");
         return contextId.isEmpty() ? null : contextId;
+    }
+
+    /**
+     * Reads the resource part id from the given page parameters.
+     *
+     * @param params the page parameters
+     * @return the part resource id, or null if not set
+     */
+    public static String getPartId(PageParameters params) {
+        if (params == null) return null;
+        String partId = params.get(PART_PARAM).toString("");
+        return partId.isEmpty() ? null : partId;
+    }
+
+    /**
+     * Reads the label of the resource part from the given page parameters.
+     *
+     * @param params the page parameters
+     * @return the part label, or null if not set
+     */
+    public static String getPartLabel(PageParameters params) {
+        if (params == null) return null;
+        String label = params.get(PART_LABEL_PARAM).toString("");
+        return label.isEmpty() ? null : label;
     }
 
     /**
@@ -113,6 +155,25 @@ public class NavigationContext {
     }
 
     /**
+     * A page reference (link target + label) for a resource part reached under the
+     * given context. A part page cannot resolve itself without its maintaining
+     * resource, so the ref carries the context along (issue #697).
+     *
+     * @param partId    the part resource id
+     * @param partLabel the part's label, or null to fall back to its short name
+     * @param contextId the context resource id the part belongs to
+     * @return the page reference, or null if part or context is missing
+     */
+    public static NanodashPageRef getPartPageRef(String partId, String partLabel, String contextId) {
+        if (partId == null || partId.isEmpty() || contextId == null || contextId.isEmpty()) return null;
+        PageParameters params = new PageParameters().set("id", partId).set(CONTEXT_PARAM, contextId);
+        boolean hasLabel = partLabel != null && !partLabel.isBlank();
+        if (hasLabel) params.set("label", partLabel);
+        return new NanodashPageRef(ResourcePartPage.class, params,
+                hasLabel ? partLabel : Utils.getShortNameFromURI(partId));
+    }
+
+    /**
      * Sets the given context id on the parameters, unless it is null or a context is
      * already set (call sites that know the context resource remain authoritative).
      *
@@ -128,10 +189,36 @@ public class NavigationContext {
     }
 
     /**
-     * A behavior that fills in the page's navigation context on a
-     * {@link BookmarkablePageLink} that doesn't carry one yet. Useful where the context
-     * id isn't at hand when the link is built (e.g. nanopub cards); runs at configure
-     * time, when the component is attached to its page.
+     * Sets the given part on the parameters, so the target page's back-link points at
+     * the part the user came from rather than at the maintaining resource (issue #697).
+     * A part is only meaningful under its own context, so nothing is set unless the
+     * parameters carry exactly that context; links to the part itself, and parameters
+     * that already name a part, are left alone.
+     *
+     * @param params        the page parameters to extend
+     * @param partId        the part resource id, or null for a no-op
+     * @param partLabel     the part's label, or null to carry none
+     * @param partContextId the context the part belongs to
+     * @return the same page parameters, for chaining
+     */
+    public static PageParameters withPart(PageParameters params, String partId, String partLabel, String partContextId) {
+        if (partId == null || partId.isEmpty() || partContextId == null || partContextId.isEmpty()) return params;
+        if (!partContextId.equals(params.get(CONTEXT_PARAM).toString(""))) return params;
+        String targetId = params.get("id").toString("");
+        // Nothing to point back to on a link to the part itself, and a link up to the
+        // maintaining resource leaves the part behind rather than carrying it along.
+        if (partId.equals(targetId) || partContextId.equals(targetId)) return params;
+        if (!params.get(PART_PARAM).isEmpty()) return params;
+        params.set(PART_PARAM, partId);
+        if (partLabel != null && !partLabel.isBlank()) params.set(PART_LABEL_PARAM, partLabel);
+        return params;
+    }
+
+    /**
+     * A behavior that fills in the page's navigation context, and the resource part it
+     * was reached under, on a {@link BookmarkablePageLink} that doesn't carry them yet.
+     * Useful where the context id isn't at hand when the link is built (e.g. nanopub
+     * cards); runs at configure time, when the component is attached to its page.
      *
      * @return the context-fallback behavior
      */
@@ -142,6 +229,7 @@ public class NavigationContext {
                 if (component instanceof BookmarkablePageLink<?> link && component.getPage() instanceof NanodashPage page
                         && link.getPageParameters() != null) {
                     withContext(link.getPageParameters(), page.getContextId());
+                    withPart(link.getPageParameters(), page.getPartId(), page.getPartLabel(), page.getIncomingContextId());
                 }
             }
         };
@@ -152,6 +240,9 @@ public class NavigationContext {
      * URL string (e.g. from {@link com.knowledgepixels.nanodash.component.NanodashLink#getPageUrl(String)})
      * rather than page parameters, where {@link #pageContextFallback()} cannot apply.
      * Only internal page URLs (starting with "/") that don't carry a context yet are touched.
+     * The resource part the page was reached under is appended along with it, under the
+     * same rule as {@link #withPart(PageParameters, String, String, String)}: only where
+     * the context we just appended is the part's own (issue #697).
      *
      * @return the context-fallback behavior
      */
@@ -164,7 +255,17 @@ public class NavigationContext {
                 if (contextId == null) return;
                 String href = tag.getAttribute("href");
                 if (href == null || !href.startsWith("/") || href.contains(CONTEXT_PARAM + "=")) return;
-                tag.put("href", href + (href.contains("?") ? "&" : "?") + CONTEXT_PARAM + "=" + Utils.urlEncode(contextId));
+                href += (href.contains("?") ? "&" : "?") + CONTEXT_PARAM + "=" + Utils.urlEncode(contextId);
+                String partId = page.getPartId();
+                if (partId != null && contextId.equals(page.getIncomingContextId())
+                        && !href.contains(PART_PARAM + "=") && !href.contains(Utils.urlEncode(partId))) {
+                    href += "&" + PART_PARAM + "=" + Utils.urlEncode(partId);
+                    String partLabel = page.getPartLabel();
+                    if (partLabel != null && !partLabel.isBlank()) {
+                        href += "&" + PART_LABEL_PARAM + "=" + Utils.urlEncode(partLabel);
+                    }
+                }
+                tag.put("href", href);
             }
         };
     }

--- a/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
@@ -17,6 +17,7 @@ import org.nanopub.extra.services.QueryRef;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -257,31 +258,90 @@ public abstract class QueryResult extends Panel {
     }
 
     /**
-     * The {@code &context=...} URL suffix for template/query links in result cells.
-     * Empty string when no context is set. Only usable at render time (needs the page).
+     * The resource part to stamp on links in result cells, next to
+     * {@link #renderContextId()}: the part this view is bound to, else the part the page
+     * was reached under. A part only travels together with its own context (issue #697),
+     * so it is dropped when the links carry a different one. Only usable at render time.
      *
-     * @return the context URL parameter suffix, possibly empty
+     * @return the part id, or null if none applies
      */
-    protected String templateLinkContextParam() {
+    private String renderPartId() {
+        if (partId != null) return partId;
+        if (getPage() instanceof NanodashPage nanodashPage
+                && Objects.equals(renderContextId(), nanodashPage.getIncomingContextId())) {
+            return nanodashPage.getPartId();
+        }
+        return null;
+    }
+
+    /**
+     * The label to carry along with {@link #renderPartId()}, so the target page's
+     * back-link can name the part. Only known where the page is the part's own.
+     *
+     * @return the part label, or null if none is known
+     */
+    private String renderPartLabel() {
+        if (getPage() instanceof NanodashPage nanodashPage
+                && Objects.equals(renderPartId(), nanodashPage.getPartId())) {
+            return nanodashPage.getPartLabel();
+        }
+        return null;
+    }
+
+    /**
+     * The navigation parameters to append to a hand-built app-internal link in a result
+     * cell: the {@code &context=...} suffix, plus the resource part the page was reached
+     * under where that applies (issue #697). Empty string when no context is set. Only
+     * usable at render time (needs the page).
+     *
+     * @param url the link the parameters are appended to, or null if not known yet
+     * @return the URL parameter suffix, possibly empty
+     */
+    protected String linkNavParams(String url) {
         String ctx = renderContextId();
-        return ctx == null ? "" : "&context=" + Utils.urlEncode(ctx);
+        if (ctx == null) return "";
+        StringBuilder params = new StringBuilder("&context=").append(Utils.urlEncode(ctx));
+        String part = renderPartId();
+        // Not on a link to the part itself, nor on one up to the resource maintaining
+        // it: the part is then either the destination or behind the user.
+        if (part != null && !namesResource(url, part) && !namesResource(url, ctx)) {
+            params.append("&part=").append(Utils.urlEncode(part));
+            String partLabel = renderPartLabel();
+            if (partLabel != null && !partLabel.isBlank()) {
+                params.append("&part-label=").append(Utils.urlEncode(partLabel));
+            }
+        }
+        return params.toString();
+    }
+
+    /**
+     * Whether the given app-internal link points at the given resource, i.e. carries it
+     * as its {@code id}. The sanitizer writes "=" as "&#61;", so both spellings count.
+     *
+     * @param url        the link to check, or null
+     * @param resourceId the resource id to look for
+     * @return true if the link's id is that resource
+     */
+    static boolean namesResource(String url, String resourceId) {
+        if (url == null) return false;
+        String encoded = Utils.urlEncode(resourceId);
+        return url.contains("id=" + encoded) || url.contains("id&#61;" + encoded);
     }
 
     private static final Pattern INTERNAL_HREF_PATTERN = Pattern.compile("href=\"(/[^\"]*)\"");
 
     /**
-     * Appends the navigation context to app-internal links ({@code href="/..."}) inside
-     * sanitized result-cell HTML, so ready-made links coming from the query data itself
-     * (e.g. template or query links emitted by the SPARQL) also lead back to the
-     * current context. Links already carrying a context are left alone.
+     * Appends the navigation context, and the resource part where one applies, to
+     * app-internal links ({@code href="/..."}) inside sanitized result-cell HTML, so
+     * ready-made links coming from the query data itself (e.g. template or query links
+     * emitted by the SPARQL) also lead back to where the user came from. Links already
+     * carrying a context are left alone.
      *
      * @param sanitizedHtml the sanitized cell HTML, or null
      * @return the HTML with context-enriched internal links
      */
-    protected String withContextInHtmlLinks(String sanitizedHtml) {
-        String ctx = renderContextId();
-        if (ctx == null || sanitizedHtml == null) return sanitizedHtml;
-        String encodedCtx = Utils.urlEncode(ctx);
+    protected String withNavParamsInHtmlLinks(String sanitizedHtml) {
+        if (renderContextId() == null || sanitizedHtml == null) return sanitizedHtml;
         Matcher m = INTERNAL_HREF_PATTERN.matcher(sanitizedHtml);
         StringBuilder sb = new StringBuilder();
         while (m.find()) {
@@ -290,7 +350,8 @@ public abstract class QueryResult extends Panel {
             // The sanitizer escapes "=" as "&#61;", so check both spellings.
             if (!url.contains("context=") && !url.contains("context&#61;")) {
                 String separator = url.contains("?") ? "&amp;" : "?";
-                replacement = "href=\"" + url + separator + "context=" + encodedCtx + "\"";
+                // The suffix starts with "&", which the separator replaces.
+                replacement = "href=\"" + url + separator + linkNavParams(url).substring(1).replace("&", "&amp;") + "\"";
             }
             m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
         }
@@ -315,7 +376,7 @@ public abstract class QueryResult extends Panel {
      * @return the sanitized and enriched HTML
      */
     protected String cellHtml(String rawHtml) {
-        return withPublishLinksAsButtons(withContextInHtmlLinks(Utils.sanitizeHtml(rawHtml)));
+        return withPublishLinksAsButtons(withNavParamsInHtmlLinks(Utils.sanitizeHtml(rawHtml)));
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultItemList.java
@@ -142,11 +142,13 @@ public class QueryResultItemList extends QueryResult {
                 }
                 String displayLabel = (entryLabel != null && !entryLabel.isBlank()) ? entryLabel : User.getShortDisplayName(userIri);
                 String userUrl = UserPage.MOUNT_PATH + "?id=" + Utils.urlEncode(value);
+                userUrl += linkNavParams(userUrl);
                 String html = "<img class=\"" + iconClass + "\" src=\"" + imgSrc + "\" /> <a href=\"" + Strings.escapeMarkup(userUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
                 return new Label("listItem", html).setEscapeModelStrings(false);
             } else if (key.endsWith("template_iri")) {
                 String displayLabel = (entryLabel != null && !entryLabel.isBlank()) ? entryLabel : value;
-                String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest" + templateLinkContextParam();
+                String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest";
+                templateUrl += linkNavParams(templateUrl);
                 String html = "<span class=\"form-icon\"></span> <a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
                 return new Label("listItem", html).setEscapeModelStrings(false);
             } else if (Utils.isUriValue(value)) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultList.java
@@ -119,6 +119,7 @@ public class QueryResultList extends QueryResult {
                             String userLabel = entry.get(key + "_label");
                             String displayLabel = userLabel != null && !userLabel.isBlank() ? userLabel : User.getShortDisplayName(userIri);
                             String userUrl = UserPage.MOUNT_PATH + "?id=" + Utils.urlEncode(entryValue);
+                            userUrl += linkNavParams(userUrl);
                             String linkHtml = "<a href=\"" + Strings.escapeMarkup(userUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
                             components.add(new ComponentSequence("component", " ", List.of(
                                     new Label("component", "<img class=\"user-icon\" src=\"" + imgSrc + "\" />").setEscapeModelStrings(false),
@@ -126,7 +127,8 @@ public class QueryResultList extends QueryResult {
                         } else if (key.endsWith("template_iri")) {
                             String templateLabel = entry.get(key + "_label");
                             String displayLabel = templateLabel != null && !templateLabel.isBlank() ? templateLabel : entryValue;
-                            String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(entryValue) + "&template-version=latest" + templateLinkContextParam();
+                            String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(entryValue) + "&template-version=latest";
+                            templateUrl += linkNavParams(templateUrl);
                             String linkHtml = "<a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
                             components.add(new ComponentSequence("component", " ", List.of(
                                     new Label("component", "<span class=\"form-icon\"></span>").setEscapeModelStrings(false),
@@ -134,7 +136,8 @@ public class QueryResultList extends QueryResult {
                         } else if (key.endsWith("query_iri")) {
                             String queryLabel = entry.get(key + "_label");
                             String displayLabel = queryLabel != null && !queryLabel.isBlank() ? queryLabel : entryValue;
-                            String queryUrl = QueryPage.MOUNT_PATH + "?id=" + Utils.urlEncode(entryValue) + templateLinkContextParam();
+                            String queryUrl = QueryPage.MOUNT_PATH + "?id=" + Utils.urlEncode(entryValue);
+                            queryUrl += linkNavParams(queryUrl);
                             String linkHtml = "<a href=\"" + Strings.escapeMarkup(queryUrl) + "\">" + Strings.escapeMarkup(displayLabel) + "</a>";
                             components.add(new Label("component", linkHtml).setEscapeModelStrings(false));
                         } else if (key.endsWith("_multi_iri")) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvg.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultSvg.java
@@ -84,7 +84,7 @@ public class QueryResultSvg extends QueryResult {
                 }
                 item.add(header);
                 String svg = item.getModelObject().get("svg");
-                item.add(new Label("content", svg == null ? null : withContextInHtmlLinks(Utils.sanitizeSvg(svg))).setEscapeModelStrings(false));
+                item.add(new Label("content", svg == null ? null : withNavParamsInHtmlLinks(Utils.sanitizeSvg(svg))).setEscapeModelStrings(false));
             }
         });
         container.add(new Label("no-records", "(nothing found)").setVisible(response.getData().isEmpty()));

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultTable.java
@@ -374,7 +374,8 @@ public class QueryResultTable extends QueryResult {
                         if (label == null || label.isBlank()) {
                             label = truncateLabel(value);
                         }
-                        String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest" + templateLinkContextParam();
+                        String templateUrl = PublishPage.MOUNT_PATH + "?template=" + Utils.urlEncode(value) + "&template-version=latest";
+                        templateUrl += linkNavParams(templateUrl);
                         String html = "<a href=\"" + Strings.escapeMarkup(templateUrl) + "\">" + Strings.escapeMarkup(label) + "</a>";
                         cellItem.add(new Label(componentId, html).setEscapeModelStrings(false));
                     } else if (isPublishLink(value)) {

--- a/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/TitleBar.java
@@ -94,15 +94,15 @@ public class TitleBar extends Panel {
             breadcrumbLinks.setVisible(false);
         }
         breadcrumbPath.add(breadcrumbLinks);
-        // Back-to-context link: on pages without a breadcrumb of their own that are not
-        // a context resource's page, show "< XXX" pointing to the navigation context
-        // (or "< Home" if none), so the user can always get back to it.
+        // Back-to-context link: on pages without a breadcrumb of their own, show "< XXX"
+        // pointing to where the user came from — the resource part, the navigation
+        // context, or "< Home" if there is none — so they can always get back to it.
         WebMarkupContainer backContextContainer = new WebMarkupContainer("backcontext-container");
         boolean backCrumbVisible = false;
-        if (crumbParts.isEmpty() && !page.isContextPage()) {
+        if (crumbParts.isEmpty()) {
             NanodashPageRef backRef = createBackContextRef(page);
             if (backRef != null) {
-                backContextContainer.add(backRef.createComponent("backcontext", Utils.truncateLinkLabel(backRef.getLabel())));
+                backContextContainer.add(backRef.createComponent("backcontext", crumbLabel(backRef.getLabel())));
                 backCrumbVisible = true;
             }
         }
@@ -117,17 +117,31 @@ public class TitleBar extends Panel {
     }
 
     /**
-     * The target of the back-to-context link for the given page: the navigation context
-     * resource, the home page if no context is set, or an explore-page link if the
-     * context id cannot (yet) be resolved. Null when the link would point to the page
-     * itself.
+     * The target of the back-to-context link for the given page: the resource part the
+     * page was reached under, else the navigation context resource, the home page if no
+     * context is set, or an explore-page link if the context id cannot (yet) be
+     * resolved. Null when the link would point to the page itself.
      */
     private static NanodashPageRef createBackContextRef(NanodashPage page) {
-        String contextId = page.getContextId();
-        if (contextId == null) {
-            if (page instanceof HomePage) return null;
-            return new NanodashPageRef(HomePage.class, "Home");
+        String contextId;
+        if (page.isContextPage()) {
+            // A page showing a context resource is where the context leads, so it needs
+            // no back-link of its own — unless it was reached under a different context
+            // (from a part page, say), whose trail would otherwise end here (issue #697).
+            contextId = page.getIncomingContextId();
+            if (contextId == null || contextId.equals(page.getContextId())) return null;
+        } else {
+            contextId = page.getContextId();
+            if (contextId == null) {
+                if (page instanceof HomePage) return null;
+                return new NanodashPageRef(HomePage.class, "Home");
+            }
         }
+        // A resource part carried along names the page the user actually came from,
+        // which is more specific than the maintaining resource the context names.
+        String partId = page.getPartId();
+        NanodashPageRef partRef = NavigationContext.getPartPageRef(partId, page.getPartLabel(), contextId);
+        if (partRef != null && !pointsToSelf(partRef, page, partId)) return partRef;
         NanodashPageRef ref = NavigationContext.getPageRef(contextId);
         if (page instanceof HomePage && ref != null && HomePage.class.equals(ref.getPageClass())) return null;
         if (ref == null) {
@@ -135,10 +149,16 @@ public class TitleBar extends Panel {
             // forwards known resources to their own pages once the caches are warm.
             ref = new NanodashPageRef(ExplorePage.class, new PageParameters().set("id", contextId), Utils.getShortNameFromURI(contextId));
         }
-        if (ref.getPageClass().equals(page.getClass()) && contextId.equals(page.getPageParameters().get("id").toString(""))) {
-            return null;
-        }
+        if (pointsToSelf(ref, page, contextId)) return null;
         return ref;
+    }
+
+    /**
+     * Whether the given ref points at the page it would be shown on: same page class,
+     * same resource id.
+     */
+    private static boolean pointsToSelf(NanodashPageRef ref, NanodashPage page, String id) {
+        return ref.getPageClass().equals(page.getClass()) && id.equals(page.getPageParameters().get("id").toString(""));
     }
 
     /**
@@ -191,12 +211,28 @@ public class TitleBar extends Panel {
             // so each path level renders as one concise crumb — e.g.
             // "FIP.38.T.8 | FAIR Implementation Profile Training Session 8" → "FIP.38.T.8",
             // "3PFF: the Three Point FAIRification Framework" → "3PFF".
-            List<String> segments = splitLabel(label);
-            if (!segments.isEmpty()) {
-                parts.add(new CrumbPart(pathRefs[i], truncateLabel(segments.get(0))));
+            String crumbLabel = crumbLabel(label);
+            if (crumbLabel != null) {
+                parts.add(new CrumbPart(pathRefs[i], crumbLabel));
             }
         }
         return parts;
+    }
+
+    /**
+     * The text to show for a single crumb: only the leading segment of the label — the
+     * part before the first list/title separator — truncated to the shared crumb length.
+     * Applied to the back-link as well as to path crumbs, so "&lt;" and "&gt;" shorten a
+     * label the same way (e.g. "More Than Data: Making Knowledge Graphs Work Together for
+     * Actionable Insights" renders as "More Than Data" either way).
+     *
+     * @param label the ref's full label, or null
+     * @return the crumb text, or null if there is nothing to show
+     */
+    static String crumbLabel(String label) {
+        if (label == null) return null;
+        List<String> segments = splitLabel(label);
+        return segments.isEmpty() ? null : truncateLabel(segments.get(0));
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/page/NanodashPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/NanodashPage.java
@@ -189,6 +189,44 @@ public abstract class NanodashPage extends WebPage {
     }
 
     /**
+     * The navigation context this page was reached under, as opposed to the one it
+     * hands on: the plain {@code context} parameter, without the override pages showing
+     * a context resource apply to {@link #getContextId()}. Tells a context page where
+     * the user came from, so the trail there is not lost (issue #697).
+     *
+     * @return the incoming context resource id, or null if none
+     */
+    public String getIncomingContextId() {
+        return NavigationContext.getContextId(getPageParameters());
+    }
+
+    /**
+     * The resource part this page was reached under (or is itself), carried along as the
+     * {@code part} parameter. A part is not a context resource of its own, so it travels
+     * next to {@link #getIncomingContextId()}, which names the maintaining resource it
+     * belongs to (issue #697).
+     *
+     * @return the part resource id, or null if the page was not reached from a part
+     */
+    public String getPartId() {
+        // Stepping up to the resource that maintains the part lands on that resource's
+        // own page; from there on the part is behind the user, not where they came from,
+        // so it stops travelling here.
+        if (isContextPage() && getContextId() != null && getContextId().equals(getIncomingContextId())) return null;
+        return NavigationContext.getPartId(getPageParameters());
+    }
+
+    /**
+     * The label of {@link #getPartId()}, carried along so a back-link can name the part
+     * without resolving it over the network.
+     *
+     * @return the part label, or null if none is known
+     */
+    public String getPartLabel() {
+        return NavigationContext.getPartLabel(getPageParameters());
+    }
+
+    /**
      * Whether this page shows a context resource itself (space, user, maintained
      * resource, or resource part). Such pages have their own breadcrumb or tab strip and
      * don't get the title bar's back-to-context link.

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
@@ -58,9 +58,32 @@ public class ResourcePartPage extends NanodashPage {
     }
 
     /**
+     * This page's own resource is the part links out of it should point back to
+     * (issue #697), not the maintaining resource the {@code context} param names.
+     */
+    @Override
+    public String getPartId() {
+        return getPageParameters().get("id").toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getPartLabel() {
+        return partLabel;
+    }
+
+    /**
      * Resource with profile (Space or MaintainedResource) object with the data shown on this page.
      */
     private AbstractResourceWithProfile resourceWithProfile;
+
+    /**
+     * The part's label as resolved for the title, handed to links out of this page so
+     * their back-link can name the part.
+     */
+    private String partLabel;
 
     /**
      * If the {@code id} in the given parameters falls under a namespace declared by a
@@ -135,6 +158,8 @@ public class ResourcePartPage extends NanodashPage {
 //        if (getDefResp == null || getDefResp.getData().isEmpty()) {
 //            throw new RestartResponseException(ExplorePage.class, parameters);
 //        }
+
+        partLabel = label;
 
         List<NanodashPageRef> breadCrumb;
         if (resourceWithProfile.getSpace() != null) {

--- a/src/test/java/com/knowledgepixels/nanodash/NavigationContextTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/NavigationContextTest.java
@@ -1,7 +1,9 @@
 package com.knowledgepixels.nanodash;
 
+import com.knowledgepixels.nanodash.page.ResourcePartPage;
 import com.knowledgepixels.nanodash.utils.TestUtils;
 import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.junit.jupiter.api.Test;
@@ -14,12 +16,16 @@ import org.nanopub.vocabulary.NPX;
 import static com.knowledgepixels.nanodash.utils.TestUtils.vf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NavigationContextTest {
 
     private static final IRI SPACE_IRI = vf.createIRI("https://example.com/space/my-space");
     private static final IRI OTHER_SPACE_IRI = vf.createIRI("https://example.com/space/other-space");
     private static final IRI RESOURCE_IRI = vf.createIRI("https://example.com/resource/my-resource");
+    private static final String PART_ID = "https://example.com/resource/my-resource/part/my-part";
+    private static final String PART_LABEL = "My Part";
 
     private static NanopubCreator creatorWithType(IRI nanopubType) throws NanopubAlreadyFinalizedException {
         NanopubCreator creator = TestUtils.getNanopubCreator();
@@ -102,6 +108,77 @@ class NavigationContextTest {
         creator.addAssertionStatement(vf.createStatement(TestUtils.anyIri, KPXL_TERMS.IS_MAINTAINED_BY, SPACE_IRI));
         Nanopub np = creator.finalizeNanopub();
         assertNull(NavigationContext.getDeclaredMaintainedResourceId(np));
+    }
+
+    private static PageParameters paramsWith(String id, String contextId) {
+        PageParameters params = new PageParameters().set("id", id);
+        if (contextId != null) params.set(NavigationContext.CONTEXT_PARAM, contextId);
+        return params;
+    }
+
+    @Test
+    void partIsCarriedAlongWithItsOwnContext() {
+        PageParameters params = paramsWith("https://example.com/somewhere-else", RESOURCE_IRI.stringValue());
+        NavigationContext.withPart(params, PART_ID, PART_LABEL, RESOURCE_IRI.stringValue());
+        assertEquals(PART_ID, params.get(NavigationContext.PART_PARAM).toString());
+        assertEquals(PART_LABEL, params.get(NavigationContext.PART_LABEL_PARAM).toString());
+    }
+
+    @Test
+    void partIsNotCarriedUnderADifferentContext() {
+        // A link the caller pointed at another context: the part means nothing there.
+        PageParameters params = paramsWith("https://example.com/somewhere-else", SPACE_IRI.stringValue());
+        NavigationContext.withPart(params, PART_ID, PART_LABEL, RESOURCE_IRI.stringValue());
+        assertTrue(params.get(NavigationContext.PART_PARAM).isEmpty());
+        assertTrue(params.get(NavigationContext.PART_LABEL_PARAM).isEmpty());
+    }
+
+    @Test
+    void partIsNotCarriedOnALinkToItself() {
+        PageParameters params = paramsWith(PART_ID, RESOURCE_IRI.stringValue());
+        NavigationContext.withPart(params, PART_ID, PART_LABEL, RESOURCE_IRI.stringValue());
+        assertTrue(params.get(NavigationContext.PART_PARAM).isEmpty());
+    }
+
+    @Test
+    void partIsNotCarriedUpToItsMaintainingResource() {
+        // Stepping up to the maintaining resource leaves the part behind.
+        PageParameters params = paramsWith(RESOURCE_IRI.stringValue(), RESOURCE_IRI.stringValue());
+        NavigationContext.withPart(params, PART_ID, PART_LABEL, RESOURCE_IRI.stringValue());
+        assertTrue(params.get(NavigationContext.PART_PARAM).isEmpty());
+    }
+
+    @Test
+    void explicitPartStaysAuthoritative() {
+        PageParameters params = paramsWith("https://example.com/somewhere-else", RESOURCE_IRI.stringValue())
+                .set(NavigationContext.PART_PARAM, "https://example.com/resource/my-resource/part/other-part");
+        NavigationContext.withPart(params, PART_ID, PART_LABEL, RESOURCE_IRI.stringValue());
+        assertEquals("https://example.com/resource/my-resource/part/other-part", params.get(NavigationContext.PART_PARAM).toString());
+        assertTrue(params.get(NavigationContext.PART_LABEL_PARAM).isEmpty());
+    }
+
+    @Test
+    void partPageRefCarriesItsContext() {
+        NanodashPageRef ref = NavigationContext.getPartPageRef(PART_ID, PART_LABEL, RESOURCE_IRI.stringValue());
+        assertSame(ResourcePartPage.class, ref.getPageClass());
+        assertEquals(PART_ID, ref.getParameters().get("id").toString());
+        assertEquals(RESOURCE_IRI.stringValue(), ref.getParameters().get(NavigationContext.CONTEXT_PARAM).toString());
+        assertEquals(PART_LABEL, ref.getParameters().get("label").toString());
+        assertEquals(PART_LABEL, ref.getLabel());
+    }
+
+    @Test
+    void partPageRefFallsBackToTheShortName() {
+        NanodashPageRef ref = NavigationContext.getPartPageRef(PART_ID, null, RESOURCE_IRI.stringValue());
+        assertEquals(Utils.getShortNameFromURI(PART_ID), ref.getLabel());
+        assertTrue(ref.getParameters().get("label").isEmpty());
+    }
+
+    @Test
+    void noPartPageRefWithoutAContext() {
+        // A part page cannot resolve itself without its maintaining resource.
+        assertNull(NavigationContext.getPartPageRef(PART_ID, PART_LABEL, null));
+        assertNull(NavigationContext.getPartPageRef(null, null, RESOURCE_IRI.stringValue()));
     }
 
 }

--- a/src/test/java/com/knowledgepixels/nanodash/QueryResultPublishLinkTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/QueryResultPublishLinkTest.java
@@ -52,4 +52,18 @@ class QueryResultPublishLinkTest {
         String html = "<a class=\"source\" href=\"/publish?a\">one</a>";
         assertEquals(html, QueryResult.withPublishLinksAsButtons(html));
     }
+
+    @Test
+    void linkTargetsAreRecognized() {
+        // Guards the part parameter on hand-built cell links: a link to the part itself,
+        // or up to the resource maintaining it, must not carry the part along.
+        String part = "https://example.com/resource/my-resource/part/my-part";
+        assertTrue(QueryResult.namesResource("/part?id=" + Utils.urlEncode(part), part));
+        // The sanitizer writes "=" as "&#61;".
+        assertTrue(QueryResult.namesResource("/part?id&#61;" + Utils.urlEncode(part), part));
+        assertFalse(QueryResult.namesResource("/user?id=" + Utils.urlEncode("https://orcid.org/0000-0002-1267-0234"), part));
+        assertFalse(QueryResult.namesResource("/space?context=" + Utils.urlEncode(part), part));
+        assertFalse(QueryResult.namesResource(null, part));
+    }
+
 }

--- a/src/test/java/com/knowledgepixels/nanodash/component/TitleBarTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/TitleBarTest.java
@@ -98,4 +98,24 @@ class TitleBarTest {
         assertEquals(List.of("Knowledge Pixels", "Incubator"),
                 crumbLabels("Knowledge Pixels", "Knowledge Pixels Incubator"));
     }
+
+    @Test
+    void backLinkLabelIsShortenedLikeAPathCrumb() {
+        // The "<" back-link and a ">" path crumb shorten a label the same way.
+        String title = "More Than Data: Making Knowledge Graphs Work Together for Actionable Insights";
+        assertEquals("More Than Data", TitleBar.crumbLabel(title));
+        assertEquals(List.of("More Than Data"), crumbLabels(title));
+        assertEquals("FIP.38.T.8", TitleBar.crumbLabel("FIP.38.T.8 | FAIR Implementation Profile Training Session 8"));
+    }
+
+    @Test
+    void backLinkLabelWithoutSeparatorIsOnlyTruncated() {
+        String plain = "Knowledge Pixels";
+        assertEquals(plain, TitleBar.crumbLabel(plain));
+        String tooLong = "Knowledge Graphs and Their Many Uses Across Rather A Lot Of Different Domains";
+        assertEquals(TitleBar.truncateLabel(tooLong), TitleBar.crumbLabel(tooLong));
+        assertNull(TitleBar.crumbLabel(null));
+        assertNull(TitleBar.crumbLabel("   "));
+    }
+
 }


### PR DESCRIPTION
Fixes #697.

## The problem

Follow a link out of a resource part page and the breadcrumb on the destination named the containing space, not the part you came from. `NanodashLink` puts only `id` and `context` on an outgoing link, and on a part page `context` is the *maintaining resource* — the part identity was never carried across.

## Shape

Shape (b) of the issue: a `part` (+ `part-label`) page parameter travelling next to `context`, rather than making a part a navigation context of its own. `part` already meant exactly this for post-publish forwarding (`ViewActionMappings`, `NavigationContext.redirectAfterPublish`).

Propagation lives in the existing `pageContextFallback()` / `hrefContextFallback()` behaviors, so all their call sites are covered without threading a part id through `NanodashLink`'s signatures. The invariant: **a part only ever travels together with its own context** — `withPart` refuses on a link carrying a different context, on a link to the part itself, and on one up to the maintaining resource, and `NanodashPage.getPartId()` returns null once the page *is* that resource. Without the last rule the part kept riding on every link out of the space page.

## Two things the issue did not anticipate

**The reported click needed more than the part parameter.** Authors are ORCID IRIs → `UserPage`, which overrides `getContextId()` to itself and returns `isContextPage() == true`, so it showed *no* back-crumb at all rather than a wrong one — neither shape in the issue would have changed that click. `TitleBar.createBackContextRef` now also serves a context page that was reached under a different context.

**Hand-built cell links bypassed all of it.** `user_iri` / `template_iri` / `query_iri` columns and query-emitted HTML render as raw `<a href>` labels, not Wicket links, so no fallback behavior reaches them — and `user_iri` carried no `context` either, which is why a user-listing view (e.g. "🗓 Organizers") led to a crumb-less user page even before this issue. Now centralised in `QueryResult.linkNavParams(url)` (replaces `templateLinkContextParam`; `withContextInHtmlLinks` → `withNavParamsInHtmlLinks`).

**Also:** the back-link now shortens its label the way path crumbs do (`TitleBar.crumbLabel`, shared with `buildCrumbParts`), so `More Than Data: Making Knowledge Graphs Work Together for Actionable Insights` renders as `< More Than Data` instead of being truncated mid-word.

## Verified

Driven end-to-end against a local instance (headless Chrome for the lazily loaded views):

| From a part page → | back-crumb |
|---|---|
| author's user page | `< KGXL-Query` (was: nothing at all) |
| explore page | `< KGXL-Query` (was: `< SEMANTiCS 2026`) |
| user page reached from the space | `< SEMANTiCS 2026` (unchanged) |
| user page with no context | none (unchanged) |
| space page reached from the part | no crumb, and 0 outgoing links carry `part=` |

The "🗓 Organizers" view rendered under a part context emits `/user?id=…&context=…&part=…&part-label=…`; on a space page the same view's user links now carry `context=` (they carried nothing) and no stray part. The part page's own path crumb (`SEMANTiCS 2026 > KGXL-Query`) and the home page are unchanged.

1378 tests pass, including new cases for the `withPart` guards, `getPartPageRef`, `namesResource`, and the `<`/`>` label equivalence.

## Known gap

`ResourceTabs` builds tab links from scratch, carrying neither context nor part, so switching tabs on the destination page still drops the trail. Pre-existing for `context` too; left out to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpQe4aJzdBr1epP8XSGYiY