### PR TITLE
feat(display): say how many assertion statements are hidden

### DIFF
--- a/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.html
@@ -33,7 +33,8 @@
         <div wicket:id="unused-assertion-statements">
           <div wicket:id="unused-assertion-statement"></div>
         </div>
-        <div class="hidden-statements">(<span class="hidden-statements-count"></span>, <a href="#" onclick="expandAssertion(this); return false;">expand</a>)</div>
+        <div class="hidden-statements"><a href="#" onclick="expandAssertion(this); return false;"><span class="hidden-statements-count"></span></a></div>
+        <div class="expand" onclick="expandAssertion(this);"></div>
         <div class="collapse" onclick="collapseAssertion(this);"></div>
       </div>
     </div>

--- a/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.html
+++ b/src/main/java/com/knowledgepixels/nanodash/component/NanopubItem.html
@@ -33,7 +33,7 @@
         <div wicket:id="unused-assertion-statements">
           <div wicket:id="unused-assertion-statement"></div>
         </div>
-        <div class="expand" onclick="expandAssertion(this);"></div>
+        <div class="hidden-statements">(<span class="hidden-statements-count"></span>, <a href="#" onclick="expandAssertion(this); return false;">expand</a>)</div>
         <div class="collapse" onclick="collapseAssertion(this);"></div>
       </div>
     </div>

--- a/src/main/java/com/knowledgepixels/nanodash/script/nanodash.js
+++ b/src/main/java/com/knowledgepixels/nanodash/script/nanodash.js
@@ -553,46 +553,89 @@ function collapsePubinfo(el) {
   $($(el).parent().find('.expand')[0]).show();
 }
 
+/**
+ * An assertion of this many statements or more is shown collapsed, down to
+ * COLLAPSED_STATEMENT_COUNT statements plus a note saying how many are hidden.
+ */
+var COLLAPSE_THRESHOLD = 10;
+var COLLAPSED_STATEMENT_COUNT = 6;
+
+/**
+ * Shows all of a collapsed assertion's statements.
+ *
+ * @param el an element inside the assertion, typically the note's expand link
+ */
 function expandAssertion(el) {
-  $(el).closest('.nanopub-assertion').find('.nanopub-statement, .nanopub-group, hr').each(function () {
-    $(this).show();
-  });
-  $(el).hide();
-  $($(el).parent().find('.collapse')[0]).show();
-  $(el).parent().find(".nanopub-graph").each(function () {
-    updateNanopubGraph(this);
-  });
+  const assertion = $(el).closest('.nanopub-assertion');
+  assertion.find('.nanopub-statement, .nanopub-group, hr').show();
+  assertion.find('.hidden-statements').hide();
+  assertion.find('.collapse').first().show();
+  adjustValueWidths();
 }
 
+/**
+ * Collapses an expanded assertion back to its first statements and its note.
+ *
+ * @param el an element inside the assertion, typically the collapse button
+ */
 function collapseAssertion(el) {
-  collapseNanopubAssertion($(el).closest('.nanopub-view'));
-  $(el).hide();
-  $($(el).parent().find('.expand')[0]).show();
+  const assertion = $(el).closest('.nanopub-assertion');
+  assertion.find('.collapse').first().hide();
+  collapseNanopubAssertion(assertion.closest('.nanopub-view'));
+  adjustValueWidths();
 }
 
+/**
+ * Collapses the long assertions of every nanopublication on the page.
+ */
 function collapseNanopubAssertions() {
   $(".nanopub-view").each(function () {
     collapseNanopubAssertion($(this));
   });
 }
 
