### PR TITLE
feat(views): let a view decide what its actions act on

### DIFF
--- a/docs/fill-modes.md
+++ b/docs/fill-modes.md
@@ -152,6 +152,9 @@ external root value was migrated from the source.
 - **`component/PublishForm.java`** — `FillMode` enum; maps the URL params to a
   mode (§ lines ~137–176); attaches the `npx:supersedes` / `prov:wasDerivedFrom`
   pubinfo template; skips default-license seeding for all fill-from modes.
+- **`component/ViewActionMappings.java`** — a view action can open a fill mode from
+  the page it is shown on: mapping the `@sourceNp` page source to `@override` makes the
+  action reopen the nanopub the view is showing. See docs/magic-query-params.md.
 - **`template/ValueFiller.java`** — copies the source graph and rewrites URIs;
   `transform(Value)` keeps introduced IRIs for `SUPERSEDE`/`OVERRIDE`, re-mints
   them otherwise.

--- a/docs/magic-query-params.md
+++ b/docs/magic-query-params.md
@@ -281,7 +281,10 @@ do take the page's nanopub.
 
 ```turtle
 sub:overrideAction a gen:ViewResultAction;
-  rdfs:label "♻️ override...";
+  # The icon is the bare U+267B, without the U+FE0F variation selector: that keeps it a
+  # text-presentation glyph, drawn monochrome in the menu's own colour, rather than a colour
+  # emoji that ignores it.
+  rdfs:label "♻ override...";
   gen:hasActionTemplate <…a fallback template…>;
   gen:hasActionTemplateQueryMapping "@result.override_target:@override @result.override_template:@template";
   gen:isVisibleTo gen:MemberRole .

--- a/docs/magic-query-params.md
+++ b/docs/magic-query-params.md
@@ -254,6 +254,85 @@ introduction is to declare. It emits the `locked` page parameter alongside the
 `param_` one; see docs/locked-prefilled-values.md. It applies to `param_` targets
 only, as a raw `@` key is not a form field.
 
+### Page sources: `@sourceNp` / `@sourceNpTemplate`
+
+The mappings above all read a result **row**, which a *result* action does not have —
+it is a button for the view as a whole. The way for such an action to carry a value of
+the view's own is a **page source**: a mapping whose left-hand side begins with `@` and
+names something the page supplies rather than a column.
+
+| Source | Resolves to |
+| --- | --- |
+| `@result.<column>` | the value `<column>` holds in the view's **own result** — one value for the whole view, so the column must hold the same one in every row |
+| `@sourceNp` | the nanopub the view's query is bound to: the `<queryField>Np` parameter the page filled in (`ViewList`), i.e. the nanopub the *page* resolved |
+| `@sourceNpTemplate` | the `nt:wasCreatedFromTemplate` of that nanopub |
+
+The case this exists for is an **override action on a view of one nanopub's content**
+(docs/fill-modes.md): the button has to name the nanopub to override, and a result action
+has no row to read it from.
+
+**Prefer `@result.`**, and let the query decide. A view whose query resolves the nanopub
+itself — rather than taking the page's `…Np` parameter — can return it as a column, and the
+action then acts on exactly what the panel is showing. That also puts the rule for *which*
+nanopub counts into the view's own query, i.e. into RDF, per view, next to the
+`gen:isVisibleTo` that says who may act on it (`get-presentation-details` does this: newest
+candidate signed by a member-tier member of the space). `@sourceNp` remains for views that
+do take the page's nanopub.
+
+```turtle
+sub:overrideAction a gen:ViewResultAction;
+  rdfs:label "♻️ override...";
+  gen:hasActionTemplate <…a fallback template…>;
+  gen:hasActionTemplateQueryMapping "@result.override_target:@override @result.override_template:@template";
+  gen:isVisibleTo gen:MemberRole .
+```
+
+Mapping the template to `@template` matters whenever a view shows nanopubs made with more
+than one template (a presentation *and* a poster, say): the form then opens the template
+that actually made the source, rather than the action's declared one, which stays as the
+fallback. `template-version=latest` still resolves it forward.
+
+Notes:
+
+- **Resolved where the link is built** (`ViewActionMappings`), for result and entry
+  actions alike — never at form time, so a page source is dropped from
+  `values-from-query-mapping` exactly as a raw `@key` target is.
+- **Always required.** An unresolvable page source hides the action, like an empty raw
+  key: the page was meant to supply it, and a button built on a value that is not there
+  would open a form on nothing. This is also what hides the action when the page has no
+  nanopub at all — `ViewList` writes the sentinel `"x:"` there, which counts as absent.
+- **No target field is passed** when an action maps a fill-mode key (`@override`,
+  `@supersede`, `@derive-a`, …): the form takes every field from the source nanopub, so
+  the page's own resource on top could only overwrite a filled field of that name.
+- **A column that varies from row to row hides the action.** It is then a property of a
+  row, not of the view — which is what an entry action is for, mapping the row's column
+  directly. (For the same reason `@result.` resolves to nothing on an entry action.)
+- **`@result.` columns are hidden from the table** like any other mapping source
+  (`View#getActionMappingSourceColumns`), so a query can return a column purely to feed an
+  action — the established idiom being an aliased `(?np as ?override_target)`. The other
+  page sources name no column, so there is nothing of theirs to hide.
+- A view whose query is *not* keyed on a nanopub has no `@sourceNp` to give (and a
+  header view has no query at all), so an action needing it does not render there.
+
+#### Publishing such a view before the code that reads it
+
+A page source means nothing to an older Nanodash, which would render the button with no
+`override=` and open an *empty* form. Two properties of the vocabulary make a view carrying
+one safe to publish ahead of its release:
+
+- **Leave `gen:hasActionTemplate` off** and let `@…:@template` supply it. A missing template
+  is the one condition under which every version skips an action, so older instances show no
+  button at all, while this one takes the template from the mapping. (An action with neither
+  is skipped everywhere — there is no form to open.) Note that `gen:hasActionTemplate` is a
+  *required* statement of the view-creation template up to
+  `RAnMcenHc46myXb_Yp-dPu62pywUIsqYJ5oJvSgV38XiQ`, so leaving it off needs the version that
+  makes it optional.
+- **Name the columns feeding the action `…_label`.** Every renderer, old and new, skips a
+  column whose name ends in `_label` / `_label_multi` (it is read only as another column's
+  companion), so action-only columns stay out of the table on instances that don't yet know
+  they are mapping sources. `get-presentation-details` uses `override_target_label` /
+  `override_template_label` for exactly this reason.
+
 ### Echo-as-column (no code)
 
 A query may `SELECT` a magic variable back out

--- a/docs/role-specific-views.md
+++ b/docs/role-specific-views.md
@@ -129,6 +129,40 @@ This is **additive**: an action without `gen:isVisibleTo` renders exactly as
 before. It composes with — does not replace — the existing `ButtonList` routing
 (see next).
 
+## The same ladder, for whose *content* counts: `gen:hasPartDefinitionTier`
+
+`gen:isVisibleTo` decides who is shown an action. A space can use the same tier
+vocabulary to decide something else: **whose nanopublications count as definitions
+of its parts**.
+
+A part page does not read the nanopub it shows from a view. It resolves it first —
+`ResourcePartPage` → `ViewDataFetcher.partDefinitionQueryRef` → the published
+`get-term-definitions` query, with the approved public keys of the owning space's
+members — and then hands it to every view as their `…Np` parameter, besides taking
+the page's own title and `rdf:type`s from it. Historically that key list was *every*
+role-holder of the space, observers included, with the newest definition winning.
+
+A space can now narrow it, in its root definition (which an admin signs):
+
+```turtle
+<https://w3id.org/spaces/example> gen:hasPartDefinitionTier gen:MemberRole .
+```
+
+Read by `Space.getPartDefinitionTierRank()` off the space's own root nanopub — no
+materialization needed, Nanodash already holds it — and applied in
+`ViewDataFetcher.partDefinitionPubkeys`, the single list behind the part page, its
+About tab (the Info view) and term resolution in the explore view, so those three
+cannot disagree about which nanopublication defines a part. **Absent means the
+original rule**: every role-holder counts, so no existing space changes behaviour.
+
+Note what this does *not* reach: a view whose query resolves the nanopub itself
+rather than taking the `…Np` parameter states its own rule in its own SPARQL (see
+`get-presentation-details`, which takes the newest candidate signed by a member of
+the space). Where both exist they should agree — a space declaring the member tier
+and a view resolving to the member tier — but they are two declarations, because a
+query can only read what nanopub-query materializes into the spaces state, and this
+one lives in the space's root definition.
+
 ## Relationship to today's `ButtonList` routing
 
 Existing action visibility is coarse and wired by resource *type*, not declared:

--- a/src/main/java/com/knowledgepixels/nanodash/PostPublishRefresh.java
+++ b/src/main/java/com/knowledgepixels/nanodash/PostPublishRefresh.java
@@ -21,6 +21,9 @@ import java.util.Set;
  * view-display query and rebuilds the entire page structure around the view. That is the
  * right thing only for the publications that actually change the structure: which views a
  * resource shows, and who may see them.
