### PR TITLE
fix(cache): let closing the entry store stop the writers in it

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/ApiCachePersistence.java
+++ b/src/main/java/com/knowledgepixels/nanodash/ApiCachePersistence.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
 
 /**
  * Persists the {@link ApiCache} content and the nanopub cache (see {@link Utils#getNanopub})
@@ -71,6 +73,8 @@ public class ApiCachePersistence {
     // which makes all entry-store operations no-ops.
     private static volatile File entryStoreDir;
 
+    private static final ReentrantReadWriteLock entryStoreLock = new ReentrantReadWriteLock();
+
     /**
      * The root object written to the snapshot file: the query cache content together with
      * the cached nanopubs. The nanopubs matter as much as the query responses for a warm
@@ -111,7 +115,7 @@ public class ApiCachePersistence {
             return;
         }
         snapshotFile = new File(path);
-        entryStoreDir = new File(path + ".d");
+        initEntryStore(new File(path + ".d"));
         load(snapshotFile);
         scheduler = Executors.newSingleThreadScheduledExecutor((r) -> {
             Thread t = new Thread(r, "nanodash-cache-persistence");
@@ -125,11 +129,15 @@ public class ApiCachePersistence {
     /**
      * Stops the periodic saving and writes a final snapshot. Meant to run once at application
      * shutdown.
+     * <p>
+     * Closing the per-entry store waits for the background writers still in it, so that no
+     * cache entry is written after this returns.
      */
     public static synchronized void shutdown() {
         if (scheduler == null) return;
         scheduler.shutdown();
         scheduler = null;
+        initEntryStore(null);
         save(snapshotFile);
     }
 