+/**
+ * Collapses one nanopublication's assertion when it has enough statements for the
+ * shortening to be worth it, and tells the reader how many it is holding back.
+ *
+ * @param el the nanopublication view holding the assertion
+ */
 function collapseNanopubAssertion(el) {
-  a = $(el).find(".nanopub-assertion")[0];
-  n = $(a).find(".nanopub-statement").length;
-  $
-  if (n < 10) return;
-  $($(a).find(".expand")[0]).show();
-  c = 0;
-  $(a).find(".nanopub-statement, .nanopub-group, hr").each(function () {
-    if (c > 5) {
-      $(this).hide();
-    } else {
+  const assertion = $(el).find(".nanopub-assertion").first();
+  if (assertion.length === 0) return;
+  if (assertion.find(".nanopub-statement").length < COLLAPSE_THRESHOLD) return;
+  let shown = 0;
+  let hidden = 0;
+  assertion.find(".nanopub-statement, .nanopub-group, hr").each(function () {
+    const isStatement = $(this).hasClass("nanopub-statement");
+    if (shown < COLLAPSED_STATEMENT_COUNT) {
       $(this).show();
+    } else {
+      $(this).hide();
+      if (isStatement) hidden = hidden + 1;
     }
-    if ($(this).hasClass("nanopub-statement")) {
-      c = c + 1;
-    }
+    if (isStatement) shown = shown + 1;
   });
+  showHiddenStatementsNote(assertion, hidden);
+}
+
+/**
+ * Says at the bottom of the assertion how many statements the collapse is holding
+ * back, so that a shortened assertion does not read as the whole of it.
+ *
+ * @param assertion   the assertion element, as a jQuery object
+ * @param hiddenCount how many statements are hidden; none leaves the note off
+ */
+function showHiddenStatementsNote(assertion, hiddenCount) {
+  const note = assertion.find(".hidden-statements").first();
+  if (note.length === 0) return;
+  if (hiddenCount < 1) {
+    note.hide();
+    return;
+  }
+  note.find(".hidden-statements-count").text(
+      hiddenCount === 1 ? "1 statement hidden" : hiddenCount + " statements hidden");
+  note.show();
 }
 
 function showMore(el) {

--- a/src/main/java/com/knowledgepixels/nanodash/script/nanodash.js
+++ b/src/main/java/com/knowledgepixels/nanodash/script/nanodash.js
@@ -568,7 +568,8 @@ var COLLAPSED_STATEMENT_COUNT = 6;
 function expandAssertion(el) {
   const assertion = $(el).closest('.nanopub-assertion');
   assertion.find('.nanopub-statement, .nanopub-group, hr').show();
-  assertion.find('.hidden-statements').hide();
+  assertion.find('.hidden-statements').removeClass('shown');
+  assertion.find('.expand').first().hide();
   assertion.find('.collapse').first().show();
   adjustValueWidths();
 }
@@ -616,6 +617,7 @@ function collapseNanopubAssertion(el) {
     }
     if (isStatement) shown = shown + 1;
   });
+  assertion.find(".expand").first().show();
   showHiddenStatementsNote(assertion, hidden);
 }
 
@@ -630,12 +632,12 @@ function showHiddenStatementsNote(assertion, hiddenCount) {
   const note = assertion.find(".hidden-statements").first();
   if (note.length === 0) return;
   if (hiddenCount < 1) {
-    note.hide();
+    note.removeClass("shown");
     return;
   }
   note.find(".hidden-statements-count").text(
       hiddenCount === 1 ? "1 statement hidden" : hiddenCount + " statements hidden");
-  note.show();
+  note.addClass("shown");
 }
 
 function showMore(el) {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2551,9 +2551,16 @@ span.internal {
    Filled and shown by collapseNanopubAssertion() in nanodash.js. */
 .hidden-statements {
   display: none;
-  margin: 8px 3px 2px 3px;
+  align-items: center;
+  justify-content: flex-end;
+  min-height: 54px;
+  padding-right: 60px;
   color: #666;
   font-size: 10pt;
+}
+
+.hidden-statements.shown {
+  display: flex;
 }
 
 .hidden-statements a {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2546,6 +2546,21 @@ span.internal {
   background-image: url("images/down-arrow.svg");
 }
 
+/* Note at the bottom of a collapsed assertion, saying how many statements the
+   collapse is holding back, so a shortened assertion does not read as all of it.
+   Filled and shown by collapseNanopubAssertion() in nanodash.js. */
+.hidden-statements {
+  display: none;
+  margin: 8px 3px 2px 3px;
+  color: #666;
+  font-size: 10pt;
+}
+
+.hidden-statements a {
+  color: #0B73DA;
+  cursor: pointer;
+}
+
 .listcomponent {
   position: relative;
 }
@@ -3282,6 +3297,16 @@ a.source:hover {
 
 .mode-advanced .advanced {
   display: revert !important;
+}
+
+/* An advanced statement the mode toggle has revealed keeps a light rule down its
+   left edge, so that it stays recognizable as one of the statements that are
+   normally out of the way. The negative margin offsets the border and padding, so
+   the marked statement lines up with the others (issue #702). */
+body.mode-advanced .nanopub-graph .advanced {
+  border-left: 2px solid #DDE4EC;
+  margin-left: -10px;
+  padding-left: 8px;
 }
 
 .mode-toggle-button {


### PR DESCRIPTION
Closes #702.

## Before

An assertion of ten or more statements is shown cut down to its first six. The only sign of that was a small unlabelled arrow in the bottom-right corner — nothing said statements were missing, let alone how many, so a shortened assertion read as the whole assertion.

## After

The arrow stays where it is, and now has the count beside it:

```
110 statements hidden  [v]
```

The count is what the collapse actually hid (singular "1 statement hidden" when it is one), it sits immediately left of the arrow and vertically centred on it, and it is itself an expand link. Expanding hides both and reveals the usual collapse arrow; collapsing brings them back. The publication info section is untouched.

**Advanced statements**, per the issue's second paragraph, now keep a light rule down their left edge once the publish form's "show more" mode reveals them, so it stays visible which statements are normally out of the way. A negative margin offsets the rule, so a marked statement still lines up with the unmarked ones. (Scope note: advanced statements are only ever hidden in the publish form — `StatementItem` adds the `advanced` class only when the form is editable — so the count itself is display-only, as agreed.)

## Incidental cleanups in the collapse code

- Implicit globals (`a`, `n`, `c`) and a stray `$` statement are gone; the function now uses named constants for the threshold and the kept-statement count.
- `expandAssertion` used to call `updateNanopubGraph` on `.nanopub-graph` elements found *inside* `.nanopub-assertion` — which is itself the graph, so `find` never matched and the call never ran. It now calls `adjustValueWidths()`, which redoes the column alignment for the statements that just appeared. Calling `updateNanopubGraph` directly would have thrown a `ReferenceError` on a window narrower than 768px, where the `limit` global it reads is never assigned.
- The count row is toggled by a class, not by jQuery's `show()`/`hide()`, which would overwrite the flex layout that aligns it with the arrow.

## Testing

The repo has no JS test infrastructure, so this was verified two ways:

1. **A jsdom harness driving the real `nanodash.js`** — 17 checks, all passing: a 12-statement assertion keeps 6 and hides 6; the label reads "6 statements hidden"; expanding shows all, hides label and arrow, and reveals the collapse button; collapsing restores all three; a 10-statement assertion says 4 hidden; 7- and 9-statement assertions are left alone with no label.
2. **The running app** (`mvnw jetty:run`, a template nanopub with 110 hidden statements) — screenshots confirm the label sits next to the arrow, and that the advanced-statement rule keeps its alignment.

Java suite on a clean build: 1404 tests, 0 failures. This change touches no Java.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnGpEQkFqCaf4AEQwwhFFn