+ * <p>
+ * A part page has one more thing to invalidate: the lookup that decides which nanopub the
+ * page shows in the first place — see {@link #partDefinitionRefreshTarget}.
  */
 public class PostPublishRefresh {
 
@@ -97,6 +100,32 @@ public class PostPublishRefresh {
             if (rolePredicates.contains(predicate)) return true;
         }
         return false;
+    }
+
+    /**
+     * The part-definition lookup a publication invalidates, or null when it invalidates none.
+     * <p>
+     * A part page does not read the nanopub it shows from any of the view queries: it
+     * resolves it first, through {@link ViewDataFetcher#partDefinitionQueryRef} (the newest
+     * definition of the term among the members' keys), and then hands that nanopub to every
+     * view as their {@code …Np} parameter. A publication that introduces the part being
+     * viewed — an override of its definition, say (docs/fill-modes.md) — is a new, newer
+     * definition, so it changes the answer to that lookup. Re-running the view queries
+     * cannot show it: they are all keyed on the nanopub the lookup returned before. The
+     * lookup itself is what has to be cleared.
+     *
+     * @param np        the just-published nanopub
+     * @param partId    the {@code part} page parameter, i.e. the part being viewed, or empty
+     * @param contextId the id of the context resource whose page is being returned to
+     * @return the query ref to invalidate, as a refresh target, or null
+     */
+    public static String partDefinitionRefreshTarget(Nanopub np, String partId, String contextId) {
+        if (np == null || partId == null || partId.isEmpty()) return null;
+        if (contextId == null || contextId.isEmpty() || partId.equals(contextId)) return null;
+        if (!NanopubUtils.getIntroducedIriIds(np).contains(partId)) return null;
+        AbstractResourceWithProfile resource = AbstractResourceWithProfile.get(contextId);
+        if (resource == null) return null;
+        return ViewDataFetcher.partDefinitionQueryRef(partId, contextId, resource).getAsUrlString();
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
@@ -97,6 +97,17 @@ public abstract class QueryResult extends Panel {
     }
 
     /**
+     * The results this view is showing. Available to the action-link builder, which runs
+     * after the response has arrived, so a view-level action can take a value from the rows
+     * (see {@link com.knowledgepixels.nanodash.component.ViewActionMappings}).
+     *
+     * @return the API response
+     */
+    public ApiResponse getApiResponse() {
+        return response;
+    }
+
+    /**
      * The version of the view definition this view display is showing, as the id to hand to
      * {@link View#refreshLatestVersion(String)} when checking for a newer one.
      *

--- a/src/main/java/com/knowledgepixels/nanodash/View.java
+++ b/src/main/java/com/knowledgepixels/nanodash/View.java
@@ -774,6 +774,12 @@ public class View implements Serializable {
      * the result builders skip them when rendering visible columns. A column that
      * happens to be both a display column and a mapping source would also be hidden;
      * map a duplicated/aliased column instead if you need to show one.
+     * <p>
+     * Page sources ({@code @}-prefixed) are not result columns at all, so they are left
+     * out — except {@code @result.<column>}, which names one: it is the column's single
+     * view-wide value, so the column is action data like any other mapping source and is
+     * hidden the same way. That is what lets a query return a column purely for an action
+     * (an aliased {@code (?np as ?override_target)}, say) without it showing up in the table.
      *
      * @return the set of mapping-source column names (never null)
      */
@@ -781,12 +787,24 @@ public class View implements Serializable {
         Set<String> columns = new HashSet<>();
         for (IRI actionIri : actionTemplateQueryMappingsMap.keySet()) {
             for (String mapping : getTemplateQueryMappings(actionIri)) {
-                int idx = mapping.indexOf(':');
-                if (idx > 0) columns.add(mapping.substring(0, idx));
+                ActionMapping m = ActionMapping.parse(mapping);
+                if (m == null) continue;
+                if (!m.pageSource()) {
+                    columns.add(m.column());
+                } else if (m.column().startsWith(RESULT_SOURCE_PREFIX)) {
+                    columns.add(m.column().substring(RESULT_SOURCE_PREFIX.length()));
+                }
             }
         }
         return columns;
     }
+
+    /**
+     * Prefix of the page source that names a result column ({@code @result.<column>}); see
+     * {@link com.knowledgepixels.nanodash.component.ViewActionMappings#RESULT_PREFIX}, which
+     * resolves it.
+     */
+    private static final String RESULT_SOURCE_PREFIX = "@result.";
 
     /**
      * Gets the fill query of an action (issue #690): a query run against the action's
@@ -838,8 +856,14 @@ public class View implements Serializable {
      * began with {@code !}: the field is filled and then locked
      * (docs/locked-prefilled-values.md). Only meaningful for a field, so never set
      * together with {@code rawKey}.
+     * <p>
+     * A {@code column} that itself begins with {@code @} names a <em>page source</em>
+     * rather than a result column: a value the page supplies, resolved by the action-link
+     * builder instead of read from a row (see
+     * {@link com.knowledgepixels.nanodash.component.ViewActionMappings} and
+     * docs/magic-query-params.md).
      *
-     * @param column the result column the value is read from
+     * @param column the result column the value is read from, or an {@code @}-prefixed page source
      * @param key    the template field or raw URL key, with its {@code @}/{@code !} marker stripped
      * @param rawKey whether {@code key} is a raw URL key rather than a template field
      * @param locked whether the field is to be locked after filling
@@ -853,6 +877,17 @@ public class View implements Serializable {
          * @param mapping the {@code "col:target"} mapping
          * @return the parsed mapping, or null if it has no colon
          */
+        /**
+         * Whether {@link #column} names a page source (it begins with {@code @}) rather
+         * than a result column: its value comes from the page the view is shown on, not
+         * from a row.
+         *
+         * @return true if this mapping reads from a page source
+         */
+        public boolean pageSource() {
+            return column.startsWith("@");
+        }
+
         public static ActionMapping parse(String mapping) {
             int sep = mapping.indexOf(':');
             if (sep < 0) return null;

--- a/src/main/java/com/knowledgepixels/nanodash/ViewDataFetcher.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ViewDataFetcher.java
@@ -18,7 +18,9 @@ import org.nanopub.extra.services.QueryTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -158,6 +160,60 @@ public final class ViewDataFetcher {
     }
 
     /**
+     * The lookup a part page resolves the nanopub it shows through: the definitions of the
+     * part's term, restricted to the approved keys of the owning resource's members (or of
+     * the owning user), newest first. The one query behind both {@link #resolvePartNanopubId}
+     * and {@link com.knowledgepixels.nanodash.page.ResourcePartPage}, so the two cannot drift
+     * apart — and the entry to invalidate when a new definition is published
+     * ({@link PostPublishRefresh#partDefinitionRefreshTarget}).
+     *
+     * @param partId    the part IRI
+     * @param contextId the context resource IRI
+     * @param resource  the resolved context resource
+     * @return the query reference
+     */
+    public static QueryRef partDefinitionQueryRef(String partId, String contextId, AbstractResourceWithProfile resource) {
+        QueryRef getDefQuery = new QueryRef(QueryApiAccess.GET_TERM_DEFINITIONS, "term", partId);
+        for (String pubkey : partDefinitionPubkeys(contextId, resource)) {
+            getDefQuery.getParams().put("pubkey", pubkey);
+        }
+        return getDefQuery;
+    }
+
+    /**
+     * The approved public keys whose nanopublications count as definitions of the given
+     * resource's parts: those of the owning space's members, or of the owning user when the
+     * context is a user page.
+     * <p>
+     * Which members count is the space's own decision: a space declaring
+     * {@code gen:hasPartDefinitionTier} in its root definition (see
+     * {@link Space#getPartDefinitionTierRank}) restricts this to that tier and above, so that
+     * "who may describe what this space contains" is stated by the space rather than fixed
+     * here. Undeclared spaces keep the original rule — every role-holder, observers included.
+     * <p>
+     * The one list behind the part page, its About tab and term resolution in the explore
+     * view, so those cannot disagree about which nanopublication defines a part.
+     *
+     * @param contextId the context resource IRI
+     * @param resource  the resolved context resource
+     * @return the public key hashes (possibly empty)
+     */
+    public static List<String> partDefinitionPubkeys(String contextId, AbstractResourceWithProfile resource) {
+        List<String> pubkeys = new ArrayList<>();
+        Space space = resource.getSpace();
+        if (space != null) {
+            int minTier = space.getPartDefinitionTierRank();
+            for (IRI userIri : space.getUsers()) {
+                if (space.userTier(userIri) < minTier) continue;
+                pubkeys.addAll(User.getUserData().getPubkeyHashes(userIri, true));
+            }
+        } else {
+            pubkeys.addAll(User.getUserData().getPubkeyHashes(Utils.vf.createIRI(contextId), true));
+        }
+        return pubkeys;
+    }
+
+    /**
      * Looks up the nanopub ID for a part's term definition (mirrors ResourcePartPage logic).
      *
      * @param partId    the part IRI
@@ -166,19 +222,7 @@ public final class ViewDataFetcher {
      * @return the nanopub ID, or null
      */
     public static String resolvePartNanopubId(String partId, String contextId, AbstractResourceWithProfile resource) {
-        QueryRef getDefQuery = new QueryRef(QueryApiAccess.GET_TERM_DEFINITIONS, "term", partId);
-        if (resource.getSpace() != null) {
-            for (IRI userIri : resource.getSpace().getUsers()) {
-                for (String pubkey : User.getUserData().getPubkeyHashes(userIri, true)) {
-                    getDefQuery.getParams().put("pubkey", pubkey);
-                }
-            }
-        } else {
-            for (String pubkey : User.getUserData().getPubkeyHashes(Utils.vf.createIRI(contextId), true)) {
-                getDefQuery.getParams().put("pubkey", pubkey);
-            }
-        }
-        ApiResponse resp = ApiCache.retrieveResponseSync(getDefQuery, false);
+        ApiResponse resp = ApiCache.retrieveResponseSync(partDefinitionQueryRef(partId, contextId, resource), false);
         if (resp != null && !resp.getData().isEmpty()) {
             return resp.getData().iterator().next().get("np");
         }

--- a/src/main/java/com/knowledgepixels/nanodash/component/AboutPartPanel.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/AboutPartPanel.java
@@ -2,11 +2,10 @@ package com.knowledgepixels.nanodash.component;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import com.knowledgepixels.nanodash.Utils;
 import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDataFetcher;
 import com.knowledgepixels.nanodash.ViewDisplay;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
-import com.knowledgepixels.nanodash.domain.User;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.extra.services.QueryRef;
@@ -67,16 +66,10 @@ public class AboutPartPanel extends Panel {
         Multimap<String, String> infoParams = ArrayListMultimap.create();
         infoParams.put("partid", partId);
         infoParams.put("context", context.getId());
-        if (context.getSpace() != null) {
-            for (IRI userIri : context.getSpace().getUsers()) {
-                for (String pubkey : User.getUserData().getPubkeyHashes(userIri, true)) {
-                    infoParams.put("pubkey", pubkey);
-                }
-            }
-        } else {
-            for (String pubkey : User.getUserData().getPubkeyHashes(Utils.vf.createIRI(context.getId()), true)) {
-                infoParams.put("pubkey", pubkey);
-            }
+        // The same keys the part page resolves the part's definition with, so the Info view
+        // cannot describe a different nanopublication than the page shows.
+        for (String pubkey : ViewDataFetcher.partDefinitionPubkeys(context.getId(), context)) {
+            infoParams.put("pubkey", pubkey);
         }
         add(QueryResultTableBuilder.create("info", new QueryRef(infoView.getQuery().getQueryId(), infoParams), new ViewDisplay(infoView)).resourceWithProfile(context).id(context.getId()).contextId(context.getId()).build());
 

--- a/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/PublishForm.java
@@ -724,6 +724,14 @@ public class PublishForm extends Panel {
                             && PostPublishRefresh.changesPageStructure(signedNp, contextId)) {
                         WicketApplication.get().notifyNanopubPublished(signedNp, contextId, 5 * 1000);
                     }
+                    // On a part page, the nanopub the page shows is resolved before any view
+                    // runs, so a publication that introduces the part is invisible until that
+                    // lookup is re-run — the view queries are all keyed on the old one (#622).
+                    String partRefresh = PostPublishRefresh.partDefinitionRefreshTarget(
+                            signedNp, pageParams.get("part").toString(""), contextId);
+                    if (partRefresh != null) {
+                        WicketApplication.get().notifyNanopubPublished(signedNp, partRefresh, 5 * 1000);
+                    }
                     if (pageParams.get("postpub-redirect-url").isEmpty() && confirmPageClass == null) {
                         // Forward to the context resource's page, or home if no context; always throws.
                         NavigationContext.redirectAfterPublish(signedNp, pageParams);
@@ -1299,7 +1307,8 @@ public class PublishForm extends Panel {
      * to the field of the same name, as the listing-driven fill has always allowed in a
      * hand-written URL. A raw-key target ({@code "col:@key"}) has no meaning here: such keys
      * (the fill mode, the template) are read before any query runs, so they can only come
-     * from the link itself, as an entry action passes them.
+     * from the link itself, as an entry action passes them. Neither has a page source
+     * ({@code "@source:target"}), which is resolved where the link is built.
      *
      * @param mapping the mapping
      * @return the parsed mapping, or null if it cannot apply at this point
@@ -1309,6 +1318,12 @@ public class PublishForm extends Panel {
         if (m == null) return new View.ActionMapping(mapping, mapping, false, false);
         if (m.rawKey()) {
             logger.warn("Ignoring mapping {}: a raw key cannot be set from a query result at form time", mapping);
+            return null;
+        }
+        if (m.pageSource()) {
+            // A page source is resolved where the action link is built, against the page the
+            // view is on; the form has no page to read it from.
+            logger.warn("Ignoring mapping {}: a page source cannot be resolved at form time", mapping);
             return null;
         }
         return m;

--- a/src/main/java/com/knowledgepixels/nanodash/component/ViewActionMappings.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/ViewActionMappings.java
@@ -13,16 +13,23 @@ import com.knowledgepixels.nanodash.page.NanodashPage;
 import com.knowledgepixels.nanodash.page.PublishPage;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.template.Template;
+import com.knowledgepixels.nanodash.template.TemplateData;
 import org.apache.wicket.markup.html.link.AbstractLink;
 import org.apache.wicket.markup.html.link.BookmarkablePageLink;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.eclipse.rdf4j.model.IRI;
+import org.nanopub.Nanopub;
+import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.ApiResponseEntry;
 import org.nanopub.extra.services.QueryRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Applies a view entry action's per-row query mappings and decides whether the
@@ -32,7 +39,178 @@ import java.util.List;
  */
 class ViewActionMappings {
 
+    private static final Logger logger = LoggerFactory.getLogger(ViewActionMappings.class);
+
+    /**
+     * Page source naming the nanopublication the view's query is bound to: the value the
+     * page filled into the query's {@code <queryField>Np} parameter, i.e. the nanopub whose
+     * content the view is showing. Mapped to {@code @override} it opens that nanopub in the
+     * publish form (docs/fill-modes.md).
+     */
+    static final String SOURCE_NP = "@sourceNp";
+
+    /**
+     * Page source naming the template {@link #SOURCE_NP} was created from, read from its
+     * {@code nt:wasCreatedFromTemplate}. A view showing nanopubs of more than one template
+     * maps this to {@code @template} so the form opens the one that actually made the
+     * source, rather than the action's declared fallback.
+     */
+    static final String SOURCE_NP_TEMPLATE = "@sourceNpTemplate";
+
+    /**
+     * Page-source prefix naming a column of the view's <em>own result</em>:
+     * {@code @result.<column>}. Its value is that column's, taken once for the view rather
+     * than per row, so a result action (which has no row) can carry it — the column must
+     * therefore hold one and the same value in every row. This is what lets the <em>query</em>
+     * decide which nanopub an action acts on: it resolves the nanopub, returns it as a column,
+     * and the action reads it back. On an entry action there is no need for it — map the row's
+     * own column instead.
+     */
+    static final String RESULT_PREFIX = "@result.";
+
+    /**
+     * The raw publish-URL keys that put the form in a fill mode, i.e. make it take its
+     * values from a source nanopub ({@link com.knowledgepixels.nanodash.component.PublishForm.FillMode}).
+     * An action mapping one of these gets no target-field parameter: the source supplies
+     * every field, and passing the page's own resource on top would overwrite the filled
+     * value of a field that happens to carry the target field's name.
+     */
+    private static final Set<String> FILL_MODE_KEYS = Set.of(
+            "use", "use-a", "partial", "partial-a", "supersede", "supersede-a",
+            "derive", "derive-a", "override", "override-a", "fill", "fill-all");
+
     private ViewActionMappings() {
+    }
+
+    /**
+     * Resolves a page source — a mapping whose {@code column} begins with {@code @} — to the
+     * value the page supplies for it. Unlike a result column this is one value for the whole
+     * view, so it is available to result actions (which have no row) as well as entry ones.
+     *
+     * @param source    the page-source name, including its {@code @}
+     * @param view      the view declaring the action
+     * @param queryRef  the query reference the view is rendered from, or null
+     * @param response  the view's own results, or null where they are not in hand
+     * @return the value, or null if the page cannot supply it
+     */
+    private static String resolvePageSource(String source, View view, QueryRef queryRef, ApiResponse response) {
+        if (source.startsWith(RESULT_PREFIX)) {
+            return singleResultValue(response, source.substring(RESULT_PREFIX.length()));
+        }
+        String npId = sourceNanopubId(view, queryRef);
+        if (SOURCE_NP.equals(source)) return npId;
+        if (SOURCE_NP_TEMPLATE.equals(source)) {
+            Nanopub np = Utils.getAsNanopub(npId);
+            if (np == null) return null;
+            IRI templateId = TemplateData.get().getTemplateId(np);
+            return templateId == null ? null : templateId.stringValue();
+        }
+        logger.warn("Unknown page source in action mapping: {}", source);
+        return null;
+    }
+
+    /**
+     * The one value a result column holds across every row, or null if it holds none or
+     * several. A view-level action speaks for the whole view, so a column that varies from
+     * row to row is not something it can act on — that is what an entry action is for, and
+     * hiding the button is the safe reading (see {@link #applyEntryMappings}).
+     *
+     * @param response the view's results, or null
+     * @param column   the result column to read
+     * @return the single value, or null
+     */
+    private static String singleResultValue(ApiResponse response, String column) {
+        if (response == null || column.isEmpty()) return null;
+        String found = null;
+        for (ApiResponseEntry row : response.getData()) {
+            String value = row.get(column);
+            if (value == null || value.isBlank()) continue;
+            for (String token : value.trim().split("\\s+")) {
+                if (found == null) {
+                    found = token;
+                } else if (!found.equals(token)) {
+                    return null;
+                }
+            }
+        }
+        return found;
+    }
+
+    /**
+     * The nanopub the view's query is bound to: the {@code <queryField>Np} parameter the
+     * page filled in (see {@link ViewList}, which resolves it from the resource or, on a part
+     * page, from the part's term definition).
+     *
+     * @param view     the view whose query field names the parameter
+     * @param queryRef the query reference, or null
+     * @return the nanopub id, or null when the page has none
+     */
+    private static String sourceNanopubId(View view, QueryRef queryRef) {
+        if (view == null || queryRef == null || queryRef.getParams() == null) return null;
+        String queryField = view.getQueryField();
+        if (queryField == null || queryField.isBlank()) return null;
+        Collection<String> values = queryRef.getParams().get(queryField + "Np");
+        if (values == null) return null;
+        for (String value : values) {
+            // "x:" is the sentinel ViewList fills in when the page has no nanopub and the
+            // placeholder is not optional -- no source, so no action.
+            if (value != null && !value.isBlank() && !"x:".equals(value)) return value;
+        }
+        return null;
+    }
+
+    /**
+     * Whether the action takes the template to open from its mappings (a {@code @template}
+     * raw key) rather than from a declared {@code gen:hasActionTemplate}. A view showing
+     * nanopubs of several templates wants the former, and then a declared one would only be
+     * a fallback the action never uses.
+     * <p>
+     * Leaving the declaration off is also what makes such an action <em>invisible to older
+     * Nanodash versions</em>, which cannot resolve the mapping and skip an action with no
+     * template — rather than offering a button that opens an empty form. That is what lets a
+     * view carrying one be published before the code that understands it is released.
+     *
+     * @param view      the view declaring the action
+     * @param actionIri the action node IRI
+     * @return true if a mapping supplies the template
+     */
+    private static boolean mapsTemplate(View view, IRI actionIri) {
+        for (String mapping : view.getTemplateQueryMappings(actionIri)) {
+            View.ActionMapping m = View.ActionMapping.parse(mapping);
+            if (m != null && m.rawKey() && "template".equals(m.key())) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Whether the action opens the form in a fill mode, i.e. maps one of
+     * {@link #FILL_MODE_KEYS} as a raw key.
+     *
+     * @param view      the view declaring the action
+     * @param actionIri the action node IRI
+     * @return true if the action's values come from a source nanopub
+     */
+    private static boolean declaresFillMode(View view, IRI actionIri) {
+        for (String mapping : view.getTemplateQueryMappings(actionIri)) {
+            View.ActionMapping m = View.ActionMapping.parse(mapping);
+            if (m != null && m.rawKey() && FILL_MODE_KEYS.contains(m.key())) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Writes one resolved mapping into the link parameters: to the raw URL key, or to the
+     * template field's {@code param_} name, locking it when the mapping asks for that.
+     *
+     * @param params the link parameters
+     * @param m      the parsed mapping
+     * @param value  the resolved, non-empty value
+     */
+    private static void setMapped(PageParameters params, View.ActionMapping m, String value) {
+        params.set(m.rawKey() ? m.key() : "param_" + m.key(), value);
+        // A "!" in front of the field name says that what the action fills in is not the
+        // user's to change (issue #678): the field is shown with the value but locked.
+        if (m.locked()) params.add("locked", "param_" + m.key());
     }
 
     /**
@@ -83,15 +261,20 @@ class ViewActionMappings {
             // ref's authority on a ?root=-pinned page. See docs/space-ref-identity.md.
             if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), resourceWithProfile, refRoot)) continue;
             Template t = view.getTemplateForAction(actionIri);
-            if (t == null) continue;
+            // An action that takes its template from the data need not declare one; one that
+            // does not, cannot open a form at all.
+            if (t == null && !mapsTemplate(view, actionIri)) continue;
             String targetField = view.getTemplateTargetFieldForAction(actionIri);
             if (targetField == null) targetField = "resource";
             String label = view.getLabelForAction(actionIri);
             if (label == null) label = "action...";
             if (!label.endsWith("...")) label += "...";
-            PageParameters params = new PageParameters().set("template", t.getId())
-                    .set("template-version", "latest");
-            if (id != null) params.set("param_" + targetField, id);
+            PageParameters params = new PageParameters().set("template-version", "latest");
+            if (t != null) params.set("template", t.getId());
+            // The target field names the resource the action is about. An action in a fill
+            // mode takes every field from its source nanopub instead, so passing the page's
+            // own resource on top could only overwrite a filled field of that name.
+            if (id != null && !declaresFillMode(view, actionIri)) params.set("param_" + targetField, id);
             if (contextId != null) params.set("context", contextId);
             if (id != null && contextId != null && !id.equals(contextId)) {
                 params.set("part", id);
@@ -115,9 +298,30 @@ class ViewActionMappings {
                     params.set("param_" + partField, namespace + "<SET-SUFFIX>");
                 }
             }
+            // Page sources are resolved here and now: a result action has no row to read
+            // from, so this is the one way it can carry a value of the view's own — above
+            // all the nanopub it is showing, for an action that opens that nanopub in a
+            // fill mode. An unresolvable one hides the action, as an empty raw key does
+            // for an entry action (docs/magic-query-params.md).
+            List<String> queryMappings = new ArrayList<>();
+            boolean pageSourceMissing = false;
+            for (String mapping : view.getTemplateQueryMappings(actionIri)) {
+                View.ActionMapping m = View.ActionMapping.parse(mapping);
+                if (m == null) continue;
+                if (!m.pageSource()) {
+                    queryMappings.add(mapping);
+                    continue;
+                }
+                String value = resolvePageSource(m.column(), view, queryRef, result.getApiResponse());
+                if (value == null || value.isBlank()) {
+                    pageSourceMissing = true;
+                    break;
+                }
+                setMapped(params, m, value);
+            }
+            if (pageSourceMissing) continue;
             // Listing-driven mappings: the form re-runs this view's query and copies the
             // mapped columns of every row into the template (see PublishForm.applyQueryValues).
-            List<String> queryMappings = view.getTemplateQueryMappings(actionIri);
             if (!queryMappings.isEmpty()) {
                 params.set("values-from-query", queryRef.getAsUrlString());
                 params.set("values-from-query-mapping", String.join(" ", queryMappings));
@@ -166,16 +370,20 @@ class ViewActionMappings {
             // whose gen:isVisibleTo the viewer does not satisfy.
             if (!SpaceMemberRole.isViewerEntitled(view.getActionVisibleTo(actionIri), entitlementResource, refRoot)) continue;
             Template t = view.getTemplateForAction(actionIri);
-            if (t == null) continue;
+            // See addResultActions: the template may come from the row instead.
+            if (t == null && !mapsTemplate(view, actionIri)) continue;
             String targetField = view.getTemplateTargetFieldForAction(actionIri);
             if (targetField == null) targetField = "resource";
             String label = view.getLabelForAction(actionIri);
             if (label == null) label = "action...";
             if (!label.endsWith("...")) label += "...";
-            PageParameters params = new PageParameters().set("template", t.getId())
-                    .set("param_" + targetField, contextId)
+            PageParameters params = new PageParameters()
                     .set("context", contextId)
                     .set("template-version", "latest");
+            if (t != null) params.set("template", t.getId());
+            // See addResultActions: an action in a fill mode gets its fields from the source
+            // nanopub, so the target field is not passed on top of them.
+            if (!declaresFillMode(view, actionIri)) params.set("param_" + targetField, contextId);
             if (partId != null && contextId != null && !partId.equals(contextId)) {
                 params.set("part", partId);
             }
@@ -190,7 +398,7 @@ class ViewActionMappings {
             }
             // Apply the action's query mappings; hide the button for this row
             // if any required mapped value is empty (docs/magic-query-params.md).
-            if (!applyEntryMappings(view, actionIri, row, params)) {
+            if (!applyEntryMappings(view, actionIri, row, params, queryRef)) {
                 continue;
             }
             params.set("refresh-upon-publish", queryRef.getAsUrlString());
@@ -208,21 +416,23 @@ class ViewActionMappings {
         return links;
     }
 
-    static boolean applyEntryMappings(View view, IRI actionIri, ApiResponseEntry row, PageParameters params) {
+    static boolean applyEntryMappings(View view, IRI actionIri, ApiResponseEntry row, PageParameters params, QueryRef queryRef) {
         Template template = view.getTemplateForAction(actionIri);
         for (String mapping : view.getTemplateQueryMappings(actionIri)) {
             View.ActionMapping m = View.ActionMapping.parse(mapping);
             if (m == null) continue;
-            String value = row.get(m.column());
+            // The row is this action's own source of values, so a @result. source — the one
+            // value a column holds for the whole view — has nothing to add here: map the row's
+            // column directly instead. It resolves to nothing and hides the action.
+            String value = m.pageSource() ? resolvePageSource(m.column(), view, queryRef, null) : row.get(m.column());
             if (value == null || value.isBlank()) {
-                // Empty: hide the action only if the target is required.
-                if (m.rawKey() || template == null || template.isRequiredField(m.key())) return false;
+                // Empty: hide the action only if the target is required. A page source is
+                // always required — the page was meant to supply it, and an action built on
+                // a value that isn't there would open a form on nothing.
+                if (m.rawKey() || m.pageSource() || template == null || template.isRequiredField(m.key())) return false;
                 continue;
             }
-            params.set(m.rawKey() ? m.key() : "param_" + m.key(), value);
-            // A "!" in front of the field name says that what the action fills in is not the
-            // user's to change (issue #678): the field is shown with the value but locked.
-            if (m.locked()) params.add("locked", "param_" + m.key());
+            setMapped(params, m, value);
         }
         return true;
     }

--- a/src/main/java/com/knowledgepixels/nanodash/domain/Space.java
+++ b/src/main/java/com/knowledgepixels/nanodash/domain/Space.java
@@ -33,6 +33,9 @@ public class Space extends AbstractResourceWithProfile {
 
     private String label, rootNanopubId, type;
     private Nanopub rootNanopub = null;
+    // The lowest role tier whose definitions count for this space's parts, as declared in
+    // its root definition (gen:hasPartDefinitionTier); null = no restriction.
+    private IRI partDefinitionTier = null;
     // Space-ref identity (space IRI + root-definition NPID). Populated only by the
     // ref-aware get-spaces query (v3); null/empty with the pre-v3 query. See
     // docs/space-ref-identity.md. refRootId = the representative ref's root nanopub;
@@ -142,6 +145,7 @@ public class Space extends AbstractResourceWithProfile {
             altIds.clear();
             rootAdmins.clear();
             declaredTypes.clear();
+            partDefinitionTier = null;
             description = null;
             startDate = null;
             endDate = null;
@@ -621,6 +625,23 @@ public class Space extends AbstractResourceWithProfile {
         return altIds;
     }
 
+    /**
+     * The lowest role tier whose members' nanopublications count as definitions of this
+     * space's parts, as the rank {@link SpaceMemberRole#tierRank} gives it. Declared in the
+     * space's root definition with {@code gen:hasPartDefinitionTier} — which an admin signs,
+     * so the space itself says who may describe what it contains. Undeclared spaces keep
+     * Nanodash's original rule, every role-holder counting, which is
+     * {@link SpaceMemberRole#EVERYONE_RANK}: no filtering.
+     * <p>
+     * Read from the representative ref's root definition, like the rest of
+     * {@code readCoreData}; a {@code ?root=}-pinned page does not scope this.
+     *
+     * @return the minimum tier rank, or the "everyone" floor when none is declared
+     */
+    public int getPartDefinitionTierRank() {
+        return SpaceMemberRole.tierRank(partDefinitionTier);
+    }
+
     @Override
     public void forceRefresh(long waitMillis) {
         super.forceRefresh(waitMillis);
@@ -849,6 +870,8 @@ public class Space extends AbstractResourceWithProfile {
                     if (!rootAdmins.contains(obj)) rootAdmins.add(obj);
                 } else if (st.getPredicate().equals(NTEMPLATE.HAS_DEFAULT_PROVENANCE) && st.getObject() instanceof IRI obj) {
                     defaultProvenance = obj;
+                } else if (st.getPredicate().equals(KPXL_TERMS.HAS_PART_DEFINITION_TIER) && st.getObject() instanceof IRI obj) {
+                    partDefinitionTier = obj;
                 }
             }
         }

--- a/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ExplorePage.java
@@ -232,18 +232,7 @@ public class ExplorePage extends NanodashPage {
             // the same way ResourcePartPage does.
             Nanopub termNp = np;
             if (termNp == null && contextResource != null) {
-                QueryRef getDefQuery = new QueryRef(QueryApiAccess.GET_TERM_DEFINITIONS, "term", tempRef);
-                if (contextResource.getSpace() != null) {
-                    for (IRI userIri : contextResource.getSpace().getUsers()) {
-                        for (String pubkey : User.getUserData().getPubkeyHashes(userIri, true)) {
-                            getDefQuery.getParams().put("pubkey", pubkey);
-                        }
-                    }
-                } else {
-                    for (String pubkey : User.getUserData().getPubkeyHashes(Utils.vf.createIRI(contextId), true)) {
-                        getDefQuery.getParams().put("pubkey", pubkey);
-                    }
-                }
+                QueryRef getDefQuery = ViewDataFetcher.partDefinitionQueryRef(tempRef, contextId, contextResource);
                 ApiResponse getDefResp = ApiCache.retrieveResponseSync(getDefQuery, false);
                 if (getDefResp != null && !getDefResp.getData().isEmpty()) {
                     termNp = Utils.getAsNanopub(getDefResp.getData().iterator().next().get("np"));

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
@@ -2,13 +2,12 @@ package com.knowledgepixels.nanodash.page;
 
 import com.knowledgepixels.nanodash.ApiCache;
 import com.knowledgepixels.nanodash.NanodashPageRef;
-import com.knowledgepixels.nanodash.QueryApiAccess;
 import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.ViewDataFetcher;
 import com.knowledgepixels.nanodash.component.*;
 import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.domain.IndividualAgent;
 import com.knowledgepixels.nanodash.domain.MaintainedResource;
-import com.knowledgepixels.nanodash.domain.User;
 import com.knowledgepixels.nanodash.repository.MaintainedResourceRepository;
 import com.knowledgepixels.nanodash.repository.SpaceRepository;
 import org.apache.wicket.Component;
@@ -123,19 +122,7 @@ public class ResourcePartPage extends NanodashPage {
             }
         }
 
-        QueryRef getDefQuery = new QueryRef(QueryApiAccess.GET_TERM_DEFINITIONS, "term", id);
-        if (resourceWithProfile.getSpace() != null) {
-            for (IRI userIri : resourceWithProfile.getSpace().getUsers()) {
-                for (String pubkey : User.getUserData().getPubkeyHashes(userIri, true)) {
-                    getDefQuery.getParams().put("pubkey", pubkey);
-                }
-            }
-        } else {
-            for (String pubkey : User.getUserData().getPubkeyHashes(Utils.vf.createIRI(contextId), true)) {
-                getDefQuery.getParams().put("pubkey", pubkey);
-            }
-        }
-
+        QueryRef getDefQuery = ViewDataFetcher.partDefinitionQueryRef(id, contextId, resourceWithProfile);
         ApiResponse getDefResp = ApiCache.retrieveResponseSync(getDefQuery, false);
         if (getDefResp != null && !getDefResp.getData().isEmpty()) {
             nanopubId = getDefResp.getData().iterator().next().get("np");

--- a/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
+++ b/src/main/java/com/knowledgepixels/nanodash/vocabulary/KPXL_TERMS.java
@@ -210,4 +210,12 @@ public class KPXL_TERMS {
      */
     public static final IRI IS_VISIBLE_TO = VocabUtils.createIRI(NAMESPACE, "isVisibleTo");
 
+    /**
+     * Declared on a space: the lowest role tier whose members' nanopublications count as
+     * definitions of the space's parts. The object is one of the tier IRIs
+     * ({@link #MEMBER_ROLE} and friends), as with {@link #IS_VISIBLE_TO}. Absent means what
+     * Nanodash has always done: every role-holder of the space, observers included.
+     */
+    public static final IRI HAS_PART_DEFINITION_TIER = VocabUtils.createIRI(NAMESPACE, "hasPartDefinitionTier");
+
 }

--- a/src/test/java/com/knowledgepixels/nanodash/PostPublishRefreshTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/PostPublishRefreshTest.java
@@ -1,23 +1,32 @@
 package com.knowledgepixels.nanodash;
 
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
 import com.knowledgepixels.nanodash.utils.TestUtils;
 import com.knowledgepixels.nanodash.vocabulary.KPXL_TERMS;
 import org.eclipse.rdf4j.model.IRI;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubAlreadyFinalizedException;
 import org.nanopub.NanopubCreator;
+import org.nanopub.extra.services.QueryRef;
 import org.nanopub.vocabulary.NPX;
 
 import static com.knowledgepixels.nanodash.utils.TestUtils.vf;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 
 class PostPublishRefreshTest {
 
     private static final String SPACE_ID = "https://w3id.org/spaces/test";
+    private static final String PART_ID = "https://w3id.org/np/RAppppppppppppppppppppppppppppppppppppppppppp/a-talk";
+    private static final QueryRef PART_LOOKUP =
+            new QueryRef("RAddddddddddddddddddddddddddddddddddddddddddd/get-term-definitions", "term", PART_ID);
 
     private static Nanopub withType(IRI type) throws MalformedNanopubException, NanopubAlreadyFinalizedException {
         NanopubCreator creator = TestUtils.getNanopubCreator();
@@ -91,6 +100,54 @@ class PostPublishRefreshTest {
         assertFalse(PostPublishRefresh.changesPageStructure(TestUtils.createNanopub(), null));
         assertFalse(PostPublishRefresh.changesPageStructure(TestUtils.createNanopub(), ""));
         assertTrue(PostPublishRefresh.changesPageStructure(withType(KPXL_TERMS.SPACE), null));
+    }
+
+    private static Nanopub introducing(String iri) throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        creator.addAssertionStatement(vf.createIRI(iri), TestUtils.anyIri, TestUtils.anyIri);
+        TestUtils.fillProvenanceGraph(creator);
+        TestUtils.fillPubInfoGraph(creator);
+        creator.addPubinfoStatement(NPX.INTRODUCES, vf.createIRI(iri));
+        return creator.finalizeNanopub();
+    }
+
+    @Test
+    @DisplayName("a publication introducing the part being viewed invalidates the part's definition lookup")
+    void introducingThePartRefreshesItsLookup() throws Exception {
+        try (MockedStatic<AbstractResourceWithProfile> resources = mockStatic(AbstractResourceWithProfile.class);
+             MockedStatic<ViewDataFetcher> fetcher = mockStatic(ViewDataFetcher.class)) {
+            resources.when(() -> AbstractResourceWithProfile.get(SPACE_ID)).thenReturn(mock(AbstractResourceWithProfile.class));
+            fetcher.when(() -> ViewDataFetcher.partDefinitionQueryRef(anyString(), anyString(), any())).thenReturn(PART_LOOKUP);
+
+            assertEquals(PART_LOOKUP.getAsUrlString(),
+                    PostPublishRefresh.partDefinitionRefreshTarget(introducing(PART_ID), PART_ID, SPACE_ID));
+        }
+    }
+
+    @Test
+    @DisplayName("a publication introducing something else leaves the part's definition lookup alone")
+    void introducingSomethingElseRefreshesNothing() throws Exception {
+        assertNull(PostPublishRefresh.partDefinitionRefreshTarget(
+                introducing("https://w3id.org/np/RAppppppppppppppppppppppppppppppppppppppppppp/another-talk"),
+                PART_ID, SPACE_ID));
+    }
+
+    @Test
+    @DisplayName("no part in view, no part-definition lookup to invalidate")
+    void noPartMeansNoRefresh() throws Exception {
+        Nanopub np = introducing(PART_ID);
+        assertNull(PostPublishRefresh.partDefinitionRefreshTarget(np, "", SPACE_ID));
+        assertNull(PostPublishRefresh.partDefinitionRefreshTarget(np, null, SPACE_ID));
+        assertNull(PostPublishRefresh.partDefinitionRefreshTarget(np, PART_ID, ""));
+        // The resource's own page is not a part page.
+        assertNull(PostPublishRefresh.partDefinitionRefreshTarget(np, SPACE_ID, SPACE_ID));
+        assertNull(PostPublishRefresh.partDefinitionRefreshTarget(null, PART_ID, SPACE_ID));
+    }
+
+    @Test
+    @DisplayName("an unknown context resolves to no lookup rather than failing")
+    void unknownContextRefreshesNothing() throws Exception {
+        assertNull(PostPublishRefresh.partDefinitionRefreshTarget(introducing(PART_ID), PART_ID, "https://example.org/not-a-resource"));
     }
 
 }

--- a/src/test/java/com/knowledgepixels/nanodash/ViewDataFetcherTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ViewDataFetcherTest.java
@@ -1,5 +1,11 @@
 package com.knowledgepixels.nanodash;
 
+import com.knowledgepixels.nanodash.domain.AbstractResourceWithProfile;
+import com.knowledgepixels.nanodash.domain.Space;
+import com.knowledgepixels.nanodash.domain.User;
+import com.knowledgepixels.nanodash.domain.UserData;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.util.Values;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -9,11 +15,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.nanopub.extra.services.ApiResponse;
 import org.nanopub.extra.services.QueryRef;
 
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ViewDataFetcherTest {
@@ -72,6 +83,84 @@ class ViewDataFetcherTest {
                 apiCache.verify(() -> ApiCache.retrieveResponseSync(queryRef, false), times(2));
             }
         }
+    }
+
+    @Nested
+    @DisplayName("partDefinitionPubkeys")
+    class PartDefinitionPubkeysTest {
+
+        private static final IRI ADMIN = Values.iri("https://orcid.org/0000-0000-0000-0001");
+        private static final IRI MEMBER = Values.iri("https://orcid.org/0000-0000-0000-0002");
+        private static final IRI OBSERVER = Values.iri("https://orcid.org/0000-0000-0000-0003");
+        private static final String SPACE = "https://w3id.org/spaces/example";
+
+        /** A space with one member of each tier, restricted to the given minimum rank. */
+        private Space spaceWithTier(int minTierRank) {
+            Space space = mock(Space.class);
+            when(space.getPartDefinitionTierRank()).thenReturn(minTierRank);
+            when(space.getUsers()).thenReturn(List.of(ADMIN, MEMBER, OBSERVER));
+            lenient().when(space.userTier(ADMIN)).thenReturn(4);
+            lenient().when(space.userTier(MEMBER)).thenReturn(2);
+            lenient().when(space.userTier(OBSERVER)).thenReturn(1);
+            return space;
+        }
+
+        private AbstractResourceWithProfile contextOf(Space space) {
+            AbstractResourceWithProfile resource = mock(AbstractResourceWithProfile.class);
+            when(resource.getSpace()).thenReturn(space);
+            return resource;
+        }
+
+        private UserData userDataWithAKeyEach() {
+            UserData userData = mock(UserData.class);
+            when(userData.getPubkeyHashes(ADMIN, true)).thenReturn(List.of("keyAdmin"));
+            lenient().when(userData.getPubkeyHashes(MEMBER, true)).thenReturn(List.of("keyMember"));
+            lenient().when(userData.getPubkeyHashes(OBSERVER, true)).thenReturn(List.of("keyObserver"));
+            return userData;
+        }
+
+        @Test
+        @DisplayName("an undeclared space keeps every role-holder, observers included")
+        void undeclaredSpaceKeepsEveryone() {
+            // Built before the static stubbing: stubbing inside a thenReturn() argument
+            // leaves Mockito mid-stub.
+            UserData userData = userDataWithAKeyEach();
+            AbstractResourceWithProfile context = contextOf(spaceWithTier(0));
+            try (MockedStatic<User> user = mockStatic(User.class)) {
+                user.when(User::getUserData).thenReturn(userData);
+
+                assertEquals(List.of("keyAdmin", "keyMember", "keyObserver"),
+                        ViewDataFetcher.partDefinitionPubkeys(SPACE, context));
+            }
+        }
+
+        @Test
+        @DisplayName("a space declaring the member tier drops the observers")
+        void declaredTierDropsLowerTiers() {
+            UserData userData = userDataWithAKeyEach();
+            AbstractResourceWithProfile context = contextOf(spaceWithTier(2));
+            try (MockedStatic<User> user = mockStatic(User.class)) {
+                user.when(User::getUserData).thenReturn(userData);
+
+                assertEquals(List.of("keyAdmin", "keyMember"),
+                        ViewDataFetcher.partDefinitionPubkeys(SPACE, context));
+            }
+        }
+
+        @Test
+        @DisplayName("a user page uses the user's own keys, with no tier to apply")
+        void userContextUsesItsOwnKeys() {
+            AbstractResourceWithProfile resource = mock(AbstractResourceWithProfile.class);
+            when(resource.getSpace()).thenReturn(null);
+            UserData userData = mock(UserData.class);
+            when(userData.getPubkeyHashes(Values.iri(SPACE), true)).thenReturn(List.of("keyOwn"));
+            try (MockedStatic<User> user = mockStatic(User.class)) {
+                user.when(User::getUserData).thenReturn(userData);
+
+                assertEquals(List.of("keyOwn"), ViewDataFetcher.partDefinitionPubkeys(SPACE, resource));
+            }
+        }
+
     }
 
 }

--- a/src/test/java/com/knowledgepixels/nanodash/component/ViewActionMappingsPageSourceTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/ViewActionMappingsPageSourceTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.*;
 /**
  * Page sources in action mappings: a mapping whose source begins with {@code @} takes its
  * value from the page the view is on rather than from a result row. The case this exists
- * for is the {@code ♻️ override...} action of a view showing one nanopub's content, which
+ * for is the {@code ♻ override...} action of a view showing one nanopub's content, which
  * has to name that nanopub — a result action has no row to read it from.
  */
 class ViewActionMappingsPageSourceTest {
@@ -144,7 +144,7 @@ class ViewActionMappingsPageSourceTest {
              MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
             QueryResult result = resultActions(utils, grlc, td, SOURCE_NP, SOURCE_TEMPLATE);
 
-            PageParameters override = paramsOf(result, "♻️ override...");
+            PageParameters override = paramsOf(result, "♻ override...");
             assertNotNull(override);
             assertEquals(SOURCE_NP, override.get("override").toString());
             // The source's own template wins over the action's declared fallback, and stays
@@ -165,7 +165,7 @@ class ViewActionMappingsPageSourceTest {
              MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
             QueryResult result = resultActions(utils, grlc, td, SOURCE_NP, SOURCE_TEMPLATE);
 
-            assertTrue(paramsOf(result, "♻️ override...").get("param_resource").isNull());
+            assertTrue(paramsOf(result, "♻ override...").get("param_resource").isNull());
             assertTrue(paramsOf(result, "derive...").get("param_resource").isNull());
         }
     }
@@ -177,7 +177,7 @@ class ViewActionMappingsPageSourceTest {
              MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
             QueryResult result = resultActions(utils, grlc, td, null, SOURCE_TEMPLATE);
 
-            assertNull(paramsOf(result, "♻️ override..."));
+            assertNull(paramsOf(result, "♻ override..."));
             assertNull(paramsOf(result, "derive..."));
         }
     }
@@ -190,7 +190,7 @@ class ViewActionMappingsPageSourceTest {
              MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
             QueryResult result = resultActions(utils, grlc, td, "x:", SOURCE_TEMPLATE);
 
-            assertNull(paramsOf(result, "♻️ override..."));
+            assertNull(paramsOf(result, "♻ override..."));
         }
     }
 
@@ -205,7 +205,7 @@ class ViewActionMappingsPageSourceTest {
              MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
             QueryResult result = resultActions(utils, grlc, td, SOURCE_NP, null);
 
-            assertNull(paramsOf(result, "♻️ override..."));
+            assertNull(paramsOf(result, "♻ override..."));
             assertNotNull(paramsOf(result, "derive..."));
         }
     }
@@ -272,12 +272,12 @@ class ViewActionMappingsPageSourceTest {
             QueryResult result = resultActions(utils, grlc, td, null, null,
                     rows(SOURCE_NP, SOURCE_TEMPLATE, SOURCE_NP, SOURCE_TEMPLATE));
 
-            PageParameters override = paramsOf(result, "♻️ override result...");
+            PageParameters override = paramsOf(result, "♻ override result...");
             assertNotNull(override);
             assertEquals(SOURCE_NP, override.get("override").toString());
             assertEquals(SOURCE_TEMPLATE, override.get("template").toString());
             // It needs nothing from the page: the page-source action is gone here, this one is not.
-            assertNull(paramsOf(result, "♻️ override..."));
+            assertNull(paramsOf(result, "♻ override..."));
         }
     }
 
@@ -293,7 +293,7 @@ class ViewActionMappingsPageSourceTest {
             QueryResult result = resultActions(utils, grlc, td, null, null,
                     rows(SOURCE_NP, SOURCE_TEMPLATE, SOURCE_NP + "x", SOURCE_TEMPLATE));
 
-            assertNull(paramsOf(result, "♻️ override result..."));
+            assertNull(paramsOf(result, "♻ override result..."));
         }
     }
 
@@ -304,7 +304,7 @@ class ViewActionMappingsPageSourceTest {
              MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
             QueryResult result = resultActions(utils, grlc, td, null, null, new ApiResponse());
 
-            assertNull(paramsOf(result, "♻️ override result..."));
+            assertNull(paramsOf(result, "♻ override result..."));
         }
     }
 
@@ -337,7 +337,7 @@ class ViewActionMappingsPageSourceTest {
             QueryResult result = resultActions(utils, grlc, td, null, null,
                     rows(SOURCE_NP, SOURCE_TEMPLATE));
 
-            PageParameters params = paramsOf(result, "♻️ override templateless...");
+            PageParameters params = paramsOf(result, "♻ override templateless...");
             assertNotNull(params);
             assertEquals(SOURCE_TEMPLATE, params.get("template").toString());
             assertEquals(SOURCE_NP, params.get("override").toString());

--- a/src/test/java/com/knowledgepixels/nanodash/component/ViewActionMappingsPageSourceTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/ViewActionMappingsPageSourceTest.java
@@ -1,0 +1,360 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.knowledgepixels.nanodash.GrlcQuery;
+import com.knowledgepixels.nanodash.QueryResult;
+import com.knowledgepixels.nanodash.Utils;
+import com.knowledgepixels.nanodash.View;
+import com.knowledgepixels.nanodash.ViewDisplay;
+import com.knowledgepixels.nanodash.WicketApplication;
+import com.knowledgepixels.nanodash.template.Template;
+import com.knowledgepixels.nanodash.template.TemplateData;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.util.tester.WicketTester;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubImpl;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.ApiResponseEntry;
+import org.nanopub.extra.services.QueryRef;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Page sources in action mappings: a mapping whose source begins with {@code @} takes its
+ * value from the page the view is on rather than from a result row. The case this exists
+ * for is the {@code ♻️ override...} action of a view showing one nanopub's content, which
+ * has to name that nanopub — a result action has no row to read it from.
+ */
+class ViewActionMappingsPageSourceTest {
+
+    private static final String NP = "https://w3id.org/np/RAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPS1";
+    private static final String VIEW = NP + "/view";
+    private static final String VIEW_QUERY = "https://w3id.org/np/RAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq/get-presentation-details";
+    private static final String VIEW_QUERY_ID = "RAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq/get-presentation-details";
+    private static final String ACTION_TEMPLATE = "https://w3id.org/np/RAttttttttttttttttttttttttttttttttttttttttttt";
+    private static final IRI ENTRY_ACTION = SimpleValueFactory.getInstance().createIRI(NP + "/entryOverrideAction");
+
+    /** The nanopub the view is showing, and the template it was made with. */
+    private static final String SOURCE_NP = "https://w3id.org/np/RAmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm";
+    private static final String SOURCE_TEMPLATE = "https://w3id.org/np/RAssssssssssssssssssssssssssssssssssssssssssss";
+
+    private static final String RESOURCE = "https://w3id.org/np/RAmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm/a-talk";
+    private static final String CONTEXT = "https://w3id.org/spaces/example";
+
+    @BeforeEach
+    void setUp() {
+        new WicketTester(new WicketApplication());
+    }
+
+    /**
+     * Loads the fixture view with its query and action template stubbed out, and the
+     * nanopub the view shows resolving to a nanopub made with {@code sourceTemplate} (null
+     * for one that names no template).
+     */
+    private static View loadFixture(MockedStatic<Utils> utils, MockedStatic<GrlcQuery> grlc,
+            MockedStatic<TemplateData> td, String sourceTemplate) throws Exception {
+        Nanopub np = new NanopubImpl(new File("src/test/resources/np-page-source-view.trig"), RDFFormat.TRIG);
+        utils.when(() -> Utils.getAsNanopub(NP)).thenReturn(np);
+        utils.when(() -> Utils.getAsNanopub(SOURCE_NP)).thenReturn(mock(Nanopub.class));
+        utils.when(() -> Utils.menuEntryIconBodyHtml(anyString())).thenCallRealMethod();
+        GrlcQuery viewQuery = mock(GrlcQuery.class);
+        when(viewQuery.getQueryId()).thenReturn(VIEW_QUERY_ID);
+        grlc.when(() -> GrlcQuery.get(VIEW_QUERY)).thenReturn(viewQuery);
+        Template template = mock(Template.class);
+        when(template.getId()).thenReturn(ACTION_TEMPLATE);
+        TemplateData templateData = mock(TemplateData.class);
+        when(templateData.getTemplate(anyString())).thenReturn(template);
+        when(templateData.getTemplateId(any())).thenReturn(sourceTemplate == null ? null : Values.iri(sourceTemplate));
+        td.when(TemplateData::get).thenReturn(templateData);
+        return View.get(VIEW, false);
+    }
+
+    /** The query ref a page builds for this view, with or without the source nanopub. */
+    private static QueryRef queryRef(String sourceNp) {
+        Multimap<String, String> params = ArrayListMultimap.create();
+        params.put("resource", RESOURCE);
+        if (sourceNp != null) params.put("resourceNp", sourceNp);
+        return new QueryRef(VIEW_QUERY_ID, params);
+    }
+
+    /** A result whose rows carry the given values in the two action columns. */
+    private static ApiResponse rows(String... targetsAndTemplates) {
+        ApiResponse response = new ApiResponse();
+        response.setHeader(new String[]{"property", "override_target", "override_template"});
+        for (int i = 0; i < targetsAndTemplates.length; i += 2) {
+            ApiResponseEntry row = new ApiResponseEntry();
+            row.add("property", "a value");
+            if (targetsAndTemplates[i] != null) row.add("override_target", targetsAndTemplates[i]);
+            if (targetsAndTemplates[i + 1] != null) row.add("override_template", targetsAndTemplates[i + 1]);
+            response.add(row);
+        }
+        return response;
+    }
+
+    private static QueryResult resultFor(View view, QueryRef queryRef) {
+        return resultFor(view, queryRef, new ApiResponse());
+    }
+
+    private static QueryResult resultFor(View view, QueryRef queryRef, ApiResponse response) {
+        return new QueryResult("r", queryRef, response, new ViewDisplay(view)) {
+            @Override
+            protected void populateComponent() {
+            }
+        };
+    }
+
+    private static PageParameters paramsOf(QueryResult result, String label) {
+        for (QueryResult.MenuAction a : result.getMenuActions()) {
+            if (a.label().equals(label)) return a.params();
+        }
+        return null;
+    }
+
+    private static QueryResult resultActions(MockedStatic<Utils> utils, MockedStatic<GrlcQuery> grlc,
+            MockedStatic<TemplateData> td, String sourceNp, String sourceTemplate) throws Exception {
+        return resultActions(utils, grlc, td, sourceNp, sourceTemplate, new ApiResponse());
+    }
+
+    private static QueryResult resultActions(MockedStatic<Utils> utils, MockedStatic<GrlcQuery> grlc,
+            MockedStatic<TemplateData> td, String sourceNp, String sourceTemplate, ApiResponse response) throws Exception {
+        View view = loadFixture(utils, grlc, td, sourceTemplate);
+        QueryRef queryRef = queryRef(sourceNp);
+        QueryResult result = resultFor(view, queryRef, response);
+        ViewActionMappings.addResultActions(result, new ViewDisplay(view), queryRef, RESOURCE, CONTEXT, null, null);
+        return result;
+    }
+
+    @Test
+    void overrideActionOpensTheNanopubTheViewIsShowing() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            QueryResult result = resultActions(utils, grlc, td, SOURCE_NP, SOURCE_TEMPLATE);
+
+            PageParameters override = paramsOf(result, "♻️ override...");
+            assertNotNull(override);
+            assertEquals(SOURCE_NP, override.get("override").toString());
+            // The source's own template wins over the action's declared fallback, and stays
+            // resolved forward to its latest version.
+            assertEquals(SOURCE_TEMPLATE, override.get("template").toString());
+            assertEquals("latest", override.get("template-version").toString());
+        }
+    }
+
+    /**
+     * A fill mode takes every field from the source nanopub, so the target field is not
+     * passed on top of them — it could only overwrite a filled field of the same name.
+     */
+    @Test
+    void fillModeActionCarriesNoTargetField() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            QueryResult result = resultActions(utils, grlc, td, SOURCE_NP, SOURCE_TEMPLATE);
+
+            assertTrue(paramsOf(result, "♻️ override...").get("param_resource").isNull());
+            assertTrue(paramsOf(result, "derive...").get("param_resource").isNull());
+        }
+    }
+
+    @Test
+    void actionIsHiddenWhenThePageHasNoSourceNanopub() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            QueryResult result = resultActions(utils, grlc, td, null, SOURCE_TEMPLATE);
+
+            assertNull(paramsOf(result, "♻️ override..."));
+            assertNull(paramsOf(result, "derive..."));
+        }
+    }
+
+    /** "x:" is what ViewList fills in when the page has no nanopub: no source, no action. */
+    @Test
+    void sentinelSourceHidesTheAction() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            QueryResult result = resultActions(utils, grlc, td, "x:", SOURCE_TEMPLATE);
+
+            assertNull(paramsOf(result, "♻️ override..."));
+        }
+    }
+
+    /**
+     * A source nanopub naming no template leaves the override form nothing to open, so the
+     * action goes — while an action not asking for the template is unaffected.
+     */
+    @Test
+    void missingSourceTemplateHidesOnlyTheActionThatNeedsIt() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            QueryResult result = resultActions(utils, grlc, td, SOURCE_NP, null);
+
+            assertNull(paramsOf(result, "♻️ override..."));
+            assertNotNull(paramsOf(result, "derive..."));
+        }
+    }
+
+    /**
+     * Page sources are applied to the link; only the ordinary column mappings are handed to
+     * the form to apply against the query's rows.
+     */
+    @Test
+    void columnMappingsStillGoToTheFormWithoutThePageSources() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            QueryResult result = resultActions(utils, grlc, td, SOURCE_NP, SOURCE_TEMPLATE);
+
+            PageParameters mixed = paramsOf(result, "derive...");
+            assertEquals(SOURCE_NP, mixed.get("derive-a").toString());
+            assertEquals("series:series", mixed.get("values-from-query-mapping").toString());
+            assertEquals(queryRef(SOURCE_NP).getAsUrlString(), mixed.get("values-from-query").toString());
+        }
+    }
+
+    /** A page source is not a result column, so there is no column of its name to hide. */
+    @Test
+    void pageSourcesAreNotMappingSourceColumns() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            View view = loadFixture(utils, grlc, td, SOURCE_TEMPLATE);
+
+            assertEquals(java.util.Set.of("series", "override_target", "override_template"),
+                    view.getActionMappingSourceColumns());
+        }
+    }
+
+    @Test
+    void entryActionsResolvePageSourcesToo() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            View view = loadFixture(utils, grlc, td, SOURCE_TEMPLATE);
+            ApiResponseEntry row = mock(ApiResponseEntry.class);
+
+            PageParameters params = new PageParameters();
+            assertTrue(ViewActionMappings.applyEntryMappings(view, ENTRY_ACTION, row, params, queryRef(SOURCE_NP)));
+            assertEquals(SOURCE_NP, params.get("override").toString());
+
+            // Nothing to resolve it against: the action goes, rather than opening a form on
+            // no source.
+            PageParameters none = new PageParameters();
+            assertFalse(ViewActionMappings.applyEntryMappings(view, ENTRY_ACTION, row, none, queryRef(null)));
+        }
+    }
+
+    /**
+     * The other way round: the query decides which nanopub the action acts on, returns it as
+     * a column, and the action reads it back — no page-level resolution involved.
+     */
+    @Test
+    void resultColumnsCarryTheActionTarget() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            QueryResult result = resultActions(utils, grlc, td, null, null,
+                    rows(SOURCE_NP, SOURCE_TEMPLATE, SOURCE_NP, SOURCE_TEMPLATE));
+
+            PageParameters override = paramsOf(result, "♻️ override result...");
+            assertNotNull(override);
+            assertEquals(SOURCE_NP, override.get("override").toString());
+            assertEquals(SOURCE_TEMPLATE, override.get("template").toString());
+            // It needs nothing from the page: the page-source action is gone here, this one is not.
+            assertNull(paramsOf(result, "♻️ override..."));
+        }
+    }
+
+    /**
+     * A column that differs from row to row is a property of a row, not of the view, so a
+     * view-level action cannot speak for it.
+     */
+    @Test
+    void aColumnThatVariesAcrossRowsHidesTheAction() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            QueryResult result = resultActions(utils, grlc, td, null, null,
+                    rows(SOURCE_NP, SOURCE_TEMPLATE, SOURCE_NP + "x", SOURCE_TEMPLATE));
+
+            assertNull(paramsOf(result, "♻️ override result..."));
+        }
+    }
+
+    @Test
+    void emptyResultsHideTheAction() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            QueryResult result = resultActions(utils, grlc, td, null, null, new ApiResponse());
+
+            assertNull(paramsOf(result, "♻️ override result..."));
+        }
+    }
+
+    /**
+     * A column feeding an action is action data: it stays out of the rendered table, exactly
+     * like an ordinary mapping source.
+     */
+    @Test
+    void resultSourceColumnsAreHiddenFromTheTable() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            View view = loadFixture(utils, grlc, td, SOURCE_TEMPLATE);
+
+            assertEquals(java.util.Set.of("series", "override_target", "override_template"),
+                    view.getActionMappingSourceColumns());
+        }
+    }
+
+    /**
+     * An action whose template comes from the result needs no declared one — which is also
+     * what keeps it out of older Nanodash versions, whose only way to hide an action is a
+     * missing template. Publishing such a view ahead of the code release is then harmless.
+     */
+    @Test
+    void anActionCanTakeItsTemplateFromTheResultWithoutDeclaringOne() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            QueryResult result = resultActions(utils, grlc, td, null, null,
+                    rows(SOURCE_NP, SOURCE_TEMPLATE));
+
+            PageParameters params = paramsOf(result, "♻️ override templateless...");
+            assertNotNull(params);
+            assertEquals(SOURCE_TEMPLATE, params.get("template").toString());
+            assertEquals(SOURCE_NP, params.get("override").toString());
+        }
+    }
+
+    /** With neither a declared template nor one in the result, there is no form to open. */
+    @Test
+    void anActionWithNoTemplateAnywhereIsNotShown() throws Exception {
+        try (MockedStatic<Utils> utils = mockStatic(Utils.class);
+             MockedStatic<GrlcQuery> grlc = mockStatic(GrlcQuery.class);
+             MockedStatic<TemplateData> td = mockStatic(TemplateData.class)) {
+            QueryResult result = resultActions(utils, grlc, td, null, null,
+                    rows(SOURCE_NP, SOURCE_TEMPLATE));
+
+            assertNull(paramsOf(result, "broken..."));
+        }
+    }
+
+}

