### PR TITLE
feat(views): let a paragraph link to its own part page

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
+++ b/src/main/java/com/knowledgepixels/nanodash/QueryResult.java
@@ -300,6 +300,26 @@ public abstract class QueryResult extends Panel {
     }
 
     /**
+     * A page reference for a result row's own resource part, reached from this view: the
+     * part page of the given IRI under this view's navigation context, carrying the given
+     * label as the page title where the part declares none, plus the part this page was
+     * reached under so the target's back-link can name it (issue #697). Only usable at
+     * render time (needs the page).
+     *
+     * @param partId the row's resource IRI
+     * @param label  the label to show for it, or null to fall back to its short name
+     * @return the page reference, or null when no navigation context is known (a part
+     * page cannot resolve a part without its maintaining resource)
+     */
+    protected NanodashPageRef partPageRef(String partId, String label) {
+        String ctx = renderContextId();
+        NanodashPageRef ref = NavigationContext.getPartPageRef(partId, label, ctx);
+        if (ref == null) return null;
+        NavigationContext.withPart(ref.getParameters(), renderPartId(), renderPartLabel(), ctx);
+        return ref;
+    }
+
+    /**
      * The navigation parameters to append to a hand-built app-internal link in a result
      * cell: the {@code &context=...} suffix, plus the resource part the page was reached
      * under where that applies (issue #697). Empty string when no context is set. Only

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.html
@@ -16,12 +16,12 @@
     <span wicket:id="buttons" class="buttons"></span>
   </div>
   <div wicket:id="paragraphs-container">
-    <div wicket:id="paragraphs">
+    <div wicket:id="paragraphs" class="paragraph-block">
       <div wicket:id="header" class="paragraph-header">
         <h5 wicket:id="heading"><span wicket:id="title">[title]</span><a wicket:id="title-link" class="paragraph-title-link"><span wicket:id="title-link-label">[title]</span></a></h5>
         <span class="buttons"><span wicket:id="pnp"></span></span>
       </div>
-      <p wicket:id="content" class="paragraph-content">[content]</p>
+      <div wicket:id="content" class="paragraph-content">[content]</div>
     </div>
     <p wicket:id="no-records" class="no-records-note">(nothing found)</p>
   </div>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.html
@@ -18,7 +18,7 @@
   <div wicket:id="paragraphs-container">
     <div wicket:id="paragraphs">
       <div wicket:id="header" class="paragraph-header">
-        <h5 wicket:id="title">[title]</h5>
+        <h5 wicket:id="heading"><span wicket:id="title">[title]</span><a wicket:id="title-link" class="paragraph-title-link"><span wicket:id="title-link-label">[title]</span></a></h5>
         <span class="buttons"><span wicket:id="pnp"></span></span>
       </div>
       <p wicket:id="content" class="paragraph-content">[content]</p>

--- a/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.java
+++ b/src/main/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraph.java
@@ -1,6 +1,7 @@
 package com.knowledgepixels.nanodash.component;
 
 import com.knowledgepixels.nanodash.FilteredQueryResultDataProvider;
+import com.knowledgepixels.nanodash.NanodashPageRef;
 import com.knowledgepixels.nanodash.NavigationContext;
 import com.knowledgepixels.nanodash.QueryResult;
 import com.knowledgepixels.nanodash.QueryResultDataProvider;
@@ -94,19 +95,41 @@ public class QueryResultPlainParagraph extends QueryResult {
             protected void populateItem(ListItem<ApiResponseEntry> item) {
                 String title = item.getModelObject().get("title");
                 boolean hasTitle = title != null && !title.isBlank();
+                // A row whose query names the paragraph's own IRI (a "paragraph" column)
+                // gets a way to its part page (issue #701): the heading becomes a link and
+                // the row menu gains an "open" entry. The body stays prose, never a link.
+                // Without a navigation context there is no part page to link to, so the
+                // heading stays plain.
+                String paragraphId = item.getModelObject().get("paragraph");
+                NanodashPageRef partRef = paragraphId != null && Utils.isUriValue(paragraphId)
+                        ? partPageRef(paragraphId, hasTitle ? title : null) : null;
                 // For a title-less paragraph (e.g. a space description) hide the
                 // empty heading and float the source link into the corner (via
                 // the "no-title" class) so the header takes no vertical line.
                 WebMarkupContainer header = new WebMarkupContainer("header");
                 if (!hasTitle) header.add(new AttributeAppender("class", " no-title"));
-                header.add(new Label("title", title).setVisible(hasTitle));
-                // The view's entry actions, followed by the former "^" source link as a
+                WebMarkupContainer heading = new WebMarkupContainer("heading");
+                heading.setVisible(hasTitle);
+                heading.add(new Label("title", title).setVisible(partRef == null));
+                if (partRef == null) {
+                    heading.add(new WebMarkupContainer("title-link").setVisible(false));
+                } else {
+                    heading.add(partRef.createComponent("title-link", title));
+                }
+                header.add(heading);
+                // The view's entry actions, followed by the "open" entry to the row's own
+                // part page where there is one, and the former "^" source link as a
                 // "source" entry, bundled into a per-paragraph dropdown as in the other
                 // view types.
                 List<AbstractLink> links = ViewActionMappings.buildEntryActionLinks(viewDisplay.getView(),
                         item.getModelObject(), queryRef,
                         resourceWithProfile != null ? resourceWithProfile : pageResource,
                         contextId, partId, refRoot, postPublishTab);
+                if (partRef != null) {
+                    BookmarkablePageLink<Void> openLink = new BookmarkablePageLink<>("link", partRef.getPageClass(), partRef.getParameters());
+                    openLink.setBody(Model.of("<span class=\"actionmenu-icon\">📄</span>open")).setEscapeModelStrings(false);
+                    links.add(openLink);
+                }
                 String npId = item.getModelObject().get("np");
                 if (npId != null && !npId.isBlank()) {
                     BookmarkablePageLink<Void> sourceLink = new BookmarkablePageLink<>("link", ExplorePage.class,

--- a/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/ResourcePartPage.java
@@ -102,6 +102,15 @@ public class ResourcePartPage extends NanodashPage {
         }
     }
 
+    /**
+     * Whether the given predicate is schema.org's {@code title}, in either of its
+     * spellings.
+     */
+    static boolean isSchemaTitle(IRI predicate) {
+        String p = predicate.stringValue();
+        return p.equals("http://schema.org/title") || p.equals("https://schema.org/title");
+    }
+
     public ResourcePartPage(final PageParameters parameters) {
         super(parameters);
 
@@ -128,16 +137,26 @@ public class ResourcePartPage extends NanodashPage {
             nanopubId = getDefResp.getData().iterator().next().get("np");
 
             Nanopub nanopub = Utils.getAsNanopub(nanopubId);
+            boolean hasRdfsLabel = false;
+            String schemaTitle = null;
             for (Statement st : nanopub.getAssertion()) {
                 if (!st.getSubject().stringValue().equals(id)) {
                     continue;
                 }
                 if (st.getPredicate().equals(RDFS.LABEL)) {
                     label = st.getObject().stringValue();
+                    hasRdfsLabel = true;
+                } else if (isSchemaTitle(st.getPredicate())) {
+                    schemaTitle = st.getObject().stringValue();
                 }
                 if (st.getPredicate().equals(RDF.TYPE) && st.getObject() instanceof IRI objIri) {
                     classes.add(objIri);
                 }
+            }
+            // Parts declared with a title rather than a label (paragraphs, say) are still
+            // named after it instead of after their IRI's last segment (issue #701).
+            if (!hasRdfsLabel && schemaTitle != null && !schemaTitle.isBlank()) {
+                label = schemaTitle;
             }
         } else {
             nanopubId = null;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2880,16 +2880,37 @@ div.navigator .goto a[disabled] {
   margin-left: 0;
 }
 
+/* Paragraph sections: extra room before a heading, a regular paragraph gap after
+   it. The content is a div (not a p) because paragraph HTML carries its own <p>
+   elements, which cannot nest inside a p and used to leave stray empty paragraphs
+   with uneven gaps. */
 .paragraph-header {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  margin-top: 8px;
+  margin-top: 1.8em;
   margin-bottom: 0;
 }
 
-.paragraph-header + p {
-  margin-top: 8px;
+.paragraph-block:first-child .paragraph-header {
+  margin-top: 1.25em;
+}
+
+/* A regular paragraph gap (1em) below the heading text. The heading row itself
+   runs about 4px below the text, because the row menu's chevron button is taller
+   than the heading's line box, so the margin is set from the row's edge accordingly. */
+.paragraph-header + .paragraph-content {
+  margin-top: 12px;
+}
+
+/* Inner paragraphs keep their own 1em gaps between each other; the block's
+   outer margins come from the header and the content container instead. */
+.paragraph-content > :first-child {
+  margin-top: 0;
+}
+
+.paragraph-content > :last-child {
+  margin-bottom: 0;
 }
 
 /* Title-less paragraph: float the source link to the top-right corner so it
@@ -2899,7 +2920,7 @@ div.navigator .goto a[disabled] {
   margin: 0 0 0 12px;
 }
 
-.paragraph-header.no-title + p {
+.paragraph-header.no-title + .paragraph-content {
   margin-top: 8px;
 }
 

--- a/src/test/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraphTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraphTest.java
@@ -85,8 +85,7 @@ class QueryResultPlainParagraphTest {
     @Test
     void bodyIsNotALink() {
         String html = render(rows(true), CONTEXT);
-        assertTrue(html.contains("<p wicket:id=\"content\" class=\"paragraph-content\"><p>Some prose about placeholders.</p></p>")
-                || html.contains("class=\"paragraph-content\"><p>Some prose about placeholders.</p></p>"), html);
+        assertTrue(html.contains("<div class=\"paragraph-content\"><p>Some prose about placeholders.</p></div>"), html);
     }
 
     @Test

--- a/src/test/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraphTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/component/QueryResultPlainParagraphTest.java
@@ -1,0 +1,108 @@
+package com.knowledgepixels.nanodash.component;
+
+import com.knowledgepixels.nanodash.GrlcQuery;
+import com.knowledgepixels.nanodash.ViewDisplay;
+import com.knowledgepixels.nanodash.WicketApplication;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.nanopub.extra.services.ApiResponse;
+import org.nanopub.extra.services.ApiResponseEntry;
+import org.nanopub.extra.services.QueryRef;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * A paragraph whose row names its own IRI (a {@code paragraph} column) links to its
+ * part page from the heading and from the row menu; the body stays prose (issue #701).
+ */
+class QueryResultPlainParagraphTest {
+
+    private static final String QUERY_ID = "RAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq/get-paragraphs";
+    private static final String CONTEXT = "https://w3id.org/spaces/example/r/docs";
+    private static final String PARAGRAPH = "https://w3id.org/np/RApppppppppppppppppppppppppppppppppppppppppp/paragraph";
+
+    private WicketTester tester;
+    private MockedStatic<GrlcQuery> grlc;
+
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester(new WicketApplication());
+        GrlcQuery query = mock(GrlcQuery.class);
+        when(query.getLabel()).thenReturn("Paragraphs");
+        grlc = mockStatic(GrlcQuery.class);
+        grlc.when(() -> GrlcQuery.get(any(QueryRef.class))).thenReturn(query);
+    }
+
+    @AfterEach
+    void tearDown() {
+        grlc.close();
+        tester.destroy();
+    }
+
+    private static ApiResponse rows(boolean withParagraphColumn) {
+        ApiResponse response = new ApiResponse();
+        response.setHeader(withParagraphColumn
+                ? new String[]{"paragraph", "title", "content"}
+                : new String[]{"title", "content"});
+        ApiResponseEntry row = new ApiResponseEntry();
+        if (withParagraphColumn) row.add("paragraph", PARAGRAPH);
+        row.add("title", "Placeholder structure");
+        row.add("content", "<p>Some prose about placeholders.</p>");
+        response.add(row);
+        return response;
+    }
+
+    private String render(ApiResponse response, String contextId) {
+        QueryResultPlainParagraph component = new QueryResultPlainParagraph("r", new QueryRef(QUERY_ID), response, new ViewDisplay(10));
+        component.setContextId(contextId);
+        tester.startComponentInPage(component);
+        return tester.getLastResponseAsString();
+    }
+
+    @Test
+    void headingLinksToThePartPageUnderTheContext() {
+        String html = render(rows(true), CONTEXT);
+        assertTrue(html.contains("class=\"paragraph-title-link\""), html);
+        assertTrue(html.contains("/part?id=" + PARAGRAPH + "&amp;context=" + CONTEXT), html);
+        assertTrue(html.contains("label=Placeholder+structure"), html);
+        assertTrue(html.contains(">Placeholder structure</span></a></h5>"), html);
+    }
+
+    @Test
+    void rowMenuOffersAnOpenEntry() {
+        String html = render(rows(true), CONTEXT);
+        assertTrue(html.contains("</span>open</a>"), html);
+    }
+
+    @Test
+    void bodyIsNotALink() {
+        String html = render(rows(true), CONTEXT);
+        assertTrue(html.contains("<p wicket:id=\"content\" class=\"paragraph-content\"><p>Some prose about placeholders.</p></p>")
+                || html.contains("class=\"paragraph-content\"><p>Some prose about placeholders.</p></p>"), html);
+    }
+
+    @Test
+    void withoutAParagraphColumnTheHeadingStaysPlain() {
+        String html = render(rows(false), CONTEXT);
+        assertFalse(html.contains("paragraph-title-link"), html);
+        assertFalse(html.contains("</span>open</a>"), html);
+        assertTrue(html.contains(">Placeholder structure</span></h5>"), html);
+    }
+
+    @Test
+    void withoutANavigationContextThereIsNoPartPageToLinkTo() {
+        String html = render(rows(true), null);
+        assertFalse(html.contains("paragraph-title-link"), html);
+        assertFalse(html.contains("</span>open</a>"), html);
+        assertTrue(html.contains(">Placeholder structure</span></h5>"), html);
+    }
+
+}


### PR DESCRIPTION
## Summary

Implements #701: a `gen:PlainParagraphView` row can now reach its own part page.

- When a row's query projects a **`paragraph`** column holding the row's IRI, the heading renders as a link to that resource's part page under the view's navigation context, and the per-row menu gains a "📄 open" entry ahead of "↗︎ source". The body stays prose.
- Rows without the column, and views on a page without navigation context, render exactly as before, so existing paragraph-type views are unaffected.
- The link goes through the existing part-page reference from #697 (new protected `QueryResult.partPageRef`) rather than `NanodashLink`, because paragraph IRIs live outside the maintaining resource's namespace and would otherwise bounce through the explore page's forward-to-part check.
- `ResourcePartPage` falls back to `schema:title` (http and https) when the part declares no `rdfs:label`, so paragraph part pages are titled after their title instead of "paragraph".

## Column convention

A fixed `paragraph` column, matching how the component already reads `title`, `content` and `np` by name, and matching the class `gen:Paragraph` and the variable the docs query already binds.

## Data side (already live)

- Query `RAbOBFWFpJ0K7ShUeAW7gfhAJiIC1CHBGdSPkL5T-3mko/get-docs-paragraphs` supersedes the previous head and projects `?paragraph`.
- View `RAtqP5IOQHHbi2GJqkXDjlur7oRgOi8TR6Yc9qkaTRnL8/docs-wiki-view` supersedes the previous head and points at that query.

Until this is deployed the running instance ignores the extra column.

## Test plan

- [x] New `QueryResultPlainParagraphTest`: linked heading with id/context/label, menu entry, unlinked body, no-op without column, no-op without context
- [x] Full test suite passes
- [ ] After deploy: open a docs topic page, click a paragraph heading, check the part page title and back-crumb

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3Tn5HogvoaEB7xaxF31NF