@@ -222,11 +230,42 @@ public class ApiCachePersistence {
     /**
      * Points the per-entry store at the given directory (null disables it). Normally set by
      * {@link #init()}; exposed for tests.
+     * <p>
+     * Waits for the writers currently in the store, so that once this returns nothing is
+     * written to the previous directory any more. A background refresh submitted long
+     * before can otherwise still be on its way into a directory nobody expects to be
+     * written to — which is how a cache write landed in a test's {@code @TempDir} while
+     * JUnit was deleting it (issue #668).
      *
      * @param dir the store directory, or null to disable the store
      */
     static void initEntryStore(File dir) {
-        entryStoreDir = dir;
+        entryStoreLock.writeLock().lock();
+        try {
+            entryStoreDir = dir;
+        } finally {
+            entryStoreLock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Runs the given action on the store directory while holding the store open, and does
+     * nothing at all while the store is disabled.
+     * <p>
+     * Writers hold the store open together; only {@link #initEntryStore} excludes them,
+     * and it waits for the ones already inside.
+     *
+     * @param action what to do with the store directory
+     */
+    private static void withEntryStore(Consumer<File> action) {
+        entryStoreLock.readLock().lock();
+        try {
+            File dir = entryStoreDir;
+            if (dir == null) return;
+            action.accept(dir);
+        } finally {
+            entryStoreLock.readLock().unlock();
+        }
     }
 
     /**
@@ -242,8 +281,19 @@ public class ApiCachePersistence {
      * @param lastRefreshTime when the content was fetched
      */
     static void storeEntry(String cacheId, Serializable value, long lastRefreshTime) {
-        File dir = entryStoreDir;
-        if (dir == null) return;
+        withEntryStore(dir -> writeEntry(dir, cacheId, value, lastRefreshTime));
+    }
+
+    /**
+     * Writes one cache entry into the given store directory, atomically and ignoring any
+     * failure. Only called with the store held open by {@link #withEntryStore}.
+     *
+     * @param dir             the store directory
+     * @param cacheId         the cache id (the query's URL string)
+     * @param value           the response or map to store
+     * @param lastRefreshTime when the content was fetched
+     */
+    private static void writeEntry(File dir, String cacheId, Serializable value, long lastRefreshTime) {
         try {
             dir.mkdirs();
             File file = new File(dir, entryFileName(cacheId));
@@ -271,10 +321,10 @@ public class ApiCachePersistence {
      * @param lastRefreshTime when the content was fetched
      */
     static void storeEntryIfAbsent(String cacheId, Serializable value, long lastRefreshTime) {
-        File dir = entryStoreDir;
-        if (dir == null) return;
-        if (new File(dir, entryFileName(cacheId)).isFile()) return;
-        storeEntry(cacheId, value, lastRefreshTime);
+        withEntryStore(dir -> {
+            if (new File(dir, entryFileName(cacheId)).isFile()) return;
+            writeEntry(dir, cacheId, value, lastRefreshTime);
+        });
     }
 
     /**

--- a/src/main/java/com/knowledgepixels/nanodash/NanodashThreadPool.java
+++ b/src/main/java/com/knowledgepixels/nanodash/NanodashThreadPool.java
@@ -1,5 +1,6 @@
 package com.knowledgepixels.nanodash;
 
+import java.time.Duration;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -16,6 +17,7 @@ public class NanodashThreadPool {
     private static final int CORE_POOL_SIZE = 16;
     private static final int MAX_POOL_SIZE = 64;
     private static final long KEEP_ALIVE_SECONDS = 60;
+    private static final long QUIESCENCE_POLL_INTERVAL_MS = 20;
 
     private static final ThreadPoolExecutor POOL = new ThreadPoolExecutor(
             CORE_POOL_SIZE,
@@ -50,6 +52,33 @@ public class NanodashThreadPool {
      */
     public static <T> Future<T> submit(Callable<T> task) {
         return POOL.submit(task);
+    }
+
+    /**
+     * Waits until no submitted task is running or waiting to run any more, or until the
+     * timeout lapses.
+     * <p>
+     * For a test that tears down something its background tasks write into: a refresh
+     * submitted by an earlier test sleeps before it writes, so it can still be on its way
+     * while the next test cleans up (issue #668). Unlike a shutdown, this leaves the pool
+     * usable.
+     *
+     * @param timeout how long to wait at most
+     * @return true once the pool is idle, false if the timeout lapsed first or the wait
+     *         was interrupted
+     */
+    public static boolean awaitQuiescence(Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (POOL.getActiveCount() > 0 || !POOL.getQueue().isEmpty()) {
+            if (System.nanoTime() - deadline >= 0) return false;
+            try {
+                Thread.sleep(QUIESCENCE_POLL_INTERVAL_MS);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+        return true;
     }
 
 }

--- a/src/test/java/com/knowledgepixels/nanodash/ApiCachePersistenceTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/ApiCachePersistenceTest.java
@@ -13,12 +13,20 @@ import org.nanopub.extra.services.QueryRef;
 import com.google.common.cache.Cache;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serial;
+import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mockStatic;
@@ -30,6 +38,8 @@ class ApiCachePersistenceTest {
 
     private static final String RESPONSE_ID = "RAe-oA5eSmkCXCALZ99-0k4imnlI74KPqURfhHOmnzo6A/get-latest-nanopubs-from-pubkeys";
     private static final String MAP_ID = "RAe-oA5eSmkCXCALZ99-0k4imnlI74KPqURfhHOmnzo6A/get-some-map";
+
+    private static final Duration QUIESCENCE_TIMEOUT = Duration.ofSeconds(5);
 
     @BeforeEach
     void setUp() throws Exception {
@@ -49,9 +59,15 @@ class ApiCachePersistenceTest {
         ApiCachePersistence.initEntryStore(null);
     }
 
+    /**
+     * Closes the entry store and lets the background tasks finish before JUnit deletes the
+     * temp directory, so that a refresh submitted elsewhere in the suite cannot write into
+     * it mid-deletion (issue #668).
+     */
     @AfterEach
     void tearDown() {
         ApiCachePersistence.initEntryStore(null);
+        NanodashThreadPool.awaitQuiescence(QUIESCENCE_TIMEOUT);
     }
 
     private void resetMap(String fieldName) throws Exception {
@@ -354,6 +370,64 @@ class ApiCachePersistenceTest {
         ApiCachePersistence.PersistedEntry mapEntry = ApiCachePersistence.loadEntry(MAP_ID);
         assertNotNull(mapEntry);
         assertEquals(map, mapEntry.value);
+    }
+
+    /**
+     * A background refresh that is already writing keeps the store open: closing it waits
+     * for that write instead of leaving it to land in a directory the caller believes is
+     * finished with (issue #668).
+     */
+    @Test
+    @DisplayName("closing the entry store should wait for a write already under way")
+    void closingEntryStoreWaitsForWriteUnderWay() throws Exception {
+        File storeDir = initEntryStore();
+        BlockingValue.startedWriting = new CountDownLatch(1);
+        BlockingValue.mayFinishWriting = new CountDownLatch(1);
+        Thread writer = new Thread(() -> ApiCachePersistence.storeEntry(RESPONSE_ID, new BlockingValue(), 1000L));
+        writer.start();
+        assertTrue(BlockingValue.startedWriting.await(5, TimeUnit.SECONDS), "the write should have started");
+
+        AtomicBoolean closed = new AtomicBoolean(false);
+        Thread closer = new Thread(() -> {
+            ApiCachePersistence.initEntryStore(null);
+            closed.set(true);
+        });
+        closer.start();
+        Thread.sleep(200);
+        assertFalse(closed.get(), "closing the store should not return while a write is under way");
+
+        BlockingValue.mayFinishWriting.countDown();
+        closer.join(5000);
+        writer.join(5000);
+        assertTrue(closed.get(), "closing the store should return once the write is done");
+
+        ApiCachePersistence.storeEntry(MAP_ID, makeResponse("after-close"), 2000L);
+        assertEquals(1, storeDir.listFiles().length, "nothing should be written once the store is closed");
+    }
+
+    /**
+     * A value whose serialization blocks until released, so that a test can hold a write
+     * open inside the entry store.
+     */
+    static class BlockingValue implements Serializable {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        static CountDownLatch startedWriting;
+        static CountDownLatch mayFinishWriting;
+
+        @Serial
+        private void writeObject(ObjectOutputStream out) throws IOException {
+            out.defaultWriteObject();
+            startedWriting.countDown();
+            try {
+                mayFinishWriting.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
     }
 
 }

--- a/src/test/java/com/knowledgepixels/nanodash/NanodashThreadPoolTest.java
+++ b/src/test/java/com/knowledgepixels/nanodash/NanodashThreadPoolTest.java
@@ -1,0 +1,45 @@
+package com.knowledgepixels.nanodash;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests waiting for the shared background pool to go quiet (issue #668).
+ */
+class NanodashThreadPoolTest {
+
+    /**
+     * A caller that waits out a running task learns whether the pool went quiet, so a test
+     * cleaning up after background work can tell the difference instead of assuming it.
+     */
+    @Test
+    @DisplayName("awaitQuiescence should report the timeout while a task runs, and success once it is done")
+    void reportsWhetherThePoolWentQuiet() throws Exception {
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        NanodashThreadPool.submit(() -> {
+            started.countDown();
+            try {
+                release.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        assertTrue(started.await(5, TimeUnit.SECONDS), "the task should have started");
+
+        assertFalse(NanodashThreadPool.awaitQuiescence(Duration.ofMillis(50)),
+                "the pool is busy, so the wait should lapse");
+
+        release.countDown();
+        assertTrue(NanodashThreadPool.awaitQuiescence(Duration.ofSeconds(30)),
+                "the pool should go quiet once the task is done");
+    }
+
+}


### PR DESCRIPTION
Closes #668.

## The race

Closing the per-entry store was a bare field assignment:

```java
static void initEntryStore(File dir) {
    entryStoreDir = dir;
}
```

That only stops writers which have not read the field yet. `storeEntry` opens with `File dir = entryStoreDir`, and it is reached from `NanodashThreadPool` tasks that sleep at least ~100 ms before they land — so a refresh submitted by an *earlier* test keeps writing into whatever directory it captured, long after `@AfterEach` has disabled the store. `@TempDir` deletion runs after `@AfterEach`, which is why the write arrived exactly while JUnit was walking the tree and the deletion failed with `DirectoryNotEmptyException` on a directory the test itself had left empty.

## The fix

Both parts the issue recommended:

**1. Closing the store now stops the writers** (`ApiCachePersistence`). Writers run inside a new `withEntryStore`, holding a read lock for the whole write; `initEntryStore` takes the write lock. So it waits for the writes already under way, and a writer starting afterwards sees the new directory (or none) — nothing can reach the old directory once it returns. `storeEntry` and `storeEntryIfAbsent` now share a private `writeEntry`, so the directory is read once, under the lock.

Concurrent writes are unaffected: they share the read lock, as before.

This is also the production half — `shutdown()` had the same race, and now closes the store before writing its final snapshot.

**2. Teardown waits for the pool.** New `NanodashThreadPool.awaitQuiescence(Duration)` returns once nothing is running or queued; `ApiCachePersistenceTest`'s `@AfterEach` calls it after closing the store. Belt and braces, and it keeps the test honest if another writer appears later.

## Testing

`closingEntryStoreWaitsForWriteUnderWay` holds a write open inside the store (a value whose serialization blocks on a latch), then asserts that closing the store does not return until that write finishes, and that nothing is written afterwards.

**It fails without the fix.** With only the lock in `initEntryStore` reverted:

```
AssertionFailedError: closing the store should not return while a write is under way ==> expected: <false> but was: <true>
```

`NanodashThreadPoolTest` covers both outcomes of `awaitQuiescence`: the timeout lapsing while a task runs, and success once it is done.

Full suite: 1406 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnGpEQkFqCaf4AEQwwhFFn