--- a/src/test/java/com/knowledgepixels/nanodash/component/ViewActionMappingsTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/ViewActionMappingsTest.java
@@ -41,7 +41,7 @@ class ViewActionMappingsTest {
     void emptyRequiredParamHidesAction() {
         View view = viewWith(List.of("col:foo"), templateWhereRequired("foo"));
         PageParameters params = new PageParameters();
-        assertFalse(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", ""), params));
+        assertFalse(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", ""), params, null));
         assertTrue(params.get("param_foo").isNull());
     }
 
@@ -49,7 +49,7 @@ class ViewActionMappingsTest {
     void emptyOptionalParamKeepsActionButSetsNothing() {
         View view = viewWith(List.of("col:foo"), templateWhereRequired(/* foo optional */));
         PageParameters params = new PageParameters();
-        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", ""), params));
+        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", ""), params, null));
         assertTrue(params.get("param_foo").isNull());
     }
 
@@ -57,7 +57,7 @@ class ViewActionMappingsTest {
     void presentParamIsSetAsParamPrefixed() {
         View view = viewWith(List.of("col:foo"), templateWhereRequired("foo"));
         PageParameters params = new PageParameters();
-        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", "v"), params));
+        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", "v"), params, null));
         assertEquals("v", params.get("param_foo").toString());
     }
 
@@ -65,14 +65,14 @@ class ViewActionMappingsTest {
     void rawKeyEmptyHidesAction() {
         View view = viewWith(List.of("col:@derive-a"), mock(Template.class));
         PageParameters params = new PageParameters();
-        assertFalse(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", null), params));
+        assertFalse(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", null), params, null));
     }
 
     @Test
     void rawKeySetWithoutParamPrefix() {
         View view = viewWith(List.of("col:@derive-a"), mock(Template.class));
         PageParameters params = new PageParameters();
-        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", "np123"), params));
+        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", "np123"), params, null));
         assertEquals("np123", params.get("derive-a").toString());
         assertTrue(params.get("param_derive-a").isNull());
     }
@@ -84,7 +84,7 @@ class ViewActionMappingsTest {
         when(e.get("b")).thenReturn("np");
         View view = viewWith(List.of("a:foo", "b:@derive-a"), templateWhereRequired("foo"));
         PageParameters params = new PageParameters();
-        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, e, params));
+        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, e, params, null));
         assertEquals("v1", params.get("param_foo").toString());
         assertEquals("np", params.get("derive-a").toString());
     }
@@ -96,14 +96,14 @@ class ViewActionMappingsTest {
         when(e.get("b")).thenReturn(""); // empty raw-key target
         View view = viewWith(List.of("a:foo", "b:@derive-a"), templateWhereRequired("foo"));
         PageParameters params = new PageParameters();
-        assertFalse(ViewActionMappings.applyEntryMappings(view, ACTION, e, params));
+        assertFalse(ViewActionMappings.applyEntryMappings(view, ACTION, e, params, null));
     }
 
     @Test
     void noMappingsRendersAction() {
         View view = viewWith(List.of(), mock(Template.class));
         PageParameters params = new PageParameters();
-        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, mock(ApiResponseEntry.class), params));
+        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, mock(ApiResponseEntry.class), params, null));
     }
 
 
