### PR TITLE
feat(pages): describe pages to search engines and link previews

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.html
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.html
@@ -2,7 +2,7 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
 <wicket:head>
-  <title>nanodash</title>
+  <title wicket:id="pagetitle">Nanodash — browse and publish nanopublications</title>
 </wicket:head>
 <wicket:extend>
 

--- a/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/HomePage.java
@@ -31,6 +31,8 @@ public class HomePage extends NanodashPage {
      */
     public static final String MOUNT_PATH = "/";
 
+    private static final String PAGE_TITLE = "Nanodash — browse and publish nanopublications";
+
     /**
      * {@inheritDoc}
      */
@@ -59,6 +61,7 @@ public class HomePage extends NanodashPage {
         super(parameters);
 
         add(new TitleBar("titlebar", this));
+        add(new Label("pagetitle", PAGE_TITLE));
         final NanodashSession session = NanodashSession.get();
         String v = WicketApplication.getThisVersion();
         String lv = WicketApplication.getLatestVersion();

--- a/src/main/java/com/knowledgepixels/nanodash/page/NanodashPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/NanodashPage.java
@@ -12,12 +12,14 @@ import com.knowledgepixels.nanodash.chat.RemoteAgentService;
 import com.knowledgepixels.nanodash.component.ClaudeChatPanel;
 import com.knowledgepixels.nanodash.domain.*;
 import com.knowledgepixels.nanodash.template.TemplateData;
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AbstractAjaxTimerBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.head.CssHeaderItem;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.head.JavaScriptReferenceHeaderItem;
+import org.apache.wicket.markup.head.MetaDataHeaderItem;
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.cycle.RequestCycle;
@@ -47,6 +49,18 @@ public abstract class NanodashPage extends WebPage {
     private long state = 0L;
 
     private static JavaScriptResourceReference nanodashJs = new JavaScriptResourceReference(WicketApplication.class, "script/nanodash.js");
+
+    private static final String SITE_NAME = "Nanodash";
+
+    private static final String SITE_META_DESCRIPTION =
+            "Nanodash is a web client to browse and publish nanopublications: small, "
+            + "self-contained and citable units of scientific knowledge.";
+
+    private static final String PAGE_TITLE_ID = "pagetitle";
+
+    private static final int MAX_META_DESCRIPTION_LENGTH = 300;
+
+    private String metaDescription = SITE_META_DESCRIPTION;
 
     /**
      * Returns the mount path for this page.
@@ -308,6 +322,85 @@ public abstract class NanodashPage extends WebPage {
     }
 
     /**
+     * The description search engines and link previews show for this page, which is the
+     * one describing Nanodash itself until a page sets its own.
+     *
+     * @return the description
+     */
+    protected String getMetaDescription() {
+        return metaDescription;
+    }
+
+    /**
+     * Gives this page a description of its own subject, replacing the one describing
+     * Nanodash itself. Pages call this from their constructor, so that the description is
+     * in place before the head is rendered.
+     *
+     * @param description the description; blank leaves the site description in place, and
+     *                    one longer than a search result snippet can show is cut short
+     */
+    protected void setMetaDescription(String description) {
+        if (description == null || description.isBlank()) return;
+        String oneLine = description.strip().replaceAll("\\s+", " ");
+        metaDescription = oneLine.length() <= MAX_META_DESCRIPTION_LENGTH
+                ? oneLine
+                : oneLine.substring(0, MAX_META_DESCRIPTION_LENGTH).stripTrailing() + "\u2026";
+    }
+
+    /**
+     * The title link previews show for this page, taken from the page's own title label
+     * where it has one and falling back to the site name where the title is fixed markup.
+     *
+     * @return the title
+     */
+    protected String getMetaTitle() {
+        Component pageTitle = get(PAGE_TITLE_ID);
+        if (pageTitle == null) return SITE_NAME;
+        Object title = pageTitle.getDefaultModelObject();
+        return title == null ? SITE_NAME : title.toString();
+    }
+
+    /**
+     * Renders the description, canonical URL, Open Graph and Twitter card tags that
+     * search engines and link previews read (issue #704).
+     * <p>
+     * The URL comes from {@link Utils#absolutePageUrl}, so it carries the configured
+     * website address rather than how a reverse proxy reached this container, and never
+     * the visitor's {@code ;jsessionid}.
+     *
+     * @param response the header response to render into
+     */
+    private void renderPageMetadata(IHeaderResponse response) {
+        String title = getMetaTitle();
+        String description = getMetaDescription();
+        String url = Utils.absolutePageUrl(getClass(), getPageParameters());
+        response.render(MetaDataHeaderItem.forMetaTag("description", description));
+        response.render(MetaDataHeaderItem.forLinkTag("canonical", url));
+        response.render(propertyMetaTag("og:type", "website"));
+        response.render(propertyMetaTag("og:site_name", SITE_NAME));
+        response.render(propertyMetaTag("og:title", title));
+        response.render(propertyMetaTag("og:description", description));
+        response.render(propertyMetaTag("og:url", url));
+        response.render(MetaDataHeaderItem.forMetaTag("twitter:card", "summary"));
+        response.render(MetaDataHeaderItem.forMetaTag("twitter:title", title));
+        response.render(MetaDataHeaderItem.forMetaTag("twitter:description", description));
+    }
+
+    /**
+     * A meta tag keyed by {@code property} instead of {@code name}, as Open Graph
+     * requires.
+     *
+     * @param property the property name
+     * @param content  the property value
+     * @return the header item
+     */
+    private static MetaDataHeaderItem propertyMetaTag(String property, String content) {
+        return new MetaDataHeaderItem(MetaDataHeaderItem.META_TAG)
+                .addTagAttribute("property", property)
+                .addTagAttribute("content", content);
+    }
+
+    /**
      * {@inheritDoc}
      * <p>
      * Renders the head section of the page, including JavaScript references.
@@ -315,6 +408,7 @@ public abstract class NanodashPage extends WebPage {
     @Override
     public void renderHead(IHeaderResponse response) {
         super.renderHead(response);
+        renderPageMetadata(response);
         response.render(CssHeaderItem.forUrl(getStyleSheetUrl()));
         response.render(JavaScriptHeaderItem.forReference(getApplication().getJavaScriptLibrarySettings().getJQueryReference()));
         response.render(JavaScriptReferenceHeaderItem.forReference(nanodashJs));

--- a/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/SpacePage.java
@@ -109,6 +109,7 @@ public class SpacePage extends NanodashPage {
         }
 
         add(new Label("pagetitle", space.getLabel() + " (space) | nanodash"));
+        setMetaDescription(spaceMetaDescription(space));
         // Optional profile picture, right of the title/URI block (issue #632). Shown
         // plainly, i.e. without the tilted-square mask that user icons get, and simply
         // omitted when the space declares none.
@@ -288,6 +289,19 @@ public class SpacePage extends NanodashPage {
     protected void onDetach() {
         spaceModel.detach();
         super.onDetach();
+    }
+
+    /**
+     * The description a space page gives search engines and link previews: the space's own
+     * description where it has one, and what the page shows otherwise.
+     *
+     * @param space the space this page shows
+     * @return the description
+     */
+    private static String spaceMetaDescription(Space space) {
+        String description = space.getDescription();
+        if (description != null && !description.isBlank()) return description;
+        return "The " + space.getLabel() + " space on Nanodash, with its nanopublications, members and views.";
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
+++ b/src/main/java/com/knowledgepixels/nanodash/page/UserPage.java
@@ -101,6 +101,7 @@ public class UserPage extends NanodashPage {
 
         final String displayName = User.getShortDisplayName(userIri);
         add(new Label("pagetitle", displayName + " (user) | nanodash"));
+        setMetaDescription("The Nanodash page of " + displayName + ", with their profile and nanopublications.");
         add(new Label("username", displayName));
         add(new Label("titlesuffix", ResourceTabs.titleSuffix(activeTab)));
         add(PageTitleMenu.forResource("titlemenu", IndividualAgent.get(userIriString)));

--- a/src/test/java/com/knowledgepixels/nanodash/page/NanodashPageMetadataTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/page/NanodashPageMetadataTest.java
@@ -1,0 +1,79 @@
+package com.knowledgepixels.nanodash.page;
+
+import com.knowledgepixels.nanodash.WicketApplication;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the search engine and link preview metadata that every Nanodash page renders
+ * into its head (issue #704).
+ */
+class NanodashPageMetadataTest {
+
+    private WicketTester tester;
+
+    /**
+     * Starts a tester against the real application, so that the metadata is rendered the
+     * way a served page renders it.
+     */
+    @BeforeEach
+    void setUp() {
+        tester = new WicketTester(new WicketApplication());
+    }
+
+    private String renderedPage() {
+        tester.startPage(ErrorPage.class);
+        return tester.getLastResponse().getDocument();
+    }
+
+    /**
+     * A page without a subject of its own describes Nanodash, so that a search result for
+     * it says what Nanodash is instead of nothing at all.
+     */
+    @Test
+    void rendersTheSiteDescription() {
+        String document = renderedPage();
+        assertTrue(document.contains("<meta name=\"description\" content=\"Nanodash is a web client to browse and publish nanopublications"), document);
+    }
+
+    /**
+     * Link previews read Open Graph and Twitter card tags rather than the description.
+     */
+    @Test
+    void rendersOpenGraphAndTwitterCardTags() {
+        String document = renderedPage();
+        assertTrue(document.contains("property=\"og:site_name\" content=\"Nanodash\""), document);
+        assertTrue(document.contains("property=\"og:type\" content=\"website\""), document);
+        assertTrue(document.contains("property=\"og:title\""), document);
+        assertTrue(document.contains("property=\"og:description\""), document);
+        assertTrue(document.contains("property=\"og:url\" content=\"http"), document);
+        assertTrue(document.contains("<meta name=\"twitter:card\" content=\"summary\""), document);
+    }
+
+    /**
+     * The canonical URL is absolute and free of the visitor's session id, which would
+     * otherwise make every crawl of a page a different URL.
+     */
+    @Test
+    void rendersAnAbsoluteCanonicalUrlWithoutSessionId() {
+        String document = renderedPage();
+        assertTrue(document.contains("<link rel=\"canonical\" href=\"http"), document);
+        assertFalse(document.toLowerCase().contains(";jsessionid="), document);
+    }
+
+    /**
+     * A page's own title carries into the link preview, so that a shared link names what
+     * it points at.
+     */
+    @Test
+    void takesTheTitleFromThePage() {
+        tester.startPage(ErrorPage.class);
+        String document = tester.getLastResponse().getDocument();
+        assertTrue(document.contains("property=\"og:title\" content=\"Something went wrong"), document);
+    }
+
+}


### PR DESCRIPTION
Closes #704 (app side; see the caveat below).

## The problem

A search for nanodash.knowledgepixels.com shows "No information is available for this page". Two separate causes:

1. **Nothing to show.** A Nanodash page's `<head>` carried only charset, viewport, favicon and a title — no description, no Open Graph tags, no canonical link.
2. **Nothing to crawl.** The deployed instance serves a robots.txt with `Disallow: /`, which is *not* the one in this repo (`src/main/webapp/robots.txt`, unchanged since #401). It comes from somewhere in the deployment, most likely nginx.

This PR fixes (1). **(2) has to be fixed where it is served** — until then, Google will keep printing that message no matter what the pages say.

## What this does

Every page now renders, from `NanodashPage`:

```html
<meta name="description" content="Nanodash is a web client to browse and publish nanopublications: small, self-contained and citable units of scientific knowledge." />
<link rel="canonical" href="https://nanodash.knowledgepixels.com/" />
<meta property="og:type" content="website" />
<meta property="og:site_name" content="Nanodash" />
<meta property="og:title" content="Nanodash — browse and publish nanopublications" />
<meta property="og:description" content="…" />
<meta property="og:url" content="…" />
<meta name="twitter:card" content="summary" />
<meta name="twitter:title" content="…" />
<meta name="twitter:description" content="…" />
```

- The canonical URL comes from the existing `Utils.absolutePageUrl`, so it carries the configured website address rather than how a reverse proxy reached the container, and never the visitor's `;jsessionid` — which would otherwise make every crawl of a page a different URL.
- `getMetaTitle()` takes the preview title from the page's own `pagetitle` label where it has one, and falls back to "Nanodash".
- `setMetaDescription()` lets a page describe its own subject: `UserPage` names the user, `SpacePage` uses the space's own description where it has one. Anything longer than a snippet can show is cut short.
- The home page title changes from `nanodash` to `Nanodash — browse and publish nanopublications`, set from a title label so the tab title and the preview title stay in sync. **This is a visible change to the home page's browser tab.**

## Testing

- `NanodashPageMetadataTest` covers the description, the Open Graph and Twitter tags, the absolute session-free canonical URL, and the title coming from the page.
- Full suite: 1408 tests, 0 failures.
- The home page was rendered locally once to confirm the head comes out as above.

## Not included

- **`og:image`.** Every logo in the repo is SVG, which most social platforms ignore for previews; a 1200×630 PNG would be needed.
- **Dropping `;jsessionid` from URLs.** Cookie-only session tracking in `web.xml` would do it, but it would break sessions for clients with cookies disabled, so it is worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnGpEQkFqCaf4AEQwwhFFn