@@ -116,7 +116,7 @@ class ViewActionMappingsTest {
     void lockMarkerFillsTheFieldAndLocksIt() {
         View view = viewWith(List.of("col:!foo"), templateWhereRequired("foo"));
         PageParameters params = new PageParameters();
-        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", "v"), params));
+        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", "v"), params, null));
         assertEquals("v", params.get("param_foo").toString());
         assertEquals("param_foo", params.get("locked").toString());
     }
@@ -132,7 +132,7 @@ class ViewActionMappingsTest {
         when(e.get("c2")).thenReturn("v2");
         when(e.get("c3")).thenReturn("v3");
         PageParameters params = new PageParameters();
-        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, e, params));
+        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, e, params, null));
         assertEquals(List.of("param_foo", "param_baz"),
                 params.getValues("locked").stream().map(Object::toString).toList());
         assertEquals("v2", params.get("param_bar").toString());
@@ -146,7 +146,7 @@ class ViewActionMappingsTest {
     void lockMarkerIsStrippedFromTheFieldName() {
         View view = viewWith(List.of("col:!foo"), templateWhereRequired("foo"));
         PageParameters params = new PageParameters();
-        assertFalse(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", ""), params));
+        assertFalse(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", ""), params, null));
         assertTrue(params.get("param_foo").isNull());
         assertTrue(params.get("locked").isNull());
     }
@@ -159,7 +159,7 @@ class ViewActionMappingsTest {
     void lockMarkerDoesNotApplyToRawKeys() {
         View view = viewWith(List.of("col:@derive-a"), templateWhereRequired());
         PageParameters params = new PageParameters();
-        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", "np123"), params));
+        assertTrue(ViewActionMappings.applyEntryMappings(view, ACTION, row("col", "np123"), params, null));
         assertTrue(params.get("locked").isNull());
     }
 

--- a/src/test/resources/np-page-source-view.trig
+++ b/src/test/resources/np-page-source-view.trig
@@ -1,0 +1,74 @@
+@prefix this: <https://w3id.org/np/RAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPS1> .
+@prefix sub: <https://w3id.org/np/RAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPS1/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix gen: <https://w3id.org/kpxl/gen/terms/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+sub:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion sub:assertion;
+    np:hasProvenance sub:provenance;
+    np:hasPublicationInfo sub:pubinfo .
+}
+
+# A tabular view of one nanopub's content, with actions that map page sources: values the
+# page supplies rather than a result row. The override action opens the nanopub the view is
+# showing; the mixed action combines a page source with an ordinary column mapping; the
+# entry action does the same per row.
+sub:assertion {
+  sub:view a gen:ResourceView, gen:TabularView;
+    rdfs:label "presentation-details-view";
+    dct:title "Presentation Details";
+    gen:hasViewQuery <https://w3id.org/np/RAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq/get-presentation-details>;
+    gen:hasViewQueryTargetField "resource";
+    gen:hasViewAction sub:overrideAction, sub:mixedAction, sub:entryOverrideAction, sub:resultOverrideAction,
+      sub:templatelessAction, sub:noTemplateAtAllAction .
+
+  sub:overrideAction a gen:ViewResultAction;
+    rdfs:label "♻️ override";
+    gen:hasActionTemplate <https://w3id.org/np/RAttttttttttttttttttttttttttttttttttttttttttt>;
+    gen:hasActionTemplateTargetField "void";
+    gen:hasActionTemplatePartField "void";
+    gen:hasActionTemplateQueryMapping "@sourceNp:@override @sourceNpTemplate:@template" .
+
+  sub:mixedAction a gen:ViewResultAction;
+    rdfs:label "derive";
+    gen:hasActionTemplate <https://w3id.org/np/RAttttttttttttttttttttttttttttttttttttttttttt>;
+    gen:hasActionTemplateQueryMapping "@sourceNp:@derive-a series:series" .
+
+  sub:resultOverrideAction a gen:ViewResultAction;
+    rdfs:label "♻️ override result";
+    gen:hasActionTemplate <https://w3id.org/np/RAttttttttttttttttttttttttttttttttttttttttttt>;
+    gen:hasActionTemplateQueryMapping "@result.override_target:@override @result.override_template:@template" .
+
+  # No gen:hasActionTemplate: the template comes from the result. Older Nanodash versions
+  # skip this action instead of offering a button that would open an empty form.
+  sub:templatelessAction a gen:ViewResultAction;
+    rdfs:label "♻️ override templateless";
+    gen:hasActionTemplateQueryMapping "@result.override_target:@override @result.override_template:@template" .
+
+  # Neither a declared template nor one from the data: nothing to open.
+  sub:noTemplateAtAllAction a gen:ViewResultAction;
+    rdfs:label "broken";
+    gen:hasActionTemplateQueryMapping "@result.override_target:@override" .
+
+  sub:entryOverrideAction a gen:ViewEntryAction;
+    rdfs:label "♻️ override entry";
+    gen:hasActionTemplate <https://w3id.org/np/RAttttttttttttttttttttttttttttttttttttttttttt>;
+    gen:hasActionTemplateQueryMapping "@sourceNp:@override" .
+}
+
+sub:provenance {
+  sub:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+sub:pubinfo {
+  this: dct:created "2026-09-09T09:00:00.000Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    npx:embeds sub:view .
+}

--- a/src/test/resources/np-page-source-view.trig
+++ b/src/test/resources/np-page-source-view.trig
@@ -30,7 +30,7 @@ sub:assertion {
       sub:templatelessAction, sub:noTemplateAtAllAction .
 
   sub:overrideAction a gen:ViewResultAction;
-    rdfs:label "♻️ override";
+    rdfs:label "♻ override";
     gen:hasActionTemplate <https://w3id.org/np/RAttttttttttttttttttttttttttttttttttttttttttt>;
     gen:hasActionTemplateTargetField "void";
     gen:hasActionTemplatePartField "void";
@@ -42,14 +42,14 @@ sub:assertion {
     gen:hasActionTemplateQueryMapping "@sourceNp:@derive-a series:series" .
 
   sub:resultOverrideAction a gen:ViewResultAction;
-    rdfs:label "♻️ override result";
+    rdfs:label "♻ override result";
     gen:hasActionTemplate <https://w3id.org/np/RAttttttttttttttttttttttttttttttttttttttttttt>;
     gen:hasActionTemplateQueryMapping "@result.override_target:@override @result.override_template:@template" .
 
   # No gen:hasActionTemplate: the template comes from the result. Older Nanodash versions
   # skip this action instead of offering a button that would open an empty form.
   sub:templatelessAction a gen:ViewResultAction;
-    rdfs:label "♻️ override templateless";
+    rdfs:label "♻ override templateless";
     gen:hasActionTemplateQueryMapping "@result.override_target:@override @result.override_template:@template" .
 
   # Neither a declared template nor one from the data: nothing to open.
@@ -58,7 +58,7 @@ sub:assertion {
     gen:hasActionTemplateQueryMapping "@result.override_target:@override" .
 
   sub:entryOverrideAction a gen:ViewEntryAction;
-    rdfs:label "♻️ override entry";
+    rdfs:label "♻ override entry";
     gen:hasActionTemplate <https://w3id.org/np/RAttttttttttttttttttttttttttttttttttttttttttt>;
     gen:hasActionTemplateQueryMapping "@sourceNp:@override" .
 }


### PR DESCRIPTION
Started from a concrete question: can any member of a space use `♻️ override...` on the **Presentation Details** view of a presentation page, e.g. [More Than Data…](https://nanodash.net/part?id=https%3A%2F%2Fw3id.org%2Fnp%2FRAmhmI3qZ-bL-5Gcph5a35TGoUY-DQeWBOEvIWxZgJhN8%2Fmore-than-data-making-knowledge-graphs-work-toge&context=https%3A%2F%2Fw3id.org%2Fspaces%2Fsemantics%2F2026-eu)? A view-level action had no way to name the nanopublication it acts on.

## Page sources in action mappings

A mapping source written with a leading `@` takes its value from the view rather than from a result row:

| Source | Resolves to |
| --- | --- |
| `@result.<column>` | the value that column holds across the view's own result — one value for the whole view, so a column that varies from row to row hides the action |
| `@sourceNp` | the nanopublication the *page* resolved (the query's `…Np` parameter) |
| `@sourceNpTemplate` | the template that nanopublication was made with |

`@result.` is the interesting one: it lets the **query** decide which nanopublication the action acts on — it resolves it, returns it as a column, and the action reads it back. That also moves the rule for *which* nanopublication counts into the view's own query, i.e. into RDF, next to the `gen:isVisibleTo` that says who may act on it.

Rules: an unresolvable page source hides the action (as an empty raw key already does); an action mapping a fill-mode key gets no target-field parameter, since the source supplies every field and the page's resource on top could only overwrite one of them; `@result.` columns are hidden from the table like any other mapping source.

## Publishing a view ahead of its code

An action may now omit `gen:hasActionTemplate` when a mapping supplies `@template`. A missing template is the one condition under which *every* Nanodash version skips an action, so a view using page sources can be published before this is released: older instances show no button instead of one that opens an empty form. Together with naming the action columns `…_label` (every renderer skips those), the three nanopublications below were published today and are invisible on current deployments.

## What the part page shows

Two fixes to the other half of the same question — which nanopublication a part page shows:

- **`gen:hasPartDefinitionTier`**: a space can declare, in its root definition, the lowest role tier whose nanopublications count as definitions of its parts. Read off the space's own root nanopub (no materialization needed) and applied in the new `ViewDataFetcher.partDefinitionPubkeys` — now the single list behind the part page, its About tab and term resolution in the explore view, which each built their own copy and could disagree. **Undeclared spaces keep the original rule** (every role-holder, observers included), so nothing moves until a space opts in.
- **Post-publish refresh**: a publication that introduces the part being viewed invalidates that part's definition lookup. Without it the page keeps showing the old nanopublication, because every view query named for refresh is keyed on it.

## Published nanopublications (already live)

| | artifact | supersedes |
| --- | --- | --- |
| view-creation template | [`RApNBmFs…`](https://w3id.org/np/RApNBmFsH3uf4RIPM6TR-iFJ2geOP3uTmSFhlPZ0eikg4) | `RAnMcenHc…` — `gen:hasActionTemplate` → optional |
| query `get-presentation-details` | [`RAi2kCEU…`](https://w3id.org/np/RAi2kCEUSclv_5X5dOcNfdkNj1sHDGlRHeAIkQrfwaEZM) | `RA-TnHdB…` — resolves its own nanopublication, member tier and up |
| view `presentation-details-view` | [`RAQnpSKI…`](https://w3id.org/np/RAQnpSKI9rK-QcTpAe7iO6Wx5Xdmtj1Fj8xQijtMgPFk4) | `RAQ7Pve14…` — `♻️ override...`, `gen:isVisibleTo gen:MemberRole` |

The query was verified through the live grlc API (`_nanopub_trig`): content columns byte-identical to the previous version for the same page, and the tier gate verified to gate (same presentation against a space its signer holds no role in → no rows).

## Testing

`ViewActionMappingsPageSourceTest` (14) covers the sources, the hiding rules, the fill-mode target-field suppression and the templateless action; `ViewDataFetcherTest.PartDefinitionPubkeysTest` (3) the declared tier; four new `PostPublishRefreshTest` cases the refresh rule. Full suite: 1399 passing.

Docs: `magic-query-params.md` (page sources, publishing ahead of the code), `role-specific-views.md` (the tier ladder applied to content), `fill-modes.md`.

## Known seam

The view's query states member-upward in its SPARQL while a space would state it in its root definition — two declarations, because a query can only read what nanopub-query materializes into the spaces state. Worth an upstream issue rather than a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3Tn5HogvoaEB7xaxF31NF